### PR TITLE
improve examples for PS 1–6

### DIFF
--- a/encodings/1/mattheson/music-example1.xml
+++ b/encodings/1/mattheson/music-example1.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 1, Example 1</title>
                 <composer>Johann Mattheson</composer>
                 <respStmt>
                     <resp>Edited by</resp>
@@ -38,16 +38,14 @@
                     <scoreDef key.pname="d" key.mode="minor" meter.unit="4" mnum.visible="false">
                         <staffGrp>
                             <staffDef xml:id="staffdef-variant-1" clef.shape="C" clef.line="1" n="1" lines="5">
-                                <keySig sig="1f" type="supplied" />
                             </staffDef>
                             <staffDef xml:id="staffdef-bass" clef.shape="F" clef.line="4" n="2" lines="5">
-                                <keySig sig="1f" type="supplied" />
                             </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <sb />
-                        <measure xml:id="ex-503" n="16" corresp="#m-503">
+                        <measure corresp="#m-503">
                             <staff n="1">
                                 <layer n="1">
                                     <rest xml:id="ex-506" dur="16" />
@@ -64,8 +62,10 @@
                                         <note xml:id="ex-515" dur="16" oct="5" pname="f" />
                                         <note xml:id="ex-516" dur="32" oct="5" pname="c" />
                                         <note xml:id="ex-517" dur="32" oct="5" pname="d" />
-                                        <note xml:id="ex-518" dur="16" oct="5" pname="e">
-                                            <accid xml:id="ex-519" accid="f" />
+                                        <note xml:id="ex-518" dur="16" oct="5" pname="e" accid.ges="f">
+                                            <orig>
+                                                <accid xml:id="ex-519" accid="f" />
+                                            </orig>
                                         </note>
                                     </beam>
                                     <beam>
@@ -106,8 +106,10 @@
                                     </beam>
                                     <beam>
                                         <note xml:id="ex-547" dur="8" oct="3" pname="c" />
-                                        <note xml:id="ex-548" dur="8" oct="2" pname="b">
-                                            <accid xml:id="ex-549" accid="n" />
+                                        <note xml:id="ex-548" dur="8" oct="2" pname="b" accid.ges="n">
+                                            <orig>
+                                                <accid xml:id="ex-549" accid="n" />
+                                            </orig>
                                         </note>
                                     </beam>
                                 </layer>
@@ -133,13 +135,13 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure xml:id="ex-550" n="17" corresp="#m-550">
+                        <measure corresp="#m-550">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
                                         <note xml:id="ex-555" dur="16" oct="5" pname="e">
                                             <supplied resp="#pfeffer">
-                                                <accid xml:id="ex-556" accid="n" func="caution" enclose="brack" />
+                                                <accid xml:id="ex-556" accid="n" func="caution" />
                                             </supplied>
                                         </note>
                                         <note xml:id="ex-558" dur="16" oct="5" pname="a" />
@@ -190,13 +192,17 @@
                                     <beam>
                                         <note xml:id="ex-596" dur="8" oct="3" pname="d" />
                                         <note xml:id="ex-597" dur="8" oct="3" pname="c">
-                                            <accid xml:id="ex-598" accid="s" />
+                                            <orig>
+                                                <accid xml:id="ex-598" accid="s" />
+                                            </orig>
                                         </note>
                                     </beam>
                                     <beam>
                                         <note xml:id="ex-599" dur="8" oct="3" pname="d" />
                                         <note xml:id="ex-601" dur="8" oct="3" pname="c">
-                                            <accid xml:id="ex-602" accid="s" />
+                                            <orig>
+                                                <accid xml:id="ex-602" accid="s" />
+                                            </orig>
                                         </note>
                                     </beam>
                                     <note xml:id="ex-603" dur="4" oct="3" pname="d" />
@@ -219,7 +225,7 @@
                             </harm>
                             <tie xml:id="ex-604" endid="#ex-637" startid="#ex-603" />
                         </measure>
-                        <measure xml:id="ex-605" n="18" corresp="#m-605" right="invis" metcon="false">
+                        <measure corresp="#m-605" right="invis" metcon="false">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
@@ -232,7 +238,9 @@
                                         <note xml:id="ex-616" dur="32" oct="5" pname="e" />
                                         <note xml:id="ex-617" dur="32" oct="4" pname="e" />
                                         <note xml:id="ex-618" dur="32" oct="4" pname="g">
-                                            <accid xml:id="ex-619" accid="s" />
+                                            <orig>
+                                                <accid xml:id="ex-619" accid="s" />
+                                            </orig>
                                         </note>
                                         <note xml:id="ex-620" dur="32" oct="4" pname="b" accid.ges="f" />
                                     </beam>
@@ -242,7 +250,9 @@
                                         <note xml:id="ex-625" dur="32" oct="4" pname="a" />
                                         <note xml:id="ex-626" dur="32" oct="4" pname="e" />
                                         <note xml:id="ex-627" dur="32" oct="4" pname="g">
-                                            <accid xml:id="ex-628" accid="s" />
+                                            <orig>
+                                                <accid xml:id="ex-628" accid="s" />
+                                            </orig>
                                         </note>
                                         <note xml:id="ex-629" dur="32" oct="4" pname="d" />
                                         <note xml:id="ex-630" dur="32" oct="4" pname="g" accid.ges="s" />
@@ -278,6 +288,7 @@
                                     <f>6⃥</f>
                                 </fb>
                             </harm>
+                            <dir place="within" staff="1" tstamp="4"><rend fontstyle="normal">&amp;c.</rend></dir>
                         </measure>
                     </section>
                 </score>

--- a/encodings/1/mattheson/music-example2.xml
+++ b/encodings/1/mattheson/music-example2.xml
@@ -54,7 +54,14 @@
                                         <note xml:id="ex-1003" dur="16" oct="5" pname="a" />
                                         <note xml:id="ex-1005" dur="32" oct="5" pname="e" />
                                         <note xml:id="ex-1006" dur="32" oct="5" pname="f" />
-                                        <note xml:id="ex-1007" dur="16" oct="5" pname="g" />
+                                        <app>
+                                            <lem source="#secondEdition">
+                                                <note xml:id="ex-1007" dur="16" oct="5" pname="g" />
+                                            </lem>
+                                            <rdg source="#firstEdition">
+                                                <note xml:id="ex-1007-err" dur="16" oct="5" pname="a" />
+                                            </rdg>
+                                        </app>
                                     </beam>
                                     <note xml:id="ex-1008" dur="4" oct="5" pname="f" />
                                     <rest xml:id="ex-1002a" dur="16" />
@@ -64,7 +71,14 @@
                                         <note xml:id="ex-1006a" dur="32" oct="5" pname="f">
                                             <accid xml:id="ex-1035" accid="s" />
                                         </note>
-                                        <note xml:id="ex-1007a" dur="16" oct="5" pname="g" />
+                                        <app>
+                                            <lem source="#secondEdition">
+                                                <note xml:id="ex-1007a" dur="16" oct="5" pname="g" />
+                                            </lem>
+                                            <rdg source="#firstEdition">
+                                                <note xml:id="ex-1007a-err" dur="16" oct="5" pname="b" />
+                                            </rdg>
+                                        </app>
                                     </beam>
                                 </layer>
                             </staff>

--- a/encodings/1/mattheson/music-example2.xml
+++ b/encodings/1/mattheson/music-example2.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 1, Example 2</title>
                 <composer>Johann Mattheson</composer>
                 <respStmt>
                     <resp>Edited by</resp>
@@ -38,16 +38,14 @@
                     <scoreDef key.pname="d" key.mode="minor" meter.unit="4" mnum.visible="false">
                         <staffGrp>
                             <staffDef xml:id="staffdef-variant-1" clef.shape="C" clef.line="1" n="1" lines="5">
-                                <keySig sig="1f" type="supplied" />
                             </staffDef>
                             <staffDef xml:id="staffdef-bass" clef.shape="F" clef.line="4" n="2" lines="5">
-                                <keySig sig="1f" type="supplied" />
                             </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <sb />
-                        <measure xml:id="ex-997" n="29" corresp="#m-997">
+                        <measure corresp="#m-997">
                             <staff n="1">
                                 <layer n="1">
                                     <rest xml:id="ex-1001" dur="4" />
@@ -85,15 +83,29 @@
                                     <beam xml:id="ex-1021">
                                         <note xml:id="ex-1020" dur="16" oct="3" pname="d" />
                                         <note xml:id="ex-1022" dur="16" oct="4" pname="d" />
-                                        <note xml:id="ex-1023" dur="32" oct="4" pname="c" accid.ges="s" />
+                                        <note xml:id="ex-1023" dur="32" oct="4" pname="c" accid.ges="s">
+                                            <orig>
+                                                <accid xml:id="ex-1024" accid="s" />
+                                            </orig>
+                                        </note>
                                         <note xml:id="ex-1025" dur="32" oct="4" pname="d" />
                                         <note xml:id="ex-1026" dur="16" oct="4" pname="e" />
                                     </beam>
                                     <note xml:id="ex-1011" dur="4" oct="3" pname="a" />
                                 </layer>
                             </staff>
+                            <harm place="above" staff="2" tstamp="2">
+                              <fb>
+                                <f>♯</f>
+                              </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="4">
+                              <fb>
+                                <f>♯</f>
+                              </fb>
+                            </harm>
                         </measure>
-                        <measure xml:id="ex-1027" n="30" corresp="#m-1027" right="invis" metcon="false">
+                        <measure corresp="#m-1027" right="invis" metcon="false">
                             <staff n="1">
                                 <layer n="1">
                                     <note xml:id="ex-1037" dur="4" oct="5" pname="f">
@@ -116,12 +128,10 @@
                                     <beam xml:id="ex-1053">
                                         <note xml:id="ex-1052" dur="16" oct="3" pname="d" />
                                         <note xml:id="ex-1054" dur="16" oct="4" pname="d" />
-                                        <note xml:id="ex-1055" dur="32" oct="3" pname="b">
-                                            <accid xml:id="ex-1056" accid="n" />
-                                        </note>
+                                        <note xml:id="ex-1055" dur="32" oct="3" pname="b" accid.ges="n" />
                                         <note xml:id="ex-1057" dur="32" oct="4" pname="c">
                                             <supplied resp="#pfeffer">
-                                                <accid xml:id="ex-1058" accid="n" func="caution" enclose="brack" />
+                                                <accid xml:id="ex-1058" accid="n" func="caution" />
                                             </supplied>
                                         </note>
                                         <note xml:id="ex-1059" dur="16" oct="4" pname="d" />
@@ -130,14 +140,14 @@
                                     <beam xml:id="ex-1063">
                                         <note xml:id="ex-1061" dur="16" oct="3" pname="c" />
                                         <note xml:id="ex-1064" dur="16" oct="4" pname="c" />
-                                        <note xml:id="ex-1065" dur="32" oct="3" pname="b">
-                                            <accid xml:id="ex-1066" accid="n" />
-                                        </note>
+                                        <note xml:id="ex-1065" dur="32" oct="3" pname="b" accid.ges="n" />
                                         <note xml:id="ex-1067" dur="32" oct="4" pname="c" />
                                         <note xml:id="ex-1068" dur="16" oct="4" pname="d" />
                                     </beam>
                                 </layer>
                             </staff>
+                            <dir place="within" staff="1" tstamp="4"><rend fontstyle="normal">&amp;c.</rend></dir>
+                            <dir place="within" staff="2" tstamp="4"><rend fontstyle="normal">&amp;c.</rend></dir>
                         </measure>
                     </section>
                 </score>

--- a/encodings/1/mattheson/music-example3.xml
+++ b/encodings/1/mattheson/music-example3.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 1, Example 3</title>
                 <composer>Johann Mattheson</composer>
                 <respStmt>
                     <resp>Edited by</resp>
@@ -38,16 +38,14 @@
                     <scoreDef key.pname="d" key.mode="minor" meter.unit="4" mnum.visible="false">
                         <staffGrp>
                             <staffDef xml:id="staffdef-variant-1" clef.shape="C" clef.line="1" n="1" lines="5">
-                                <keySig sig="1f" type="supplied" />
                             </staffDef>
                             <staffDef xml:id="staffdef-bass" clef.shape="F" clef.line="4" n="2" lines="5">
-                                <keySig sig="1f" type="supplied" />
                             </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <sb />
-                        <measure xml:id="ex-1123" n="33" corresp="#m-1123">
+                        <measure corresp="#m-1123">
                             <staff n="1">
                                 <layer n="1">
                                     <beam xml:id="ex-1127">
@@ -106,7 +104,9 @@
                                     <beam xml:id="ex-1173">
                                         <note xml:id="ex-1172" dur="16" oct="4" pname="c" />
                                         <note xml:id="ex-1174" dur="16" oct="3" pname="b">
-                                            <accid xml:id="ex-1175" accid="f" />
+                                            <orig>
+                                                <accid xml:id="ex-1175" accid="f" />
+                                            </orig>
                                         </note>
                                         <note xml:id="ex-1176" dur="16" oct="3" pname="a" />
                                         <note xml:id="ex-1177" dur="32" oct="3" pname="g" />
@@ -114,7 +114,9 @@
                                     </beam>
                                     <beam xml:id="ex-1181">
                                         <note xml:id="ex-1179" dur="16" oct="3" pname="b">
-                                            <accid xml:id="ex-1180" accid="f" />
+                                            <orig>
+                                                <accid xml:id="ex-1180" accid="f" />
+                                            </orig>
                                         </note>
                                         <note xml:id="ex-1182" dur="16" oct="3" pname="a" />
                                         <note xml:id="ex-1183" dur="16" oct="3" pname="g" />
@@ -128,6 +130,18 @@
                                         <note xml:id="ex-1190" dur="32" oct="3" pname="e" />
                                         <note xml:id="ex-1191" dur="32" oct="3" pname="d" />
                                     </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure right="invis">
+                            <staff n="1">
+                                <layer>
+                                    <custos oct="4" pname="b" />
+                                </layer>
+                            </staff>
+                            <staff n="2">
+                                <layer>
+                                    <custos oct="3" pname="g" />
                                 </layer>
                             </staff>
                         </measure>

--- a/encodings/2/mattheson/comments_1st.xml
+++ b/encodings/2/mattheson/comments_1st.xml
@@ -118,12 +118,9 @@
           <head>§. 1.</head>
           <p xml:id="p1-1" facs="#facsZone-p1-1">
             <hi rendition="#in">D</hi>Jeses Prob-Stuͤcke kan an Statt einer
-            <hi rendition="#aq"><foreign xml:lang="ita">Toccata</foreign></hi>,
-            oder wenigſtens wie eine
-            <lb/>gute <hi rendition="#aq"><foreign xml:lang="ita">Toccatina</foreign></hi>
-            gebraucht werden, und geben ſchon im ersten Tact die
-            <lb/><ref target="#m-81">beyden Achtel-Noten</ref> und <ref target="#m-83">ihre Pauſen</ref> zu erkennen,
-            daß daſelbſt im Diſcant
+            <hi rendition="#aq"><foreign xml:lang="ita">Toccata</foreign></hi>, oder wenigſtens wie eine
+            <lb/>gute <hi rendition="#aq"><foreign xml:lang="ita">Toccatina</foreign></hi> gebraucht werden, und geben ſchon im ersten Tact die
+            <lb/><ref target="#m-81 #m-84">beyden Achtel-Noten</ref> und <ref target="#m-83 #m-86">ihre Pauſen</ref> zu erkennen, daß daſelbſt im Diſcant
             <lb/>wiederholet werden mag, was vorhin der Baß bereits geſpielet hat. Mit dem
             <lb/><ref target="#m-87">andern</ref>, <ref target="#m-226">fuͤnfften</ref>,
             <ref target="#m-377">achten</ref>,

--- a/encodings/2/mattheson/comments_de.xml
+++ b/encodings/2/mattheson/comments_de.xml
@@ -115,8 +115,8 @@
             <hi rendition="#aq"><foreign xml:lang="ita">Toccata</foreign></hi>, oder wenigſtens wie ei-<lb/>
             ne gute <hi rendition="#aq"><foreign xml:lang="ita">Toccatina</foreign></hi>
             gebraucht werden, und geben ſchon im ersten Tact die<lb/>
-            <ref target="#m-81">beiden Achtel-Noten</ref> und
-            <ref target="#m-83">ihre Pauſen zu erkennen</ref>,
+            <ref target="#m-81 #m-84">beiden Achtel-Noten</ref> und
+            <ref target="#m-83 #m-86">ihre Pauſen zu erkennen</ref>,
             daß daselbst im Diſcant<lb/>
             wiederholet werden mag, was vorhin der Baß bereits gespielet hat.
             Mit dem <ref target="#m-87">an-<lb/>

--- a/encodings/2/mattheson/music-example1.xml
+++ b/encodings/2/mattheson/music-example1.xml
@@ -4,8 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title>
-                </title>
+                <title>Prob-Stück 2, Example 1</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -43,7 +42,7 @@
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure xml:id="ex-269" n="6" corresp="#m-269">
+                        <measure corresp="#m-269">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
@@ -117,7 +116,7 @@
                                 </layer>
                             </staff>
                         </measure>
-                        <measure>
+                        <measure right="invis">
                             <staff n="1">
                                 <layer n="1">
                                     <custos oct="4" pname="d" />
@@ -128,6 +127,7 @@
                                     <custos oct="2" pname="b" />
                                 </layer>
                             </staff>
+                            <dir place="below" staff="1" tstamp="2"><rend fontstyle="normal">&amp;c.</rend></dir>
                         </measure>
                     </section>
                 </score>

--- a/encodings/2/mattheson/music-example1.xml
+++ b/encodings/2/mattheson/music-example1.xml
@@ -50,7 +50,7 @@
                                         <note xml:id="ex-275" dur="32" oct="4" pname="a" />
                                         <note xml:id="ex-277" dur="32" oct="5" pname="f" />
                                         <note xml:id="ex-278" dur="32" oct="4" pname="a" />
-                                        <note xml:id="ex-279" breaksec="1" dur="32" oct="5" pname="f" />
+                                        <note xml:id="ex-279" dur="32" oct="5" pname="f" />
                                         <note xml:id="ex-280" dur="32" oct="4" pname="a" />
                                         <note xml:id="ex-281" dur="32" oct="5" pname="f" />
                                         <note xml:id="ex-282" dur="32" oct="4" pname="a" />
@@ -60,7 +60,7 @@
                                         <note xml:id="ex-284" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-286" dur="32" oct="5" pname="e" />
                                         <note xml:id="ex-287" dur="32" oct="4" pname="g" />
-                                        <note xml:id="ex-288" breaksec="1" dur="32" oct="5" pname="e" />
+                                        <note xml:id="ex-288" dur="32" oct="5" pname="e" />
                                         <note xml:id="ex-289" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-290" dur="32" oct="5" pname="e" />
                                         <note xml:id="ex-291" dur="32" oct="4" pname="g" />
@@ -70,7 +70,7 @@
                                         <note xml:id="ex-293" dur="32" oct="4" pname="f" />
                                         <note xml:id="ex-295" dur="32" oct="5" pname="d" />
                                         <note xml:id="ex-296" dur="32" oct="4" pname="f" />
-                                        <note xml:id="ex-297" breaksec="1" dur="32" oct="5" pname="d" />
+                                        <note xml:id="ex-297" dur="32" oct="5" pname="d" />
                                         <note xml:id="ex-298" dur="32" oct="4" pname="f" />
                                         <note xml:id="ex-299" dur="32" oct="5" pname="d" />
                                         <note xml:id="ex-300" dur="32" oct="4" pname="f" />
@@ -80,7 +80,7 @@
                                         <note xml:id="ex-302" dur="32" oct="4" pname="e" />
                                         <note xml:id="ex-304" dur="32" oct="5" pname="c" />
                                         <note xml:id="ex-305" dur="32" oct="4" pname="e" />
-                                        <note xml:id="ex-306" breaksec="1" dur="32" oct="5" pname="c" />
+                                        <note xml:id="ex-306" dur="32" oct="5" pname="c" />
                                         <note xml:id="ex-307" dur="32" oct="4" pname="e" />
                                         <note xml:id="ex-308" dur="32" oct="5" pname="c" />
                                         <note xml:id="ex-309" dur="32" oct="4" pname="e" />

--- a/encodings/2/mattheson/music-example2.xml
+++ b/encodings/2/mattheson/music-example2.xml
@@ -4,8 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title>
-                </title>
+                <title>Prob-Stück 2, Example 2</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -43,7 +42,7 @@
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure xml:id="ex-606" n="13" corresp="#m-606">
+                        <measure corresp="#m-606">
                             <staff n="1">
                                 <layer n="1">
                                     <space xml:id="ex-614" dur="2" />
@@ -78,7 +77,7 @@
                             </staff>
                             <fermata xml:id="ex-632" form="norm" layer="1" shape="curved" staff="3" startid="#m-631" tstamp="1" />
                         </measure>
-                        <measure xml:id="ex-640" n="14" corresp="#m-640">
+                        <measure corresp="#m-640">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
@@ -104,7 +103,11 @@
                                     <beam>
                                         <note xml:id="ex-664" dur="16" oct="5" pname="g" />
                                         <note xml:id="ex-666" dur="16" oct="4" pname="a" />
-                                        <note xml:id="ex-667" dur="16" oct="5" pname="e" accid.ges="f" />
+                                        <note xml:id="ex-667" dur="16" oct="5" pname="e" accid.ges="f">
+                                            <orig>
+                                                <accid xml:id="ex-668" accid="f" />
+                                            </orig>
+                                        </note>
                                         <note xml:id="ex-669" dur="16" oct="5" pname="g" />
                                     </beam>
                                 </layer>
@@ -122,7 +125,11 @@
                                         <note xml:id="ex-677" dur="8" oct="3" pname="b" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <note xml:id="ex-679" dur="8" oct="4" pname="e" accid.ges="f" />
+                                        <note xml:id="ex-679" dur="8" oct="4" pname="e" accid.ges="f">
+                                            <orig>
+                                                <accid xml:id="ex-680" accid="f" />
+                                            </orig>
+                                        </note>
                                         <note xml:id="ex-682" dur="8" oct="4" pname="d" />
                                     </beam>
                                     <beam>
@@ -132,7 +139,7 @@
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="ex-685" n="15" corresp="#m-685">
+                        <measure corresp="#m-685">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
@@ -159,8 +166,10 @@
                                         <note xml:id="ex-708" dur="16" oct="5" pname="e" accid.ges="f" />
                                         <note xml:id="ex-711" dur="16" oct="4" pname="f" />
                                         <note xml:id="ex-712" dur="16" oct="5" pname="c" />
-                                        <note xml:id="ex-713" dur="16" oct="5" pname="e">
-                                            <accid xml:id="ex-714" accid="f" />
+                                        <note xml:id="ex-713" dur="16" oct="5" pname="e" accid.ges="f">
+                                            <orig>
+                                                <accid xml:id="ex-714" accid="f" />
+                                            </orig>
                                         </note>
                                     </beam>
                                 </layer>
@@ -187,7 +196,7 @@
                                 </layer>
                             </staff>
                         </measure>
-                        <measure>
+                        <measure right="invis">
                             <staff n="1">
                                 <layer n="1">
                                     <custos oct="5" pname="d" />
@@ -198,6 +207,7 @@
                                     <custos oct="3" pname="b" />
                                 </layer>
                             </staff>
+                            <dir place="within" staff="1" tstamp="2"><rend fontstyle="normal">&amp;c.</rend></dir>
                         </measure>
                     </section>
                 </score>

--- a/encodings/2/mattheson/music-example3.xml
+++ b/encodings/2/mattheson/music-example3.xml
@@ -42,7 +42,7 @@
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure right="dbl" corresp="#m-1108">
+                        <measure corresp="#m-1108" right="dbl" metcon="false">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
@@ -104,7 +104,7 @@
                                 <rdg source="#firstEdition"></rdg>
                             </app>
                         </measure>
-                        <measure right="invis" corresp="#m-1108">
+                        <measure corresp="#m-1108" right="invis" metcon="false">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>

--- a/encodings/2/mattheson/music-example3.xml
+++ b/encodings/2/mattheson/music-example3.xml
@@ -53,7 +53,7 @@
                                         <note xml:id="ex-1142" dur="32" oct="4" pname="b">
                                             <accid xml:id="ex-1143" accid="n" />
                                         </note>
-                                        <note xml:id="ex-1144" breaksec="1" dur="32" oct="4" pname="g" />
+                                        <note xml:id="ex-1144" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-1145" dur="32" oct="5" pname="d" />
                                         <note xml:id="ex-1146" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-1147" dur="32" oct="4" pname="b">
@@ -67,7 +67,7 @@
                                         </note>
                                         <note xml:id="ex-1153" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-1154" dur="32" oct="5" pname="c" />
-                                        <note xml:id="ex-1155" breaksec="1" dur="32" oct="4" pname="g" />
+                                        <note xml:id="ex-1155" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-1156" dur="32" oct="5" pname="e" accid.ges="f" />
                                         <note xml:id="ex-1158" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-1159" dur="32" oct="5" pname="c" />
@@ -101,7 +101,7 @@
                                         <note xml:id="ex-1115" dur="32" oct="4" pname="b">
                                             <accid xml:id="ex-1116" accid="n" />
                                         </note>
-                                        <note xml:id="ex-1117" breaksec="1" dur="32" oct="5" pname="d" />
+                                        <note xml:id="ex-1117" dur="32" oct="5" pname="d" />
                                         <note xml:id="ex-1118" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-1119" dur="32" oct="5" pname="d" />
                                         <note xml:id="ex-1120" dur="32" oct="4" pname="b">
@@ -115,7 +115,7 @@
                                             <accid xml:id="ex-1126" accid="f" />
                                         </note>
                                         <note xml:id="ex-1127" dur="32" oct="5" pname="c" />
-                                        <note xml:id="ex-1128" breaksec="1" dur="32" oct="5" pname="e" accid.ges="f" />
+                                        <note xml:id="ex-1128" dur="32" oct="5" pname="e" accid.ges="f" />
                                         <note xml:id="ex-1130" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-1131" dur="32" oct="5" pname="e" accid.ges="f" />
                                         <note xml:id="ex-1133" dur="32" oct="5" pname="c" />

--- a/encodings/2/mattheson/music-example3.xml
+++ b/encodings/2/mattheson/music-example3.xml
@@ -97,7 +97,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <dir place="below" staff="1" tstamp="2.9"><rend fontstyle="normal">&amp;c.</rend></dir>
+                            <app resp="#rettinghaus">
+                                <lem source="#secondEdition">
+                                    <dir place="below" staff="1" tstamp="2.9"><rend fontstyle="normal">&amp;c.</rend></dir>
+                                </lem>
+                                <rdg source="#firstEdition"></rdg>
+                            </app>
                         </measure>
                         <measure right="invis" corresp="#m-1108">
                             <staff n="1">

--- a/encodings/2/mattheson/music-example3.xml
+++ b/encodings/2/mattheson/music-example3.xml
@@ -4,8 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title>
-                </title>
+                <title>Prob-Stück 2, Example 3</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -43,10 +42,9 @@
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure right="dbl">
+                        <measure right="dbl" corresp="#m-1108">
                             <staff n="1">
                                 <layer n="1">
-                                    <space dur="2" />
                                     <beam>
                                         <note xml:id="ex-1139" dur="32" oct="5" pname="d" />
                                         <note xml:id="ex-1141" dur="32" oct="4" pname="g" />
@@ -54,10 +52,14 @@
                                             <accid xml:id="ex-1143" accid="n" />
                                         </note>
                                         <note xml:id="ex-1144" dur="32" oct="4" pname="g" />
+                                    </beam>
+                                    <beam>
                                         <note xml:id="ex-1145" dur="32" oct="5" pname="d" />
                                         <note xml:id="ex-1146" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-1147" dur="32" oct="4" pname="b">
-                                            <accid xml:id="ex-1148" accid="n" />
+                                            <orig>
+                                                <accid xml:id="ex-1148" accid="n" />
+                                            </orig>
                                         </note>
                                         <note xml:id="ex-1149" dur="32" oct="4" pname="g" />
                                     </beam>
@@ -68,7 +70,13 @@
                                         <note xml:id="ex-1153" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-1154" dur="32" oct="5" pname="c" />
                                         <note xml:id="ex-1155" dur="32" oct="4" pname="g" />
-                                        <note xml:id="ex-1156" dur="32" oct="5" pname="e" accid.ges="f" />
+                                      </beam>
+                                      <beam>
+                                        <note xml:id="ex-1156" dur="32" oct="5" pname="e" accid.ges="f">
+                                            <orig>
+                                                <accid xml:id="ex-1157" accid="f" />
+                                            </orig>
+                                        </note>
                                         <note xml:id="ex-1158" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-1159" dur="32" oct="5" pname="c" />
                                         <note xml:id="ex-1160" dur="32" oct="4" pname="g" />
@@ -77,7 +85,6 @@
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <space dur="2" />
                                     <beam>
                                         <note xml:id="ex-1167" dur="8" oct="3" pname="g" />
                                         <note xml:id="ex-1169" dur="8" oct="3" pname="b">
@@ -90,11 +97,11 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <dir place="below" staff="1" tstamp="2.9"><rend fontstyle="normal">&amp;c.</rend></dir>
                         </measure>
-                        <measure>
+                        <measure right="invis" corresp="#m-1108">
                             <staff n="1">
                                 <layer n="1">
-                                    <space dur="2" />
                                     <beam>
                                         <note xml:id="ex-1112" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-1114" dur="32" oct="5" pname="d" />
@@ -105,7 +112,9 @@
                                         <note xml:id="ex-1118" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-1119" dur="32" oct="5" pname="d" />
                                         <note xml:id="ex-1120" dur="32" oct="4" pname="b">
-                                            <accid xml:id="ex-1121" accid="n" />
+                                            <orig>
+                                                <accid xml:id="ex-1121" accid="n" />
+                                            </orig>
                                         </note>
                                         <note xml:id="ex-1122" dur="32" oct="5" pname="d" />
                                     </beam>
@@ -117,15 +126,19 @@
                                         <note xml:id="ex-1127" dur="32" oct="5" pname="c" />
                                         <note xml:id="ex-1128" dur="32" oct="5" pname="e" accid.ges="f" />
                                         <note xml:id="ex-1130" dur="32" oct="4" pname="g" />
-                                        <note xml:id="ex-1131" dur="32" oct="5" pname="e" accid.ges="f" />
+                                        <note xml:id="ex-1131" dur="32" oct="5" pname="e" accid.ges="f">
+                                            <orig>
+                                                <accid xml:id="ex-1132" accid="f" />
+                                            </orig>
+                                        </note>
                                         <note xml:id="ex-1133" dur="32" oct="5" pname="c" />
                                         <note xml:id="ex-1134" dur="32" oct="5" pname="e" accid.ges="f" />
                                     </beam>
+                                    <custos oct="4" pname="f" />
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <space dur="2" />
                                     <beam>
                                         <note xml:id="ex-1187" dur="8" oct="3" pname="g" />
                                         <note xml:id="ex-1189" dur="8" oct="3" pname="b">
@@ -136,8 +149,11 @@
                                         <note xml:id="ex-1191" dur="8" oct="4" pname="c" />
                                         <note xml:id="ex-1192" dur="8" oct="3" pname="c" />
                                     </beam>
+                                    <custos oct="3" pname="a" />
                                 </layer>
                             </staff>
+                            <dir place="below" staff="1" tstamp="3"><rend fontstyle="normal">&amp;c.</rend></dir>
+                            <dir place="below" staff="2" tstamp="3"><rend fontstyle="normal">&amp;c.</rend></dir>
                         </measure>
                     </section>
                 </score>

--- a/encodings/2/mattheson/score.xml
+++ b/encodings/2/mattheson/score.xml
@@ -163,7 +163,7 @@
                     <beam xml:id="m-47">
                       <note xml:id="m-46" dur="32" oct="4" pname="d"/>
                       <note xml:id="m-48" dur="32" oct="4" pname="e"/>
-                      <note xml:id="m-49" breaksec="1" dur="32" oct="4" pname="f">
+                      <note xml:id="m-49" dur="32" oct="4" pname="f">
                         <accid accid="s"/>
                       </note>
                       <note xml:id="m-51" dur="32" oct="4" pname="g"/>
@@ -243,7 +243,7 @@
                     <beam xml:id="m-95">
                       <note xml:id="m-94" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-96" dur="32" oct="4" pname="a"/>
-                      <note xml:id="m-97" breaksec="1" dur="32" oct="4" pname="b">
+                      <note xml:id="m-97" dur="32" oct="4" pname="b">
                         <accid accid="n"/>
                       </note>
                       <note xml:id="m-99" dur="32" oct="5" pname="c"/>
@@ -478,7 +478,7 @@
                     <beam xml:id="m-236">
                       <note xml:id="m-235" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-237" dur="32" oct="5" pname="d"/>
-                      <note xml:id="m-238" breaksec="1" dur="32" oct="5" pname="e"/>
+                      <note xml:id="m-238" dur="32" oct="5" pname="e"/>
                       <note xml:id="m-239" dur="32" oct="5" pname="f"/>
                       <note xml:id="m-240" dur="32" oct="5" pname="g"/>
                       <note xml:id="m-241" dur="32" oct="5" pname="a"/>
@@ -550,7 +550,7 @@
                       <note xml:id="m-275" dur="32" oct="4" pname="a"/>
                       <note xml:id="m-277" dur="32" oct="5" pname="f"/>
                       <note xml:id="m-278" dur="32" oct="4" pname="a"/>
-                      <note xml:id="m-279" breaksec="1" dur="32" oct="5" pname="f"/>
+                      <note xml:id="m-279" dur="32" oct="5" pname="f"/>
                       <note xml:id="m-280" dur="32" oct="4" pname="a"/>
                       <note xml:id="m-281" dur="32" oct="5" pname="f"/>
                       <note xml:id="m-282" dur="32" oct="4" pname="a"/>
@@ -560,7 +560,7 @@
                       <note xml:id="m-284" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-286" dur="32" oct="5" pname="e"/>
                       <note xml:id="m-287" dur="32" oct="4" pname="g"/>
-                      <note xml:id="m-288" breaksec="1" dur="32" oct="5" pname="e"/>
+                      <note xml:id="m-288" dur="32" oct="5" pname="e"/>
                       <note xml:id="m-289" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-290" dur="32" oct="5" pname="e"/>
                       <note xml:id="m-291" dur="32" oct="4" pname="g"/>
@@ -570,7 +570,7 @@
                       <note xml:id="m-293" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-295" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-296" dur="32" oct="4" pname="f"/>
-                      <note xml:id="m-297" breaksec="1" dur="32" oct="5" pname="d"/>
+                      <note xml:id="m-297" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-298" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-299" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-300" dur="32" oct="4" pname="f"/>
@@ -580,7 +580,7 @@
                       <note xml:id="m-302" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-304" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-305" dur="32" oct="4" pname="e"/>
-                      <note xml:id="m-306" breaksec="1" dur="32" oct="5" pname="c"/>
+                      <note xml:id="m-306" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-307" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-308" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-309" dur="32" oct="4" pname="e"/>
@@ -678,7 +678,7 @@
                     <beam xml:id="m-385">
                       <note xml:id="m-384" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-386" dur="32" oct="5" pname="e"/>
-                      <note xml:id="m-387" breaksec="1" dur="32" oct="5" pname="f">
+                      <note xml:id="m-387" dur="32" oct="5" pname="f">
                         <accid accid="s"/>
                       </note>
                       <note xml:id="m-389" dur="32" oct="5" pname="g"/>
@@ -1197,7 +1197,7 @@
                     <beam xml:id="m-739">
                       <note xml:id="m-738" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-740" dur="32" oct="4" pname="g"/>
-                      <note xml:id="m-741" breaksec="1" dur="32" oct="4" pname="a"/>
+                      <note xml:id="m-741" dur="32" oct="4" pname="a"/>
                       <note xml:id="m-742" dur="32" oct="4" pname="b" accid.ges="f"/>
                       <note xml:id="m-744" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-745" dur="32" oct="5" pname="d"/>
@@ -1267,7 +1267,7 @@
                     <beam xml:id="m-790">
                       <note xml:id="m-788" dur="32" oct="4" pname="b" accid.ges="f"/>
                       <note xml:id="m-791" dur="32" oct="5" pname="c"/>
-                      <note xml:id="m-792" breaksec="1" dur="32" oct="5" pname="d"/>
+                      <note xml:id="m-792" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-793" dur="32" oct="5" pname="e">
                         <accid accid="f"/>
                       </note>
@@ -1347,7 +1347,7 @@
                     <beam xml:id="m-850">
                       <note xml:id="m-849" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-851" dur="32" oct="4" pname="a"/>
-                      <note xml:id="m-852" breaksec="1" dur="32" oct="4" pname="b">
+                      <note xml:id="m-852" dur="32" oct="4" pname="b">
                         <accid accid="n"/>
                       </note>
                       <note xml:id="m-854" dur="32" oct="5" pname="c"/>
@@ -1605,7 +1605,7 @@
                     <beam xml:id="m-1011">
                       <note xml:id="m-1010" dur="32" oct="4" pname="c"/>
                       <note xml:id="m-1012" dur="32" oct="4" pname="d"/>
-                      <note xml:id="m-1013" breaksec="1" dur="32" oct="4" pname="e"/>
+                      <note xml:id="m-1013" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-1014" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-1015" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-1016" dur="32" oct="4" pname="a">
@@ -1838,7 +1838,7 @@
                       <note xml:id="m-1142" dur="32" oct="4" pname="b">
                         <accid accid="n"/>
                       </note>
-                      <note xml:id="m-1144" breaksec="1" dur="32" oct="4" pname="g"/>
+                      <note xml:id="m-1144" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-1145" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-1146" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-1147" dur="32" oct="4" pname="b">
@@ -1852,7 +1852,7 @@
                       </note>
                       <note xml:id="m-1153" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-1154" dur="32" oct="5" pname="c"/>
-                      <note xml:id="m-1155" breaksec="1" dur="32" oct="4" pname="g"/>
+                      <note xml:id="m-1155" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-1156" dur="32" oct="5" pname="e" accid.ges="f"/>
                       <note xml:id="m-1158" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-1159" dur="32" oct="5" pname="c"/>
@@ -2203,7 +2203,7 @@
                       <note xml:id="m-1348" dur="32" oct="4" pname="b">
                         <accid accid="n"/>
                       </note>
-                      <note xml:id="m-1350" breaksec="1" dur="32" oct="5" pname="c">
+                      <note xml:id="m-1350" dur="32" oct="5" pname="c">
                         <accid accid="s"/>
                       </note>
                       <note xml:id="m-1352" dur="32" oct="5" pname="d"/>
@@ -2331,7 +2331,7 @@
                     <beam xml:id="m-1405">
                       <note xml:id="m-1404" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-1406" dur="32" oct="5" pname="e"/>
-                      <note xml:id="m-1407" breaksec="1" dur="32" oct="5" pname="f">
+                      <note xml:id="m-1407" dur="32" oct="5" pname="f">
                         <accid accid="s"/>
                       </note>
                       <note xml:id="m-1409" dur="32" oct="5" pname="g"/>
@@ -2351,7 +2351,7 @@
                     <beam xml:id="m-1422">
                       <note xml:id="m-1421" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-1423" dur="32" oct="5" pname="e"/>
-                      <note xml:id="m-1424" breaksec="1" dur="32" oct="5" pname="f" accid.ges="s"/>
+                      <note xml:id="m-1424" dur="32" oct="5" pname="f" accid.ges="s"/>
                       <note xml:id="m-1426" dur="32" oct="5" pname="g"/>
                       <note xml:id="m-1427" dur="32" oct="5" pname="a"/>
                       <note xml:id="m-1428" dur="32" oct="5" pname="b" accid.ges="f"/>
@@ -2454,7 +2454,7 @@
                       <note xml:id="m-1482" dur="32" oct="5" pname="g"/>
                       <note xml:id="m-1484" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-1485" dur="32" oct="4" pname="a"/>
-                      <note xml:id="m-1486" breaksec="1" dur="32" oct="4" pname="b">
+                      <note xml:id="m-1486" dur="32" oct="4" pname="b">
                         <accid accid="n"/>
                       </note>
                       <note xml:id="m-1488" dur="32" oct="5" pname="c"/>
@@ -2470,7 +2470,7 @@
                       <note xml:id="m-1496" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-1497" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-1498" dur="32" oct="4" pname="a"/>
-                      <note xml:id="m-1499" breaksec="1" dur="32" oct="4" pname="b">
+                      <note xml:id="m-1499" dur="32" oct="4" pname="b">
                         <accid accid="n"/>
                       </note>
                       <note xml:id="m-1501" dur="32" oct="5" pname="c"/>
@@ -2569,7 +2569,7 @@
                       <note xml:id="m-1552" dur="32" oct="5" pname="e"/>
                       <note xml:id="m-1554" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-1555" dur="32" oct="5" pname="d"/>
-                      <note xml:id="m-1556" breaksec="1" dur="32" oct="5" pname="e"/>
+                      <note xml:id="m-1556" dur="32" oct="5" pname="e"/>
                       <note xml:id="m-1557" dur="32" oct="5" pname="f"/>
                       <note xml:id="m-1558" dur="32" oct="5" pname="g"/>
                       <note xml:id="m-1559" dur="32" oct="5" pname="a"/>
@@ -2581,7 +2581,7 @@
                       <note xml:id="m-1564" dur="16" oct="5" pname="c"/>
                       <note xml:id="m-1565" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-1566" dur="32" oct="5" pname="d"/>
-                      <note xml:id="m-1567" breaksec="1" dur="32" oct="5" pname="e"/>
+                      <note xml:id="m-1567" dur="32" oct="5" pname="e"/>
                       <note xml:id="m-1568" dur="32" oct="5" pname="f"/>
                       <note xml:id="m-1569" dur="32" oct="5" pname="g"/>
                       <note xml:id="m-1570" dur="32" oct="5" pname="a"/>

--- a/encodings/2/mattheson/score.xml
+++ b/encodings/2/mattheson/score.xml
@@ -197,7 +197,7 @@
                       <note xml:id="m-75" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-77" dur="16" oct="3" pname="f" accid.ges="s">
                         <orig>
-                          <accid accid="s"/>
+                          <accid xml:id="m-78" accid="s"/>
                         </orig>
                       </note>
                       <note xml:id="m-79" dur="16" oct="3" pname="d"/>
@@ -207,7 +207,7 @@
                     <rest xml:id="m-83" dur="8"/>
                     <note xml:id="m-84" dur="8" oct="3" pname="f" accid.ges="s">
                       <orig>
-                        <accid accid="s"/>
+                        <accid xml:id="m-85" accid="s"/>
                       </orig>
                     </note>
                     <rest xml:id="m-86" dur="8"/>
@@ -287,7 +287,7 @@
                     </beam>
                     <note xml:id="m-129" dur="8" oct="4" pname="e" accid.ges="f">
                       <orig>
-                        <accid accid="f"/>
+                        <accid xml:id="m-130" accid="f"/>
                       </orig>
                     </note>
                     <rest xml:id="m-131" dur="8"/>
@@ -347,7 +347,7 @@
                     <beam xml:id="m-170">
                       <note xml:id="m-168" dur="32" oct="3" pname="f" accid.ges="s">
                         <orig>
-                          <accid accid="s"/>
+                          <accid xml:id="m-169" accid="s"/>
                         </orig>
                       </note>
                       <note xml:id="m-171" dur="32" oct="3" pname="e">
@@ -362,7 +362,7 @@
                       <note xml:id="m-176" dur="32" oct="3" pname="g"/>
                       <note xml:id="m-177" dur="32" oct="3" pname="f" accid.ges="s">
                         <orig>
-                          <accid accid="s"/>
+                          <accid xml:id="m-178" accid="s"/>
                         </orig>
                       </note>
                       <note xml:id="m-179" dur="32" oct="3" pname="g"/>
@@ -431,7 +431,7 @@
                       <note xml:id="m-207" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-209" dur="16" oct="3" pname="f" accid.ges="s">
                         <orig>
-                          <accid accid="s"/>
+                          <accid xml:id="m-210" accid="s"/>
                         </orig>
                       </note>
                       <note xml:id="m-211" dur="16" oct="3" pname="a"/>
@@ -743,7 +743,7 @@
                       <note xml:id="m-429" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-430" dur="16" oct="3" pname="f">
                         <orig>
-                          <accid accid="s"/>
+                          <accid xml:id="m-431" accid="s"/>
                         </orig>
                       </note>
                       <note xml:id="m-432" dur="16" oct="3" pname="d"/>
@@ -775,13 +775,13 @@
                       <note xml:id="m-454" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-456" dur="16" oct="3" pname="f" accid.ges="s">
                         <orig>
-                          <accid accid="s"/>
+                          <accid xml:id="m-457" accid="s"/>
                         </orig>
                       </note>
                       <note xml:id="m-458" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-459" dur="16" oct="3" pname="f" accid.ges="s">
                         <orig>
-                          <accid accid="s"/>
+                          <accid xml:id="m-452" accid="s"/>
                         </orig>
                       </note>
                     </beam>
@@ -846,7 +846,7 @@
                       <note xml:id="m-497" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-498" dur="16" oct="3" pname="e" accid.ges="f">
                         <orig>
-                          <accid accid="f"/>
+                          <accid xml:id="m-499" accid="f"/>
                         </orig>
                       </note>
                       <note xml:id="m-500" dur="16" oct="3" pname="f"/>
@@ -888,7 +888,7 @@
                     <beam xml:id="m-530">
                       <note xml:id="m-528" dur="32" oct="3" pname="e" accid.ges="f">
                         <orig>
-                          <accid accid="f"/>
+                          <accid xml:id="m-529" accid="f"/>
                         </orig>
                       </note>
                       <note xml:id="m-531" dur="32" oct="4" pname="c"/>
@@ -1095,7 +1095,7 @@
                     <beam xml:id="m-681">
                       <note xml:id="m-679" dur="8" oct="4" pname="e" accid.ges="f">
                         <orig>
-                          <accid accid="f"/>
+                          <accid xml:id="m-680" accid="f"/>
                         </orig>
                       </note>
                       <note xml:id="m-682" dur="8" oct="4" pname="d"/>
@@ -1307,7 +1307,7 @@
                       <note xml:id="m-828" dur="32" oct="3" pname="d"/>
                       <note xml:id="m-829" dur="32" oct="3" pname="e" accid.ges="f">
                         <orig>
-                          <accid accid="f"/>
+                          <accid xml:id="m-830" accid="f"/>
                         </orig>
                       </note>
                       <note xml:id="m-831" dur="32" oct="3" pname="f"/>
@@ -1392,14 +1392,14 @@
                       <note xml:id="m-890" dur="32" oct="2" pname="a"/>
                       <note xml:id="m-891" dur="32" oct="2" pname="b" accid.ges="n">
                         <orig>
-                          <accid accid="n"/>
+                          <accid xml:id="m-892" accid="n"/>
                         </orig>
                       </note>
                       <note xml:id="m-893" dur="32" oct="3" pname="c"/>
                       <note xml:id="m-894" dur="32" oct="3" pname="d"/>
                       <note xml:id="m-895" dur="32" oct="3" pname="e" accid.ges="f">
                         <orig>
-                          <accid accid="f"/>
+                          <accid xml:id="m-896" accid="f"/>
                         </orig>
                       </note>
                       <note xml:id="m-897" dur="32" oct="3" pname="c"/>
@@ -1408,13 +1408,13 @@
                       <note xml:id="m-898" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-900" dur="16" oct="2" pname="b" accid.ges="n">
                         <orig>
-                          <accid accid="n"/>
+                          <accid xml:id="m-901" accid="n"/>
                         </orig>
                       </note>
                       <note xml:id="m-902" dur="16" oct="2" pname="g"/>
                       <note xml:id="m-903" dur="16" oct="2" pname="b" accid.ges="n">
                         <orig>
-                          <accid accid="n"/>
+                          <accid xml:id="m-904" accid="n"/>
                         </orig>
                       </note>
                     </beam>
@@ -1508,7 +1508,7 @@
                     <beam xml:id="m-958">
                       <note xml:id="m-956" dur="16" oct="4" pname="e" accid.ges="f">
                         <orig>
-                          <accid accid="f"/>
+                          <accid xml:id="m-957" accid="f"/>
                         </orig>
                       </note>
                       <note xml:id="m-959" dur="16" oct="3" pname="b" accid.ges="f"/>
@@ -1643,7 +1643,7 @@
                       <note xml:id="m-1035" dur="32" oct="3" pname="g"/>
                       <note xml:id="m-1036" dur="32" oct="3" pname="a" accid.ges="f">
                         <orig>
-                          <accid accid="f"/>
+                          <accid xml:id="m-1037" accid="f"/>
                         </orig>
                       </note>
                       <note xml:id="m-1038" dur="32" oct="3" pname="f"/>
@@ -1658,7 +1658,7 @@
                     </beam>
                     <note xml:id="m-1045" dur="8" oct="3" pname="a" accid.ges="f">
                       <orig>
-                        <accid accid="f"/>
+                        <accid xml:id="m-1046" accid="f"/>
                       </orig>
                     </note>
                     <rest xml:id="m-1047" dur="8"/>
@@ -1733,7 +1733,7 @@
                     <beam xml:id="m-1085">
                       <note xml:id="m-1083" dur="32" oct="3" pname="a" accid.ges="f">
                         <orig>
-                          <accid accid="f"/>
+                          <accid xml:id="m-1084" accid="f"/>
                         </orig>
                       </note>
                       <note xml:id="m-1086" dur="32" oct="2" pname="a">
@@ -1744,7 +1744,7 @@
                       <note xml:id="m-1091" dur="32" oct="3" pname="d"/>
                       <note xml:id="m-1092" dur="32" oct="3" pname="e" accid.ges="f">
                         <orig>
-                          <accid accid="f"/>
+                          <accid xml:id="m-1093" accid="f"/>
                         </orig>
                       </note>
                       <note xml:id="m-1094" dur="32" oct="3" pname="f"/>
@@ -1767,7 +1767,7 @@
                       <note xml:id="m-1104" dur="32" oct="3" pname="d"/>
                       <note xml:id="m-1105" dur="32" oct="3" pname="e" accid.ges="f">
                         <orig>
-                          <accid accid="f"/>
+                          <accid xml:id="m-1106" accid="f"/>
                         </orig>
                       </note>
                       <note xml:id="m-1107" dur="32" oct="3" pname="c"/>
@@ -1878,7 +1878,7 @@
                     <beam xml:id="m-1176">
                       <note xml:id="m-1174" dur="32" oct="3" pname="a" accid.ges="f">
                         <orig>
-                          <accid accid="f"/>
+                          <accid xml:id="m-1175" accid="f"/>
                         </orig>
                       </note>
                       <note xml:id="m-1177" dur="32" oct="4" pname="f"/>
@@ -2034,7 +2034,7 @@
                     <beam xml:id="m-1251">
                       <note xml:id="m-1249" dur="8" oct="3" pname="f" accid.ges="s">
                         <orig>
-                          <accid accid="s"/>
+                          <accid xml:id="m-1250" accid="s"/>
                         </orig>
                       </note>
                       <note xml:id="m-1252" dur="8" oct="3" pname="d"/>
@@ -2239,7 +2239,7 @@
                       <note xml:id="m-1375" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-1377" dur="16" oct="4" pname="c" accid.ges="s">
                         <orig>
-                          <accid accid="s"/>
+                          <accid xml:id="m-1378" accid="s"/>
                         </orig>
                       </note>
                       <note xml:id="m-1379" dur="16" oct="3" pname="a"/>
@@ -2264,7 +2264,7 @@
                       <note xml:id="m-1393" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-1394" dur="16" oct="3" pname="c" accid.ges="s">
                         <orig>
-                          <accid accid="s"/>
+                          <accid xml:id="m-1395" accid="s"/>
                         </orig>
                       </note>
                       <note xml:id="m-1396" dur="16" oct="2" pname="a"/>
@@ -2390,7 +2390,7 @@
                       <note xml:id="m-1454" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-1455" dur="16" oct="3" pname="f" accid.ges="s">
                         <orig>
-                          <accid accid="s"/>
+                          <accid xml:id="m-1456" accid="s"/>
                         </orig>
                       </note>
                       <note xml:id="m-1457" dur="16" oct="3" pname="d"/>
@@ -2401,7 +2401,7 @@
                       <note xml:id="m-1461" dur="32" oct="3" pname="e"/>
                       <note xml:id="m-1462" dur="32" oct="3" pname="f" accid.ges="s">
                         <orig>
-                          <accid accid="s"/>
+                          <accid xml:id="m-1463" accid="s"/>
                         </orig>
                       </note>
                       <note xml:id="m-1464" dur="32" oct="3" pname="g"/>
@@ -2413,7 +2413,7 @@
                       <note xml:id="m-1469" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-1471" dur="16" oct="3" pname="f" accid.ges="s">
                         <orig>
-                          <accid accid="s"/>
+                          <accid xml:id="m-1472" accid="s"/>
                         </orig>
                       </note>
                       <note xml:id="m-1473" dur="16" oct="3" pname="d"/>
@@ -2507,7 +2507,7 @@
                       <note xml:id="m-1526" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1527" dur="16" oct="2" pname="b" accid.ges="n">
                         <orig>
-                          <accid accid="n"/>
+                          <accid xml:id="m-1528" accid="n"/>
                         </orig>
                       </note>
                       <note xml:id="m-1529" dur="16" oct="2" pname="g"/>
@@ -2528,7 +2528,7 @@
                       <note xml:id="m-1540" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-1542" dur="16" oct="3" pname="b" accid.ges="n">
                         <orig>
-                          <accid accid="n"/>
+                          <accid xml:id="m-1543" accid="n"/>
                         </orig>
                       </note>
                       <note xml:id="m-1544" dur="16" oct="3" pname="g"/>

--- a/encodings/3/mattheson/music-example1.xml
+++ b/encodings/3/mattheson/music-example1.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 3, Example 1</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -37,8 +37,8 @@
                             <staffDef xml:id="bass" clef.shape="F" clef.line="4" n="2" lines="5" />
                         </staffGrp>
                     </scoreDef>
-                    <section xml:id="ex-34">
-                        <measure xml:id="ex-269" n="17" corresp="#m-603">
+                    <section>
+                        <measure corresp="#m-603">
                             <staff n="1">
                                 <layer>
                                     <rest dur="16" />

--- a/encodings/4/mattheson/music-example1.xml
+++ b/encodings/4/mattheson/music-example1.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 4, Example 1</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -31,34 +31,36 @@
                 <score>
                     <scoreDef key.pname="e" key.mode="minor" meter.unit="8" midi.bpm="85" mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" key.sig="1s" n="1" lines="5" meter.unit="8" />
+                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5">
+                                <!-- key accidental missing in first edition -->
+                                <keySig sig="1s" />
+                            </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure xml:id="ex-101">
+                        <measure corresp="#m-101">
                             <staff n="1">
-                                <layer>
+                                <layer n="1">
                                     <rest xml:id="ex-105" dur="16" />
-                                    <beam xml:id="ex-107">
-                                        <note xml:id="ex-106" dur="16" oct="4" pname="b" stem.dir="down"/>
-                                        <note xml:id="ex-108" dur="16" oct="4" pname="b" stem.dir="down"/>
-                                        <note xml:id="ex-109" dur="16" oct="4" pname="a" stem.dir="down"/>
-                                        <note xml:id="ex-110" dur="32" oct="4" pname="g" stem.dir="down"/>
-                                        <note xml:id="ex-111" dur="32" oct="4" pname="a" stem.dir="down"/>
-                                        <note xml:id="ex-112" dur="32" oct="4" pname="f" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="ex-114" dur="32" oct="4" pname="g" stem.dir="down"/>
+                                    <beam place="below">
+                                        <note xml:id="ex-106" dur="16" oct="4" pname="b" />
+                                        <note xml:id="ex-108" dur="16" oct="4" pname="b" />
+                                        <note xml:id="ex-109" dur="16" oct="4" pname="a" />
+                                        <note xml:id="ex-110" dur="32" oct="4" pname="g" />
+                                        <note xml:id="ex-111" dur="32" oct="4" pname="a" />
+                                        <note xml:id="ex-112" dur="32" oct="4" pname="f" accid.ges="s" />
+                                        <note xml:id="ex-114" dur="32" oct="4" pname="g" />
                                     </beam>
-                                    <note xml:id="ex-120" dur="4" dots="1" oct="4" pname="a" stem.dir="up"/>
+                                    <note xml:id="ex-120" dur="4" dots="1" oct="4" pname="a" />
                                 </layer>
-                                <layer>
+                                <layer n="2">
                                   <space dur="4" dots="1"/>
-                                  <note xml:id="ex-118" dur="4" dots="1" oct="4" pname="f" stem.dir="down"/>
-                                </layer>
-                                <layer>
-                                  <space dur="4" dots="1"/>
-                                  <note xml:id="ex-116" dur="4" oct="4" pname="d" dots="1" stem.dir="down">
-                                      <accid accid="s" />
-                                  </note>
+                                  <chord dur="4" dots="1">
+                                      <note xml:id="ex-118" oct="4" pname="f" />
+                                      <note xml:id="ex-116" oct="4" pname="d" >
+                                          <accid accid="s" />
+                                      </note>
+                                  </chord>
                                 </layer>
                             </staff>
                         </measure>

--- a/encodings/4/mattheson/music-example2.xml
+++ b/encodings/4/mattheson/music-example2.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 4, Example 2</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -31,11 +31,13 @@
                 <score>
                     <scoreDef key.pname="e" key.accid="n" key.mode="minor" meter.unit="8" midi.bpm="85" mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" key.sig="1s" n="1" lines="5" meter.unit="8" />
+                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5">
+                                <keySig sig="1s" />
+                            </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure xml:id="ex-101" metcon="false" right="invis">
+                        <measure corresp="#m-327" metcon="false" right="invis">
                             <staff n="1">
                                 <layer n="1">
                                     <space xml:id="ex-331" dots="1" dur="4" />
@@ -47,8 +49,15 @@
                                     <space xml:id="ex-365" dur="8" />
                                 </layer>
                                 <layer n="2">
-                                    <rest xml:id="ex-333" dur="16" />
-                                    <beam>
+                                    <app>
+                                        <lem source="#secondEdition">
+                                            <rest dur="16" oloc="5" ploc="d" />
+                                        </lem>
+                                        <rdg source="#firstEdition">
+                                            <space dur="16" />
+                                        </rdg>
+                                    </app>
+                                    <beam place="below">
                                         <note xml:id="ex-334" dur="16" oct="4" pname="b" />
                                         <note xml:id="ex-337" dur="16" oct="4" pname="b" />
                                         <note xml:id="ex-338" dur="16" oct="4" pname="a" />
@@ -57,7 +66,7 @@
                                         <note xml:id="ex-341" dur="32" oct="4" pname="f" accid.ges="s" />
                                         <note xml:id="ex-343" dur="32" oct="4" pname="g" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note xml:id="ex-345" dur="16" oct="4" pname="e" />
                                         <note xml:id="ex-347" dur="16" oct="5" pname="c" />
                                         <note xml:id="ex-350" dur="16" oct="5" pname="c" />
@@ -67,7 +76,7 @@
                                         <note xml:id="ex-355" dur="32" oct="4" pname="g" />
                                         <note xml:id="ex-356" dur="32" oct="4" pname="a" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note xml:id="ex-358" dur="16" oct="4" pname="f" accid.ges="s" />
                                         <note xml:id="ex-361" dur="16" oct="5" pname="d" />
                                         <note xml:id="ex-363" dur="16" oct="5" pname="d" />
@@ -80,6 +89,17 @@
                                     <custos oct="4" pname="g" />
                                 </layer>
                             </staff>
+                            <app>
+                                <lem source="#secondEdition">
+                                    <bracketSpan func="analytical" startid="#ex-337" endid="#ex-343" lform="solid" />
+                                    <bracketSpan func="analytical" startid="#ex-350" endid="#ex-356" lform="solid" />
+                                    <supplied resp="#rettinghaus" cert="medium">
+                                        <bracketSpan func="analytical" startid="#ex-363" endid="#ex-369" lform="solid" />
+                                    </supplied>
+                                </lem>
+                                <rdg source="#firstEdition">
+                                </rdg>
+                            </app>
                         </measure>
                     </section>
                 </score>

--- a/encodings/4/mattheson/music-example3.xml
+++ b/encodings/4/mattheson/music-example3.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 4, Example 3</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -35,11 +35,18 @@
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure xml:id="ex-101" metcon="false" right="invis">
+                        <measure corresp="#m-588" metcon="false" right="invis">
                             <staff n="1">
                                 <layer>
-                                    <rest dur="16" />
-                                    <beam>
+                                    <app>
+                                        <lem source="#secondEdition">
+                                            <rest dur="16" oloc="5" ploc="b" />
+                                        </lem>
+                                        <rdg source="#firstEdition">
+                                            <space dur="16" />
+                                        </rdg>
+                                    </app>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="b" />
                                         <note dur="16" oct="5" pname="b" />
                                         <note dur="16" oct="5" pname="a" />
@@ -48,7 +55,7 @@
                                         <note dur="32" oct="5" pname="f" accid.ges="s" />
                                         <note dur="32" oct="5" pname="a" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="g" />
                                         <note dur="16" oct="5" pname="b" />
                                         <note dur="16" oct="5" pname="b" />

--- a/encodings/4/mattheson/music-example4.xml
+++ b/encodings/4/mattheson/music-example4.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 4, Example 4</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -31,11 +31,13 @@
                 <score>
                     <scoreDef key.pname="e" key.accid="n" key.mode="minor" meter.unit="8" midi.bpm="85" mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" key.sig="1s" n="1" lines="5" meter.unit="8" />
+                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5" meter.unit="8">
+                                <keySig sig="1s" />
+                            </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure xml:id="ex-101">
+                        <measure corresp="#m-1078">
                             <staff n="1">
                                 <layer>
                                     <beam>

--- a/encodings/4/mattheson/music-example5.xml
+++ b/encodings/4/mattheson/music-example5.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 4, Example 5</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -35,7 +35,7 @@
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure xml:id="ex-101" metcon="false" right="invis">
+                        <measure corresp="#m-1117" metcon="false" right="invis">
                             <staff n="1">
                                 <layer>
                                     <beam>

--- a/encodings/4/mattheson/score.xml
+++ b/encodings/4/mattheson/score.xml
@@ -211,7 +211,7 @@
                   <beam>
                     <note xml:id="m-59" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-61" dur="16" oct="3" pname="e"/>
-                    <note xml:id="m-62" breaksec="1" dur="16" oct="3" pname="f" accid.ges="s"/>
+                    <note xml:id="m-62" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-64" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-65" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-66" dur="32" oct="3" pname="a"/>
@@ -221,7 +221,7 @@
                     <note xml:id="m-68" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-70" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-71" dur="16" oct="3" pname="d"/>
-                    <note xml:id="m-72" breaksec="1" dur="16" oct="3" pname="e"/>
+                    <note xml:id="m-72" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-73" dur="32" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-75" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-76" dur="32" oct="3" pname="g"/>
@@ -231,7 +231,7 @@
                     <note xml:id="m-78" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-80" dur="16" oct="3" pname="c"/>
                     <note xml:id="m-81" dur="16" oct="3" pname="c"/>
-                    <note xml:id="m-82" breaksec="1" dur="16" oct="3" pname="d"/>
+                    <note xml:id="m-82" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-83" dur="32" oct="3" pname="e"/>
                     <note xml:id="m-84" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-85" dur="32" oct="3" pname="f" accid.ges="s"/>
@@ -241,7 +241,7 @@
                     <note xml:id="m-88" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-90" dur="16" oct="2" pname="b"/>
                     <note xml:id="m-91" dur="16" oct="2" pname="b"/>
-                    <note xml:id="m-92" breaksec="1" dur="16" oct="3" pname="c">
+                    <note xml:id="m-92" dur="16" oct="3" pname="c">
                       <accid accid="s"/>
                     </note>
                     <note xml:id="m-94" dur="32" oct="3" pname="d">
@@ -297,7 +297,7 @@
                   <beam>
                     <note xml:id="m-106" dur="16" oct="4" pname="b"/>
                     <note xml:id="m-108" dur="16" oct="4" pname="b"/>
-                    <note xml:id="m-109" breaksec="1" dur="16" oct="4" pname="a"/>
+                    <note xml:id="m-109" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-110" dur="32" oct="4" pname="g"/>
                     <note xml:id="m-111" dur="32" oct="4" pname="a"/>
                     <note xml:id="m-112" dur="32" oct="4" pname="f" accid.ges="s"/>
@@ -329,7 +329,7 @@
                   <beam xml:id="m-158">
                     <note xml:id="m-157" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-159" dur="16" oct="4" pname="e"/>
-                    <note xml:id="m-160" breaksec="1" dur="16" oct="4" pname="d">
+                    <note xml:id="m-160" dur="16" oct="4" pname="d">
                       <supplied resp="#pfeffer">
                         <reg>
                           <accid accid="n" func="caution"/>
@@ -351,7 +351,7 @@
                     <note xml:id="m-167" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-169" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-170" dur="16" oct="4" pname="e"/>
-                    <note xml:id="m-171" breaksec="1" dur="16" oct="4" pname="d"/>
+                    <note xml:id="m-171" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-172" dur="32" oct="4" pname="c"/>
                     <note xml:id="m-173" dur="32" oct="4" pname="d"/>
                     <note xml:id="m-174" dur="32" oct="3" pname="b"/>
@@ -412,7 +412,7 @@
                   <beam>
                     <note xml:id="m-180" dur="16" oct="5" pname="e"/>
                     <note xml:id="m-182" dur="16" oct="5" pname="e"/>
-                    <note xml:id="m-183" breaksec="1" dur="16" oct="5" pname="d">
+                    <note xml:id="m-183" dur="16" oct="5" pname="d">
                       <accid accid="n"/>
                     </note>
                     <note xml:id="m-185" dur="32" oct="5" pname="c"/>
@@ -482,7 +482,7 @@
                   <beam>
                     <note xml:id="m-235" dur="16" oct="5" pname="d"/>
                     <note xml:id="m-237" dur="16" oct="5" pname="d"/>
-                    <note xml:id="m-238" breaksec="1" dur="16" oct="5" pname="c"/>
+                    <note xml:id="m-238" dur="16" oct="5" pname="c"/>
                     <note xml:id="m-239" dur="32" oct="4" pname="b"/>
                     <note xml:id="m-240" dur="32" oct="5" pname="c"/>
                     <note xml:id="m-241" dur="32" oct="4" pname="a"/>
@@ -501,7 +501,7 @@
                   <beam>
                     <note xml:id="m-251" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-253" dur="16" oct="4" pname="d"/>
-                    <note xml:id="m-254" breaksec="1" dur="16" oct="4" pname="c"/>
+                    <note xml:id="m-254" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-255" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-256" dur="32" oct="4" pname="c"/>
                     <note xml:id="m-257" dur="32" oct="3" pname="a"/>
@@ -511,7 +511,7 @@
                     <note xml:id="m-259" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-261" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-262" dur="16" oct="4" pname="d"/>
-                    <note xml:id="m-263" breaksec="1" dur="16" oct="4" pname="c"/>
+                    <note xml:id="m-263" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-264" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-265" dur="32" oct="4" pname="c"/>
                     <note xml:id="m-266" dur="32" oct="3" pname="a"/>
@@ -563,7 +563,7 @@
                   <beam>
                     <note xml:id="m-281" dur="16" oct="4" pname="b"/>
                     <note xml:id="m-283" dur="16" oct="4" pname="b"/>
-                    <note xml:id="m-284" breaksec="1" dur="16" oct="4" pname="a"/>
+                    <note xml:id="m-284" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-285" dur="32" oct="4" pname="g"/>
                     <note xml:id="m-286" dur="32" oct="4" pname="a"/>
                     <note xml:id="m-287" dur="32" oct="4" pname="f" accid.ges="s"/>
@@ -584,7 +584,7 @@
                   <beam>
                     <note xml:id="m-299" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-301" dur="16" oct="3" pname="b"/>
-                    <note xml:id="m-302" breaksec="1" dur="16" oct="3" pname="a"/>
+                    <note xml:id="m-302" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-303" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-304" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-305" dur="32" oct="3" pname="f" accid.ges="s"/>
@@ -594,7 +594,7 @@
                     <note xml:id="m-308" dur="16" oct="3" pname="g"/>
                     <note xml:id="m-310" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-311" dur="16" oct="3" pname="b"/>
-                    <note xml:id="m-312" breaksec="1" dur="16" oct="3" pname="a"/>
+                    <note xml:id="m-312" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-313" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-314" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-315" dur="32" oct="3" pname="f" accid.ges="s"/>
@@ -674,7 +674,7 @@
                   <beam>
                     <note xml:id="m-334" dur="16" oct="4" pname="b"/>
                     <note xml:id="m-337" dur="16" oct="4" pname="b"/>
-                    <note xml:id="m-338" breaksec="1" dur="16" oct="4" pname="a"/>
+                    <note xml:id="m-338" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-339" dur="32" oct="4" pname="g"/>
                     <note xml:id="m-340" dur="32" oct="4" pname="a"/>
                     <note xml:id="m-341" dur="32" oct="4" pname="f" accid.ges="s"/>
@@ -684,7 +684,7 @@
                     <note xml:id="m-345" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-347" dur="16" oct="5" pname="c"/>
                     <note xml:id="m-350" dur="16" oct="5" pname="c"/>
-                    <note xml:id="m-351" breaksec="1" dur="16" oct="4" pname="b"/>
+                    <note xml:id="m-351" dur="16" oct="4" pname="b"/>
                     <note xml:id="m-353" dur="32" oct="4" pname="a"/>
                     <note xml:id="m-354" dur="32" oct="4" pname="b"/>
                     <note xml:id="m-355" dur="32" oct="4" pname="g"/>
@@ -694,7 +694,7 @@
                     <note xml:id="m-358" dur="16" oct="4" pname="f" accid.ges="s"/>
                     <note xml:id="m-361" dur="16" oct="5" pname="d"/>
                     <note xml:id="m-363" dur="16" oct="5" pname="d"/>
-                    <note xml:id="m-364" breaksec="1" dur="16" oct="5" pname="c"/>
+                    <note xml:id="m-364" dur="16" oct="5" pname="c"/>
                     <note xml:id="m-366" dur="32" oct="4" pname="b"/>
                     <note xml:id="m-367" dur="32" oct="5" pname="c"/>
                     <note xml:id="m-368" dur="32" oct="4" pname="a"/>
@@ -795,7 +795,7 @@
                   <beam>
                     <note xml:id="m-429" dur="16" oct="3" pname="g"/>
                     <note xml:id="m-431" dur="16" oct="3" pname="g"/>
-                    <note xml:id="m-432" breaksec="1" dur="16" oct="3" pname="a"/>
+                    <note xml:id="m-432" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-433" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-434" dur="32" oct="4" pname="d"/>
                     <note xml:id="m-435" dur="32" oct="4" pname="c"/>
@@ -805,7 +805,7 @@
                     <note xml:id="m-437" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-439" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-441" dur="16" oct="3" pname="f" accid.ges="s"/>
-                    <note xml:id="m-443" breaksec="1" dur="16" oct="3" pname="g"/>
+                    <note xml:id="m-443" dur="16" oct="3" pname="g"/>
                     <note xml:id="m-444" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-445" dur="32" oct="4" pname="c"/>
                     <note xml:id="m-446" dur="32" oct="3" pname="b"/>
@@ -815,7 +815,7 @@
                     <note xml:id="m-448" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-450" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-451" dur="16" oct="3" pname="e"/>
-                    <note xml:id="m-452" breaksec="1" dur="16" oct="3" pname="f" accid.ges="s"/>
+                    <note xml:id="m-452" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-454" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-455" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-456" dur="32" oct="3" pname="a"/>
@@ -825,7 +825,7 @@
                     <note xml:id="m-458" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-460" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-461" dur="16" oct="3" pname="d"/>
-                    <note xml:id="m-462" breaksec="1" dur="16" oct="3" pname="e"/>
+                    <note xml:id="m-462" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-463" dur="32" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-465" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-466" dur="32" oct="3" pname="g"/>
@@ -866,7 +866,7 @@
                   <beam>
                     <note xml:id="m-473" dur="16" oct="4" pname="g"/>
                     <note xml:id="m-475" dur="16" oct="4" pname="g"/>
-                    <note xml:id="m-476" breaksec="1" dur="16" oct="4" pname="a"/>
+                    <note xml:id="m-476" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-477" dur="32" oct="4" pname="b"/>
                     <note xml:id="m-478" dur="32" oct="5" pname="d"/>
                     <note xml:id="m-479" dur="32" oct="5" pname="c"/>
@@ -876,7 +876,7 @@
                     <note xml:id="m-481" dur="16" oct="5" pname="e"/>
                     <note xml:id="m-483" dur="16" oct="4" pname="f" accid.ges="s"/>
                     <note xml:id="m-485" dur="16" oct="4" pname="f" accid.ges="s"/>
-                    <note xml:id="m-487" breaksec="1" dur="16" oct="4" pname="g"/>
+                    <note xml:id="m-487" dur="16" oct="4" pname="g"/>
                     <note xml:id="m-488" dur="32" oct="4" pname="a"/>
                     <note xml:id="m-489" dur="32" oct="5" pname="c"/>
                     <note xml:id="m-490" dur="32" oct="4" pname="b"/>
@@ -886,7 +886,7 @@
                     <note xml:id="m-492" dur="16" oct="5" pname="d"/>
                     <note xml:id="m-494" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-495" dur="16" oct="4" pname="e"/>
-                    <note xml:id="m-496" breaksec="1" dur="16" oct="4" pname="f" accid.ges="s"/>
+                    <note xml:id="m-496" dur="16" oct="4" pname="f" accid.ges="s"/>
                     <note xml:id="m-498" dur="32" oct="4" pname="g"/>
                     <note xml:id="m-499" dur="32" oct="4" pname="b"/>
                     <note xml:id="m-500" dur="32" oct="4" pname="a"/>
@@ -896,7 +896,7 @@
                     <note xml:id="m-502" dur="16" oct="5" pname="c"/>
                     <note xml:id="m-504" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-505" dur="16" oct="4" pname="d"/>
-                    <note xml:id="m-506" breaksec="1" dur="16" oct="4" pname="e"/>
+                    <note xml:id="m-506" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-507" dur="32" oct="4" pname="f" accid.ges="s"/>
                     <note xml:id="m-509" dur="32" oct="4" pname="a"/>
                     <note xml:id="m-510" dur="32" oct="4" pname="g"/>
@@ -998,7 +998,7 @@
                     <clef line="4" shape="C"/>
                     <note xml:id="m-566" dur="16" oct="4" pname="f" accid.ges="s"/>
                     <note xml:id="m-568" dur="16" oct="4" pname="f" accid.ges="s"/>
-                    <note xml:id="m-570" breaksec="1" dur="16" oct="4" pname="e"/>
+                    <note xml:id="m-570" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-571" dur="32" oct="4" pname="d"/>
                     <note xml:id="m-572" dur="32" oct="4" pname="e"/>
                     <note xml:id="m-573" dur="32" oct="4" pname="c" accid.ges="s">
@@ -1012,7 +1012,7 @@
                     <note xml:id="m-576" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-578" dur="16" oct="4" pname="f" accid.ges="s"/>
                     <note xml:id="m-580" dur="16" oct="4" pname="f" accid.ges="s"/>
-                    <note xml:id="m-582" breaksec="1" dur="16" oct="4" pname="e"/>
+                    <note xml:id="m-582" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-583" dur="32" oct="4" pname="d"/>
                     <note xml:id="m-584" dur="32" oct="4" pname="e"/>
                     <note xml:id="m-585" dur="32" oct="4" pname="c" accid.ges="s">
@@ -1077,7 +1077,7 @@
                   <beam>
                     <note xml:id="m-593" dur="16" oct="5" pname="b"/>
                     <note xml:id="m-595" dur="16" oct="5" pname="b"/>
-                    <note xml:id="m-596" breaksec="1" dur="16" oct="5" pname="a"/>
+                    <note xml:id="m-596" dur="16" oct="5" pname="a"/>
                     <note xml:id="m-597" dur="32" oct="5" pname="g"/>
                     <note xml:id="m-598" dur="32" oct="5" pname="a"/>
                     <note xml:id="m-599" dur="32" oct="5" pname="f" accid.ges="s"/>
@@ -1087,7 +1087,7 @@
                     <note xml:id="m-602" dur="16" oct="5" pname="g"/>
                     <note xml:id="m-604" dur="16" oct="5" pname="b"/>
                     <note xml:id="m-605" dur="16" oct="5" pname="b"/>
-                    <note xml:id="m-606" breaksec="1" dur="16" oct="5" pname="a"/>
+                    <note xml:id="m-606" dur="16" oct="5" pname="a"/>
                     <note xml:id="m-607" dur="32" oct="5" pname="g"/>
                     <note xml:id="m-608" dur="32" oct="5" pname="a"/>
                     <note xml:id="m-609" dur="32" oct="5" pname="f" accid.ges="s"/>
@@ -1118,7 +1118,7 @@
                     <note xml:id="m-624" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-626" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-627" dur="16" oct="4" pname="e"/>
-                    <note xml:id="m-628" breaksec="1" dur="16" oct="4" pname="d">
+                    <note xml:id="m-628" dur="16" oct="4" pname="d">
                       <supplied resp="#pfeffer">
                         <reg>
                           <accid accid="n" func="caution"/>
@@ -1136,7 +1136,7 @@
                     <note xml:id="m-637" dur="16" oct="4" pname="c" accid.ges="s"/>
                     <note xml:id="m-640" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-641" dur="16" oct="4" pname="e"/>
-                    <note xml:id="m-642" breaksec="1" dur="16" oct="4" pname="d"/>
+                    <note xml:id="m-642" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-644" dur="32" oct="4" pname="c" accid.ges="s">
                       <orig>
                         <accid accid="s"/>
@@ -1211,7 +1211,7 @@
                   <beam>
                     <note xml:id="m-656" dur="16" oct="5" pname="a"/>
                     <note xml:id="m-658" dur="16" oct="5" pname="a"/>
-                    <note xml:id="m-659" breaksec="1" dur="16" oct="5" pname="g"/>
+                    <note xml:id="m-659" dur="16" oct="5" pname="g"/>
                     <note xml:id="m-660" dur="32" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-662" dur="32" oct="5" pname="g"/>
                     <note xml:id="m-663" dur="32" oct="5" pname="e"/>
@@ -1221,7 +1221,7 @@
                     <note xml:id="m-665" dur="16" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-668" dur="16" oct="5" pname="a"/>
                     <note xml:id="m-669" dur="16" oct="5" pname="a"/>
-                    <note xml:id="m-670" breaksec="1" dur="16" oct="5" pname="g"/>
+                    <note xml:id="m-670" dur="16" oct="5" pname="g"/>
                     <note xml:id="m-671" dur="32" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-673" dur="32" oct="5" pname="g"/>
                     <note xml:id="m-674" dur="32" oct="5" pname="e"/>
@@ -1253,7 +1253,7 @@
                     <note xml:id="m-690" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-692" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-693" dur="16" oct="4" pname="d"/>
-                    <note xml:id="m-694" breaksec="1" dur="16" oct="4" pname="c">
+                    <note xml:id="m-694" dur="16" oct="4" pname="c">
                       <accid accid="n"/>
                     </note>
                     <note xml:id="m-696" dur="32" oct="3" pname="b"/>
@@ -1265,7 +1265,7 @@
                     <note xml:id="m-702" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-704" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-705" dur="16" oct="4" pname="d"/>
-                    <note xml:id="m-706" breaksec="1" dur="16" oct="4" pname="c"/>
+                    <note xml:id="m-706" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-708" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-709" dur="32" oct="4" pname="c"/>
                     <note xml:id="m-711" dur="32" oct="3" pname="a"/>
@@ -1327,7 +1327,7 @@
                     <note xml:id="m-719" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-721" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-722" dur="16" oct="3" pname="d"/>
-                    <note xml:id="m-723" breaksec="1" dur="16" oct="3" pname="e"/>
+                    <note xml:id="m-723" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-724" dur="32" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-726" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-727" dur="32" oct="3" pname="g"/>
@@ -1339,7 +1339,7 @@
                       <accid accid="s"/>
                     </note>
                     <note xml:id="m-733" dur="16" oct="3" pname="c" accid.ges="s"/>
-                    <note xml:id="m-735" breaksec="1" dur="16" oct="3" pname="d"/>
+                    <note xml:id="m-735" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-736" dur="32" oct="3" pname="e"/>
                     <note xml:id="m-737" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-738" dur="32" oct="3" pname="f" accid.ges="s"/>
@@ -1349,7 +1349,7 @@
                     <note xml:id="m-741" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-743" dur="16" oct="2" pname="b"/>
                     <note xml:id="m-744" dur="16" oct="2" pname="b"/>
-                    <note xml:id="m-745" breaksec="1" dur="16" oct="3" pname="c" accid.ges="s">
+                    <note xml:id="m-745" dur="16" oct="3" pname="c" accid.ges="s">
                       <orig>
                         <accid accid="s"/>
                       </orig>
@@ -1370,7 +1370,7 @@
                     </app>
                     <note xml:id="m-755" dur="16" oct="2" pname="a"/>
                     <note xml:id="m-756" dur="16" oct="2" pname="a"/>
-                    <note xml:id="m-757" breaksec="1" dur="16" oct="2" pname="b"/>
+                    <note xml:id="m-757" dur="16" oct="2" pname="b"/>
                     <note xml:id="m-758" dur="32" oct="3" pname="c" accid.ges="s">
                       <orig>
                         <accid accid="s"/>
@@ -1466,7 +1466,7 @@
                   <beam>
                     <note xml:id="m-793" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-796" dur="16" oct="3" pname="f" accid.ges="s"/>
-                    <note xml:id="m-798" breaksec="1" dur="16" oct="3" pname="e"/>
+                    <note xml:id="m-798" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-799" dur="32" oct="3" pname="d"/>
                     <note xml:id="m-800" dur="32" oct="3" pname="e"/>
                     <note xml:id="m-801" dur="32" oct="3" pname="c">
@@ -1478,7 +1478,7 @@
                     <note xml:id="m-804" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-806" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-808" dur="16" oct="3" pname="f" accid.ges="s"/>
-                    <note xml:id="m-810" breaksec="1" dur="16" oct="3" pname="e"/>
+                    <note xml:id="m-810" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-811" dur="32" oct="3" pname="d"/>
                     <note xml:id="m-812" dur="32" oct="3" pname="e"/>
                     <note xml:id="m-813" dur="32" oct="3" pname="c" accid.ges="s">
@@ -1492,7 +1492,7 @@
                     <note xml:id="m-816" dur="16" oct="2" pname="b"/>
                     <note xml:id="m-818" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-819" dur="16" oct="3" pname="b"/>
-                    <note xml:id="m-820" breaksec="1" dur="16" oct="3" pname="a"/>
+                    <note xml:id="m-820" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-821" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-822" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-823" dur="32" oct="3" pname="f" accid.ges="s"/>
@@ -1502,7 +1502,7 @@
                     <note xml:id="m-826" dur="16" oct="3" pname="g"/>
                     <note xml:id="m-828" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-829" dur="16" oct="3" pname="b"/>
-                    <note xml:id="m-830" breaksec="1" dur="16" oct="3" pname="a"/>
+                    <note xml:id="m-830" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-831" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-832" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-833" dur="32" oct="3" pname="f" accid.ges="s"/>
@@ -1618,7 +1618,7 @@
                     <note xml:id="m-861" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-864" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-865" dur="16" oct="3" pname="d"/>
-                    <note xml:id="m-866" breaksec="1" dur="16" oct="3" pname="e"/>
+                    <note xml:id="m-866" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-867" dur="32" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-869" dur="32" oct="3" pname="e"/>
                     <note xml:id="m-870" dur="32" oct="3" pname="f" accid.ges="s"/>
@@ -1632,7 +1632,7 @@
                       <accid accid="s"/>
                     </note>
                     <note xml:id="m-878" dur="16" oct="3" pname="c" accid.ges="s"/>
-                    <note xml:id="m-880" breaksec="1" dur="16" oct="3" pname="d"/>
+                    <note xml:id="m-880" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-881" dur="32" oct="3" pname="e"/>
                     <note xml:id="m-882" dur="32" oct="3" pname="d"/>
                     <note xml:id="m-883" dur="32" oct="3" pname="e"/>
@@ -1683,7 +1683,7 @@
                     <note xml:id="m-890" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-893" dur="16" oct="2" pname="b"/>
                     <note xml:id="m-894" dur="16" oct="2" pname="b"/>
-                    <note xml:id="m-895" breaksec="1" dur="16" oct="3" pname="c">
+                    <note xml:id="m-895" dur="16" oct="3" pname="c">
                       <accid accid="s"/>
                     </note>
                     <note xml:id="m-897" dur="32" oct="3" pname="d"/>
@@ -1695,7 +1695,7 @@
                     <note xml:id="m-902" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-905" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-907" dur="16" oct="3" pname="f" accid.ges="s"/>
-                    <note xml:id="m-909" breaksec="1" dur="16" oct="3" pname="g">
+                    <note xml:id="m-909" dur="16" oct="3" pname="g">
                       <accid accid="s"/>
                     </note>
                     <note xml:id="m-910" dur="32" oct="3" pname="a">
@@ -1834,7 +1834,7 @@
                   <beam>
                     <note xml:id="m-966" dur="16" oct="5" pname="d"/>
                     <note xml:id="m-968" dur="16" oct="5" pname="d"/>
-                    <note xml:id="m-969" breaksec="1" dur="16" oct="5" pname="e"/>
+                    <note xml:id="m-969" dur="16" oct="5" pname="e"/>
                     <note xml:id="m-970" dur="32" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-972" dur="32" oct="5" pname="e"/>
                     <note xml:id="m-973" dur="32" oct="5" pname="f" accid.ges="s"/>
@@ -1844,7 +1844,7 @@
                     <note xml:id="m-976" dur="16" oct="5" pname="g"/>
                     <note xml:id="m-978" dur="16" oct="5" pname="c"/>
                     <note xml:id="m-979" dur="16" oct="5" pname="c"/>
-                    <note xml:id="m-980" breaksec="1" dur="16" oct="5" pname="d"/>
+                    <note xml:id="m-980" dur="16" oct="5" pname="d"/>
                     <note xml:id="m-981" dur="32" oct="5" pname="e">
                       <accid accid="n" func="caution"/>
                     </note>
@@ -1858,7 +1858,7 @@
                     <note xml:id="m-987" dur="16" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-990" dur="16" oct="4" pname="b"/>
                     <note xml:id="m-991" dur="16" oct="4" pname="b"/>
-                    <note xml:id="m-992" breaksec="1" dur="16" oct="5" pname="c"/>
+                    <note xml:id="m-992" dur="16" oct="5" pname="c"/>
                     <note xml:id="m-993" dur="32" oct="5" pname="d"/>
                     <note xml:id="m-994" dur="32" oct="5" pname="c"/>
                     <note xml:id="m-995" dur="32" oct="5" pname="d"/>
@@ -1870,7 +1870,7 @@
                     </note>
                     <note xml:id="m-1000" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-1001" dur="16" oct="4" pname="a"/>
-                    <note xml:id="m-1002" breaksec="1" dur="16" oct="4" pname="b"/>
+                    <note xml:id="m-1002" dur="16" oct="4" pname="b"/>
                     <note xml:id="m-1003" dur="32" oct="5" pname="c"/>
                     <note xml:id="m-1004" dur="32" oct="4" pname="b"/>
                     <note xml:id="m-1005" dur="32" oct="5" pname="c"/>
@@ -1954,7 +1954,7 @@
                   <beam>
                     <note xml:id="m-1035" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-1037" dur="16" oct="3" pname="b"/>
-                    <note xml:id="m-1038" breaksec="1" dur="16" oct="4" pname="c">
+                    <note xml:id="m-1038" dur="16" oct="4" pname="c">
                       <accid accid="s"/>
                     </note>
                     <note xml:id="m-1040" dur="32" oct="4" pname="d"/>
@@ -1966,7 +1966,7 @@
                     <note xml:id="m-1045" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-1047" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-1048" dur="16" oct="3" pname="a"/>
-                    <note xml:id="m-1049" breaksec="1" dur="16" oct="3" pname="b"/>
+                    <note xml:id="m-1049" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-1050" dur="32" oct="4" pname="c" accid.ges="s">
                       <orig>
                         <accid accid="s"/>
@@ -1980,7 +1980,7 @@
                     <note xml:id="m-1056" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-1058" dur="16" oct="3" pname="g"/>
                     <note xml:id="m-1059" dur="16" oct="3" pname="g"/>
-                    <note xml:id="m-1060" breaksec="1" dur="16" oct="3" pname="a"/>
+                    <note xml:id="m-1060" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-1061" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-1062" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-1063" dur="32" oct="3" pname="b"/>
@@ -1994,7 +1994,7 @@
                     </note>
                     <note xml:id="m-1068" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-1070" dur="16" oct="3" pname="f" accid.ges="s"/>
-                    <note xml:id="m-1072" breaksec="1" dur="16" oct="3" pname="g"/>
+                    <note xml:id="m-1072" dur="16" oct="3" pname="g"/>
                     <note xml:id="m-1073" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-1074" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-1075" dur="32" oct="3" pname="a"/>
@@ -2076,7 +2076,7 @@
                     <note xml:id="m-1092" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-1094" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-1095" dur="16" oct="3" pname="e"/>
-                    <note xml:id="m-1096" breaksec="1" dur="16" oct="3" pname="f" accid.ges="s"/>
+                    <note xml:id="m-1096" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-1098" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-1099" dur="32" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-1101" dur="32" oct="3" pname="g"/>
@@ -2086,7 +2086,7 @@
                     <note xml:id="m-1103" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-1105" dur="16" oct="2" pname="a"/>
                     <note xml:id="m-1106" dur="16" oct="2" pname="a"/>
-                    <note xml:id="m-1107" breaksec="1" dur="16" oct="2" pname="b"/>
+                    <note xml:id="m-1107" dur="16" oct="2" pname="b"/>
                     <note xml:id="m-1108" dur="32" oct="3" pname="c">
                       <accid accid="s"/>
                     </note>
@@ -2137,11 +2137,11 @@
                     <note xml:id="m-1121" dur="32" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-1124" dur="32" oct="5" pname="d"/>
                     <note xml:id="m-1125" dur="32" oct="5" pname="f" accid.ges="s"/>
-                    <note xml:id="m-1127" breaksec="1" dur="32" oct="5" pname="a"/>
+                    <note xml:id="m-1127" dur="32" oct="5" pname="a"/>
                     <note xml:id="m-1128" dur="32" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-1130" dur="32" oct="5" pname="d"/>
                     <note xml:id="m-1131" dur="32" oct="5" pname="f" accid.ges="s"/>
-                    <note xml:id="m-1133" breaksec="1" dur="32" oct="5" pname="a"/>
+                    <note xml:id="m-1133" dur="32" oct="5" pname="a"/>
                     <note xml:id="m-1134" dur="32" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-1136" dur="32" oct="5" pname="d"/>
                     <note xml:id="m-1137" dur="32" oct="5" pname="f" accid.ges="s"/>
@@ -2153,7 +2153,7 @@
                     </note>
                     <note xml:id="m-1143" dur="32" oct="4" pname="a"/>
                     <note xml:id="m-1144" dur="32" oct="5" pname="c" accid.ges="s"/>
-                    <note xml:id="m-1146" breaksec="1" dur="32" oct="5" pname="e"/>
+                    <note xml:id="m-1146" dur="32" oct="5" pname="e"/>
                     <note xml:id="m-1147" dur="32" oct="5" pname="c" accid.ges="s"/>
                     <note xml:id="m-1149" dur="32" oct="4" pname="a"/>
                     <note xml:id="m-1150" dur="32" oct="5" pname="c" accid.ges="s"/>
@@ -2164,7 +2164,7 @@
                   <beam>
                     <note xml:id="m-1155" dur="16" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-1158" dur="16" oct="5" pname="f" accid.ges="s"/>
-                    <note xml:id="m-1160" breaksec="1" dur="16" oct="5" pname="g"/>
+                    <note xml:id="m-1160" dur="16" oct="5" pname="g"/>
                     <note xml:id="m-1161" dur="32" oct="5" pname="a"/>
                     <note xml:id="m-1162" dur="32" oct="5" pname="g"/>
                     <note xml:id="m-1163" dur="32" oct="5" pname="a"/>
@@ -2174,7 +2174,7 @@
                     <note xml:id="m-1166" dur="16" oct="5" pname="b"/>
                     <note xml:id="m-1168" dur="16" oct="5" pname="e"/>
                     <note xml:id="m-1169" dur="16" oct="5" pname="e"/>
-                    <note xml:id="m-1170" breaksec="1" dur="16" oct="5" pname="f" accid.ges="s"/>
+                    <note xml:id="m-1170" dur="16" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-1172" dur="32" oct="5" pname="g"/>
                     <note xml:id="m-1173" dur="32" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-1175" dur="32" oct="5" pname="g"/>
@@ -2228,7 +2228,7 @@
                     <note xml:id="m-1195" dur="16" oct="5" pname="a"/>
                     <note xml:id="m-1197" dur="16" oct="5" pname="d"/>
                     <note xml:id="m-1198" dur="16" oct="5" pname="d"/>
-                    <note xml:id="m-1199" breaksec="1" dur="16" oct="5" pname="e"/>
+                    <note xml:id="m-1199" dur="16" oct="5" pname="e"/>
                     <note xml:id="m-1200" dur="32" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-1202" dur="32" oct="5" pname="e"/>
                     <note xml:id="m-1203" dur="32" oct="5" pname="f" accid.ges="s"/>
@@ -2240,7 +2240,7 @@
                       <accid accid="s"/>
                     </note>
                     <note xml:id="m-1210" dur="16" oct="5" pname="c" accid.ges="s"/>
-                    <note xml:id="m-1212" breaksec="1" dur="16" oct="5" pname="d"/>
+                    <note xml:id="m-1212" dur="16" oct="5" pname="d"/>
                     <note xml:id="m-1213" dur="32" oct="5" pname="e"/>
                     <note xml:id="m-1214" dur="32" oct="5" pname="d"/>
                     <note xml:id="m-1215" dur="32" oct="5" pname="e"/>
@@ -2264,7 +2264,7 @@
                     <note xml:id="m-1229" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-1231" dur="16" oct="2" pname="b"/>
                     <note xml:id="m-1232" dur="16" oct="2" pname="b"/>
-                    <note xml:id="m-1233" breaksec="1" dur="16" oct="3" pname="c">
+                    <note xml:id="m-1233" dur="16" oct="3" pname="c">
                       <accid accid="s"/>
                     </note>
                     <note xml:id="m-1235" dur="32" oct="3" pname="d"/>
@@ -2335,7 +2335,7 @@
                   <beam>
                     <note xml:id="m-1253" dur="16" oct="5" pname="g"/>
                     <note xml:id="m-1255" dur="16" oct="5" pname="g"/>
-                    <note xml:id="m-1256" breaksec="1" dur="16" oct="5" pname="a"/>
+                    <note xml:id="m-1256" dur="16" oct="5" pname="a"/>
                     <note xml:id="m-1257" dur="32" oct="5" pname="b"/>
                     <note xml:id="m-1258" dur="32" oct="5" pname="a"/>
                     <note xml:id="m-1259" dur="32" oct="5" pname="b"/>
@@ -2345,7 +2345,7 @@
                     <note xml:id="m-1261" dur="16" oct="6" pname="c"/>
                     <note xml:id="m-1263" dur="16" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-1265" dur="16" oct="5" pname="f" accid.ges="s"/>
-                    <note xml:id="m-1267" breaksec="1" dur="16" oct="5" pname="g"/>
+                    <note xml:id="m-1267" dur="16" oct="5" pname="g"/>
                     <note xml:id="m-1268" dur="32" oct="5" pname="a"/>
                     <note xml:id="m-1269" dur="32" oct="5" pname="g"/>
                     <note xml:id="m-1270" dur="32" oct="5" pname="a"/>
@@ -2355,7 +2355,7 @@
                     <note xml:id="m-1273" dur="16" oct="5" pname="b"/>
                     <note xml:id="m-1275" dur="16" oct="5" pname="e"/>
                     <note xml:id="m-1276" dur="16" oct="5" pname="e"/>
-                    <note xml:id="m-1277" breaksec="1" dur="16" oct="5" pname="f" accid.ges="s"/>
+                    <note xml:id="m-1277" dur="16" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-1279" dur="32" oct="5" pname="g"/>
                     <note xml:id="m-1280" dur="32" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-1282" dur="32" oct="5" pname="g"/>
@@ -2369,7 +2369,7 @@
                   <beam>
                     <note xml:id="m-1287" dur="16" oct="2" pname="b"/>
                     <note xml:id="m-1289" dur="16" oct="2" pname="b"/>
-                    <note xml:id="m-1290" breaksec="1" dur="16" oct="3" pname="c">
+                    <note xml:id="m-1290" dur="16" oct="3" pname="c">
                       <accid accid="s"/>
                     </note>
                     <note xml:id="m-1292" dur="32" oct="3" pname="d">
@@ -2458,7 +2458,7 @@
                       <accid accid="s"/>
                     </note>
                     <note xml:id="m-1323" dur="16" oct="5" pname="d" accid.ges="s"/>
-                    <note xml:id="m-1325" breaksec="1" dur="16" oct="5" pname="e"/>
+                    <note xml:id="m-1325" dur="16" oct="5" pname="e"/>
                     <note xml:id="m-1326" dur="32" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-1328" dur="32" oct="5" pname="e"/>
                     <note xml:id="m-1329" dur="32" oct="5" pname="f" accid.ges="s"/>
@@ -2477,7 +2477,7 @@
                     <note xml:id="m-1340" dur="16" oct="2" pname="e"/>
                     <note xml:id="m-1342" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-1343" dur="16" oct="3" pname="e"/>
-                    <note xml:id="m-1344" breaksec="1" dur="16" oct="3" pname="f" accid.ges="s"/>
+                    <note xml:id="m-1344" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-1346" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-1347" dur="32" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-1349" dur="32" oct="3" pname="g"/>
@@ -2487,7 +2487,7 @@
                     <note xml:id="m-1351" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-1353" dur="16" oct="3" pname="g"/>
                     <note xml:id="m-1354" dur="16" oct="3" pname="g"/>
-                    <note xml:id="m-1355" breaksec="1" dur="16" oct="3" pname="a"/>
+                    <note xml:id="m-1355" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-1356" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-1357" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-1358" dur="32" oct="3" pname="b"/>
@@ -2497,7 +2497,7 @@
                     <note xml:id="m-1360" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-1363" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-1365" dur="16" oct="3" pname="f" accid.ges="s"/>
-                    <note xml:id="m-1367" breaksec="1" dur="16" oct="3" pname="g"/>
+                    <note xml:id="m-1367" dur="16" oct="3" pname="g"/>
                     <note xml:id="m-1368" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-1369" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-1370" dur="32" oct="3" pname="a"/>
@@ -2550,7 +2550,7 @@
                     <note xml:id="m-1377" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-1379" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-1380" dur="16" oct="3" pname="e"/>
-                    <note xml:id="m-1381" breaksec="1" dur="16" oct="3" pname="f" accid.ges="s"/>
+                    <note xml:id="m-1381" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-1383" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-1384" dur="32" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-1386" dur="32" oct="3" pname="g"/>
@@ -2560,7 +2560,7 @@
                     <note xml:id="m-1388" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-1390" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-1391" dur="16" oct="3" pname="d"/>
-                    <note xml:id="m-1392" breaksec="1" dur="16" oct="3" pname="e"/>
+                    <note xml:id="m-1392" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-1393" dur="32" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-1395" dur="32" oct="3" pname="e"/>
                     <note xml:id="m-1396" dur="32" oct="3" pname="f" accid.ges="s"/>
@@ -2622,7 +2622,7 @@
                     <note xml:id="m-1413" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-1415" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-1416" dur="16" oct="4" pname="e"/>
-                    <note xml:id="m-1417" breaksec="1" dur="16" oct="4" pname="d"/>
+                    <note xml:id="m-1417" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-1418" dur="32" oct="4" pname="c"/>
                     <note xml:id="m-1419" dur="32" oct="4" pname="d"/>
                     <note xml:id="m-1420" dur="32" oct="3" pname="b"/>
@@ -2632,7 +2632,7 @@
                     <note xml:id="m-1422" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-1424" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-1425" dur="16" oct="4" pname="d"/>
-                    <note xml:id="m-1426" breaksec="1" dur="16" oct="4" pname="c"/>
+                    <note xml:id="m-1426" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-1427" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-1428" dur="32" oct="4" pname="c"/>
                     <note xml:id="m-1429" dur="32" oct="3" pname="a"/>
@@ -2642,7 +2642,7 @@
                     <note xml:id="m-1431" dur="16" oct="3" pname="g"/>
                     <note xml:id="m-1433" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-1434" dur="16" oct="4" pname="c"/>
-                    <note xml:id="m-1435" breaksec="1" dur="16" oct="3" pname="b"/>
+                    <note xml:id="m-1435" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-1436" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-1437" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-1438" dur="32" oct="3" pname="g"/>
@@ -2652,7 +2652,7 @@
                     <note xml:id="m-1440" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-1443" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-1444" dur="16" oct="3" pname="b"/>
-                    <note xml:id="m-1445" breaksec="1" dur="16" oct="3" pname="a"/>
+                    <note xml:id="m-1445" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-1446" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-1447" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-1448" dur="32" oct="3" pname="f" accid.ges="s"/>
@@ -2703,7 +2703,7 @@
                     <note xml:id="m-1460" dur="32" oct="3" pname="d">
                       <accid accid="s"/>
                     </note>
-                    <note xml:id="m-1462" breaksec="1" dur="32" oct="3" pname="f" accid.ges="s"/>
+                    <note xml:id="m-1462" dur="32" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-1464" dur="32" oct="3" pname="e"/>
                     <note xml:id="m-1465" dur="32" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-1467" dur="32" oct="3" pname="d" accid.ges="s">
@@ -2711,7 +2711,7 @@
                         <accid accid="s"/>
                       </orig>
                     </note>
-                    <note xml:id="m-1469" breaksec="1" dur="32" oct="3" pname="f" accid.ges="s"/>
+                    <note xml:id="m-1469" dur="32" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-1471" dur="32" oct="3" pname="e"/>
                     <note xml:id="m-1472" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-1473" dur="32" oct="3" pname="f" accid.ges="s"/>
@@ -2721,11 +2721,11 @@
                     <note xml:id="m-1476" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-1478" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-1479" dur="32" oct="3" pname="f" accid.ges="s"/>
-                    <note xml:id="m-1481" breaksec="1" dur="32" oct="3" pname="a"/>
+                    <note xml:id="m-1481" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-1482" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-1483" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-1484" dur="32" oct="3" pname="f" accid.ges="s"/>
-                    <note xml:id="m-1486" breaksec="1" dur="32" oct="3" pname="a"/>
+                    <note xml:id="m-1486" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-1487" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-1488" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-1489" dur="32" oct="3" pname="a"/>
@@ -2735,11 +2735,11 @@
                     <note xml:id="m-1491" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-1493" dur="32" oct="4" pname="c"/>
                     <note xml:id="m-1494" dur="32" oct="3" pname="a"/>
-                    <note xml:id="m-1495" breaksec="1" dur="32" oct="4" pname="c"/>
+                    <note xml:id="m-1495" dur="32" oct="4" pname="c"/>
                     <note xml:id="m-1496" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-1497" dur="32" oct="4" pname="c"/>
                     <note xml:id="m-1498" dur="32" oct="3" pname="a"/>
-                    <note xml:id="m-1499" breaksec="1" dur="32" oct="4" pname="c"/>
+                    <note xml:id="m-1499" dur="32" oct="4" pname="c"/>
                     <note xml:id="m-1500" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-1501" dur="32" oct="4" pname="c"/>
                     <note xml:id="m-1502" dur="32" oct="3" pname="a"/>

--- a/encodings/4/mattheson/score.xml
+++ b/encodings/4/mattheson/score.xml
@@ -334,7 +334,7 @@
                     <note xml:id="m-154" dur="8" oct="2" pname="b"/>
                   </beam>
                   <rest xml:id="m-156" dur="16"/>
-                  <beam xml:id="m-158">
+                  <beam>
                     <note xml:id="m-157" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-159" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-160" dur="16" oct="4" pname="d">
@@ -355,7 +355,7 @@
                     <note xml:id="m-165" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-166" dur="32" oct="4" pname="d"/>
                   </beam>
-                  <beam xml:id="m-168">
+                  <beam>
                     <note xml:id="m-167" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-169" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-170" dur="16" oct="4" pname="e"/>
@@ -1120,14 +1120,14 @@
               <staff xml:id="m-612" n="2" facs="#facsZone-m-612 #facsZone-m-612-2">
                 <layer n="1">
                   <clef line="4" shape="F"/>
-                  <beam xml:id="m-615">
+                  <beam>
                     <note xml:id="m-614" dur="8" oct="4" pname="d"/>
                     <note xml:id="m-616" dur="8" oct="3" pname="b"/>
                     <note xml:id="m-617" dur="8" oct="3" pname="d">
                       <accid accid="s"/>
                     </note>
                   </beam>
-                  <beam xml:id="m-620">
+                  <beam>
                     <note xml:id="m-619" dur="8" oct="3" pname="e"/>
                     <note xml:id="m-621" dur="8" oct="3" pname="d" accid.ges="s">
                       <orig>
@@ -1253,7 +1253,7 @@
               </staff>
               <staff xml:id="m-676" n="2" facs="#facsZone-m-676 #facsZone-m-676-2">
                 <layer n="1">
-                  <beam xml:id="m-680">
+                  <beam>
                     <note xml:id="m-678" dur="8" oct="4" pname="c">
                       <accid accid="s"/>
                     </note>
@@ -1262,7 +1262,7 @@
                       <accid accid="s"/>
                     </note>
                   </beam>
-                  <beam xml:id="m-685">
+                  <beam>
                     <note xml:id="m-684" dur="8" oct="3" pname="d"/>
                     <note xml:id="m-687" dur="8" oct="3" pname="c" accid.ges="s">
                       <orig>

--- a/encodings/4/mattheson/score.xml
+++ b/encodings/4/mattheson/score.xml
@@ -153,11 +153,13 @@
             <pb n="310" source="#secondEdition" facs="#facs-p404"/>
             <pb n="120" source="#firstEdition" facs="#facs-p284"/>
             <measure xml:id="m-35" n="1">
-              <staff xml:id="m-37" n="1">
-                <layer xml:id="m-38" n="1"/>
+              <staff n="1">
+                <layer n="1">
+                  <mSpace/>
+                </layer>
               </staff>
               <staff xml:id="m-39" n="2" facs="#facsZone-m-39">
-                <layer xml:id="m-40" n="1">
+                <layer n="1">
                   <note xml:id="m-41" dots="1" dur="4" oct="4" pname="e"/>
                   <note xml:id="m-42" dots="1" dur="4" oct="4" pname="d">
                     <accid accid="s"/>
@@ -178,9 +180,13 @@
               </harm>
             </measure>
             <measure xml:id="m-46" n="2">
-              <staff xml:id="m-47" n="1"/>
+              <staff n="1">
+                <layer>
+                  <mSpace/>
+                </layer>
+              </staff>
               <staff xml:id="m-48" n="2" facs="#facsZone-m-48">
-                <layer xml:id="m-49" n="1">
+                <layer n="1">
                   <note xml:id="m-50" dots="1" dur="2" oct="4" pname="c"/>
                   <note xml:id="m-51" dots="1" dur="2" oct="3" pname="b"/>
                 </layer>
@@ -202,11 +208,13 @@
               </harm>
             </measure>
             <measure xml:id="m-53" n="3">
-              <staff xml:id="m-54" n="1">
-                <layer xml:id="m-55" n="1"/>
+              <staff n="1">
+                <layer n="1">
+                  <mSpace/>
+                </layer>
               </staff>
               <staff xml:id="m-56" n="2" facs="#facsZone-m-56 #facsZone-m-56-2">
-                <layer xml:id="m-57" n="1">
+                <layer n="1">
                   <rest xml:id="m-58" dur="16"/>
                   <beam>
                     <note xml:id="m-59" dur="16" oct="3" pname="e"/>
@@ -291,8 +299,8 @@
               </harm>
             </measure>
             <measure xml:id="m-101" n="4">
-              <staff xml:id="m-103" n="1">
-                <layer xml:id="m-104" n="1">
+              <staff n="1">
+                <layer n="1">
                   <rest xml:id="m-105" dur="16"/>
                   <beam>
                     <note xml:id="m-106" dur="16" oct="4" pname="b"/>
@@ -314,7 +322,7 @@
                 </layer>
               </staff>
               <staff xml:id="m-135" n="2" facs="#facsZone-m-135 #facsZone-m-135-2">
-                <layer xml:id="m-136" n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-137" dur="8" oct="3" pname="g"/>
                     <note xml:id="m-142" dur="8" oct="3" pname="e"/>
@@ -406,8 +414,8 @@
               </harm>
             </measure>
             <measure xml:id="m-176" n="5">
-              <staff xml:id="m-177" n="1">
-                <layer xml:id="m-178" n="1">
+              <staff n="1">
+                <layer n="1">
                   <rest xml:id="m-179" dur="16"/>
                   <beam>
                     <note xml:id="m-180" dur="16" oct="5" pname="e"/>
@@ -430,7 +438,7 @@
                 </layer>
               </staff>
               <staff xml:id="m-194" n="2" facs="#facsZone-m-194">
-                <layer xml:id="m-195" n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-196" dur="8" oct="4" pname="c"/>
                     <note xml:id="m-201" dur="8" oct="3" pname="a"/>
@@ -475,8 +483,8 @@
               </harm>
             </measure>
             <measure xml:id="m-229" n="6">
-              <staff xml:id="m-231" n="1">
-                <layer xml:id="m-232" n="1">
+              <staff n="1">
+                <layer n="1">
                   <space xml:id="m-233" dots="1" dur="2"/>
                   <rest xml:id="m-234" dur="16"/>
                   <beam>
@@ -496,7 +504,7 @@
                 </layer>
               </staff>
               <staff xml:id="m-248" n="2" facs="#facsZone-m-248">
-                <layer xml:id="m-249" n="1">
+                <layer n="1">
                   <rest xml:id="m-250" dur="16"/>
                   <beam>
                     <note xml:id="m-251" dur="16" oct="4" pname="d"/>
@@ -556,8 +564,8 @@
               </harm>
             </measure>
             <measure xml:id="m-276" n="7">
-              <staff xml:id="m-277" n="1">
-                <layer xml:id="m-278" n="1">
+              <staff n="1">
+                <layer n="1">
                   <space xml:id="m-279" dots="1" dur="2"/>
                   <rest xml:id="m-280" dur="16"/>
                   <beam>
@@ -579,7 +587,7 @@
                 </layer>
               </staff>
               <staff xml:id="m-296" n="2" facs="#facsZone-m-296 #facsZone-m-296-2">
-                <layer xml:id="m-297" n="1">
+                <layer n="1">
                   <rest xml:id="m-298" dur="16"/>
                   <beam>
                     <note xml:id="m-299" dur="16" oct="3" pname="b"/>
@@ -659,8 +667,8 @@
               </harm>
             </measure>
             <measure xml:id="m-327" n="8">
-              <staff xml:id="m-329" n="1">
-                <layer xml:id="m-330" n="1">
+              <staff n="1">
+                <layer n="1">
                   <space xml:id="m-331" dots="1" dur="4"/>
                   <note xml:id="m-344" dur="8" oct="4" pname="b"/>
                   <space xml:id="m-349" dur="8"/>
@@ -669,7 +677,7 @@
                   <space xml:id="m-362" dur="8"/>
                   <space xml:id="m-365" dur="8"/>
                 </layer>
-                <layer xml:id="m-332" n="2">
+                <layer n="2">
                   <rest xml:id="m-333" dur="16"/>
                   <beam>
                     <note xml:id="m-334" dur="16" oct="4" pname="b"/>
@@ -703,7 +711,7 @@
                 </layer>
               </staff>
               <staff xml:id="m-370" n="2" facs="#facsZone-m-370">
-                <layer xml:id="m-371" n="1">
+                <layer n="1">
                   <rest xml:id="m-372" dur="8"/>
                   <beam>
                     <note xml:id="m-375" dur="8" oct="3" pname="g"/>
@@ -751,9 +759,13 @@
               <slur xml:id="m-348" layer="2" staff="1" tstamp="5" tstamp2="0m+6.75"/>
             </measure>
             <measure xml:id="m-405" n="9">
-              <staff xml:id="m-406" n="1"/>
+              <staff n="1">
+                <layer>
+                  <mSpace/>
+                </layer>
+              </staff>
               <staff xml:id="m-407" n="2" facs="#facsZone-m-407">
-                <layer xml:id="m-408" n="1">
+                <layer n="1">
                   <note xml:id="m-409" dots="1" dur="4" oct="3" pname="g"/>
                   <note xml:id="m-411" dots="1" dur="4" oct="3" pname="f" accid.ges="s"/>
                   <note xml:id="m-413" dots="1" dur="4" oct="3" pname="g"/>
@@ -768,10 +780,14 @@
               </harm>
             </measure>
             <measure xml:id="m-415" n="10">
-              <staff xml:id="m-416" n="1"/>
+              <staff n="1">
+                <layer>
+                  <mSpace/>
+                </layer>
+              </staff>
               <staff xml:id="m-417" n="2" facs="#facsZone-m-417">
                 <layer xml:id="m-418" n="2"/>
-                <layer xml:id="m-419" n="1">
+                <layer n="1">
                   <note xml:id="m-420" dots="1" dur="2" oct="3" pname="e"/>
                   <note xml:id="m-421" dots="1" dur="2" oct="3" pname="d"/>
                 </layer>
@@ -788,9 +804,13 @@
               </harm>
             </measure>
             <measure xml:id="m-423" n="11">
-              <staff xml:id="m-425" n="1"/>
+              <staff n="1">
+                <layer>
+                  <mSpace/>
+                </layer>
+              </staff>
               <staff xml:id="m-426" n="2" facs="#facsZone-m-426">
-                <layer xml:id="m-427" n="1">
+                <layer n="1">
                   <rest xml:id="m-428" dur="16"/>
                   <beam>
                     <note xml:id="m-429" dur="16" oct="3" pname="g"/>
@@ -860,8 +880,8 @@
               </harm>
             </measure>
             <measure xml:id="m-468" n="12">
-              <staff xml:id="m-470" n="1">
-                <layer xml:id="m-471" n="1">
+              <staff n="1">
+                <layer n="1">
                   <rest xml:id="m-472" dur="16"/>
                   <beam>
                     <note xml:id="m-473" dur="16" oct="4" pname="g"/>
@@ -905,7 +925,7 @@
                 </layer>
               </staff>
               <staff xml:id="m-512" n="2" facs="#facsZone-m-512 #facsZone-m-512-2">
-                <layer xml:id="m-513" n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-514" dur="8" oct="3" pname="b"/>
                     <note xml:id="m-516" dur="8" oct="3" pname="b"/>
@@ -950,11 +970,13 @@
               </harm>
             </measure>
             <measure xml:id="m-533" n="13">
-              <staff xml:id="m-536" n="1">
-                <layer xml:id="m-537" n="1"/>
+              <staff n="1">
+                <layer n="1">
+                  <mSpace/>
+                </layer>
               </staff>
               <staff xml:id="m-538" n="2" facs="#facsZone-m-538 #facsZone-m-538-2">
-                <layer xml:id="m-539" n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-540" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-542" dur="32" oct="4" pname="d"/>
@@ -1071,8 +1093,8 @@
               </harm>
             </measure>
             <measure xml:id="m-588" n="14">
-              <staff xml:id="m-590" n="1">
-                <layer xml:id="m-591" n="1">
+              <staff n="1">
+                <layer n="1">
                   <rest xml:id="m-592" dur="16"/>
                   <beam>
                     <note xml:id="m-593" dur="16" oct="5" pname="b"/>
@@ -1096,7 +1118,7 @@
                 </layer>
               </staff>
               <staff xml:id="m-612" n="2" facs="#facsZone-m-612 #facsZone-m-612-2">
-                <layer xml:id="m-613" n="1">
+                <layer n="1">
                   <clef line="4" shape="F"/>
                   <beam xml:id="m-615">
                     <note xml:id="m-614" dur="8" oct="4" pname="d"/>
@@ -1205,8 +1227,8 @@
               </harm>
             </measure>
             <measure xml:id="m-651" n="15">
-              <staff xml:id="m-653" n="1">
-                <layer xml:id="m-654" n="1">
+              <staff n="1">
+                <layer n="1">
                   <rest xml:id="m-655" dur="16"/>
                   <beam>
                     <note xml:id="m-656" dur="16" oct="5" pname="a"/>
@@ -1230,7 +1252,7 @@
                 </layer>
               </staff>
               <staff xml:id="m-676" n="2" facs="#facsZone-m-676 #facsZone-m-676-2">
-                <layer xml:id="m-677" n="1">
+                <layer n="1">
                   <beam xml:id="m-680">
                     <note xml:id="m-678" dur="8" oct="4" pname="c">
                       <accid accid="s"/>
@@ -1320,9 +1342,13 @@
               </harm>
             </measure>
             <measure xml:id="m-714" n="16">
-              <staff xml:id="m-716" n="1"/>
+              <staff n="1">
+                <layer>
+                  <mSpace/>
+                </layer>
+              </staff>
               <staff xml:id="m-717" n="2" facs="#facsZone-m-717 #facsZone-m-717-2">
-                <layer xml:id="m-718" n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-719" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-721" dur="16" oct="3" pname="d"/>
@@ -1415,9 +1441,13 @@
               </harm>
             </measure>
             <measure xml:id="m-763" n="17">
-              <staff xml:id="m-764" n="1"/>
+              <staff n="1">
+                <layer>
+                  <mSpace/>
+                </layer>
+              </staff>
               <staff xml:id="m-765" n="2" facs="#facsZone-m-765">
-                <layer xml:id="m-766" n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-767" dur="8" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-770" dur="8" oct="3" pname="d"/>
@@ -1459,9 +1489,13 @@
               </harm>
             </measure>
             <measure xml:id="m-787" n="18">
-              <staff xml:id="m-789" n="1"/>
+              <staff n="1">
+                <layer>
+                  <mSpace/>
+                </layer>
+              </staff>
               <staff xml:id="m-790" n="2" facs="#facsZone-m-790">
-                <layer xml:id="m-791" n="1">
+                <layer n="1">
                   <rest xml:id="m-792" dur="16"/>
                   <beam>
                     <note xml:id="m-793" dur="16" oct="3" pname="f" accid.ges="s"/>
@@ -1581,9 +1615,13 @@
               </harm>
             </measure>
             <measure xml:id="m-836" n="19">
-              <staff xml:id="m-838" n="1"/>
+              <staff n="1">
+                <layer>
+                  <mSpace/>
+                </layer>
+              </staff>
               <staff xml:id="m-839" n="2" facs="#facsZone-m-839">
-                <layer xml:id="m-840" n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-841" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-843" dur="16" oct="4" pname="e"/>
@@ -1676,9 +1714,13 @@
               </harm>
             </measure>
             <measure xml:id="m-886" n="20">
-              <staff xml:id="m-887" n="1"/>
+              <staff n="1">
+                <layer>
+                  <mSpace/>
+                </layer>
+              </staff>
               <staff xml:id="m-888" n="2" facs="#facsZone-m-888">
-                <layer xml:id="m-889" n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-890" dur="16" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-893" dur="16" oct="2" pname="b"/>
@@ -1771,11 +1813,13 @@
               </harm>
             </measure>
             <measure xml:id="m-928" n="21">
-              <staff xml:id="m-930" n="1">
-                <layer xml:id="m-931" n="1"/>
+              <staff n="1">
+                <layer n="1">
+                  <mSpace/>
+                </layer>
               </staff>
               <staff xml:id="m-932" n="2" facs="#facsZone-m-932">
-                <layer xml:id="m-933" n="1">
+                <layer n="1">
                   <note xml:id="m-934" dots="1" dur="4" oct="3" pname="b"/>
                   <note xml:id="m-937" dots="1" dur="4" oct="3" pname="a">
                     <accid accid="s"/>
@@ -1796,13 +1840,13 @@
               </harm>
             </measure>
             <measure xml:id="m-947" n="22">
-              <staff xml:id="m-948" n="1">
-                <layer xml:id="m-949" n="1">
+              <staff n="1">
+                <layer n="1">
                   <note xml:id="m-950" dots="1" dur="2" oct="5" pname="e"/>
                 </layer>
               </staff>
               <staff xml:id="m-952" n="2" facs="#facsZone-m-952">
-                <layer xml:id="m-953" n="1">
+                <layer n="1">
                   <note xml:id="m-954" dots="1" dur="2" oct="3" pname="g"/>
                   <note xml:id="m-957" dots="1" dur="2" oct="3" pname="f" accid.ges="s"/>
                 </layer>
@@ -1828,8 +1872,8 @@
             <pb n="322" source="#secondEdition" facs="#facs-p406"/>
             <pb n="122" source="#firstEdition" facs="#facs-p286"/>
             <measure xml:id="m-962" n="23">
-              <staff xml:id="m-963" n="1">
-                <layer xml:id="m-964" n="1">
+              <staff n="1">
+                <layer n="1">
                   <rest xml:id="m-965" dur="16"/>
                   <beam>
                     <note xml:id="m-966" dur="16" oct="5" pname="d"/>
@@ -1879,7 +1923,7 @@
                 </layer>
               </staff>
               <staff xml:id="m-1007" n="2" facs="#facsZone-m-1007">
-                <layer xml:id="m-1008" n="1">
+                <layer n="1">
                   <rest xml:id="m-1009" dur="8"/>
                   <beam>
                     <note xml:id="m-1010" dur="8" oct="2" pname="b"/>
@@ -1947,9 +1991,13 @@
               </harm>
             </measure>
             <measure xml:id="m-1028" n="24">
-              <staff xml:id="m-1031" n="1"/>
+              <staff n="1">
+                <layer>
+                  <mSpace/>
+                </layer>
+              </staff>
               <staff xml:id="m-1032" n="2" facs="#facsZone-m-1032 #facsZone-m-1032-2">
-                <layer xml:id="m-1033" n="1">
+                <layer n="1">
                   <rest xml:id="m-1034" dur="16"/>
                   <beam>
                     <note xml:id="m-1035" dur="16" oct="3" pname="b"/>
@@ -2056,8 +2104,8 @@
               </app>
             </measure>
             <measure xml:id="m-1078" n="25">
-              <staff xml:id="m-1079" n="1">
-                <layer xml:id="m-1080" n="1">
+              <staff n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-1081" dur="8" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-1084" dur="8" oct="5" pname="d"/>
@@ -2071,7 +2119,7 @@
                 </layer>
               </staff>
               <staff xml:id="m-1090" n="2" facs="#facsZone-m-1090 #facsZone-m-1090-2">
-                <layer xml:id="m-1091" n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-1092" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-1094" dur="16" oct="3" pname="e"/>
@@ -2131,8 +2179,8 @@
               </harm>
             </measure>
             <measure xml:id="m-1117" n="26">
-              <staff xml:id="m-1119" n="1">
-                <layer xml:id="m-1120" n="1">
+              <staff n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-1121" dur="32" oct="5" pname="f" accid.ges="s"/>
                     <note xml:id="m-1124" dur="32" oct="5" pname="d"/>
@@ -2183,7 +2231,7 @@
                 </layer>
               </staff>
               <staff xml:id="m-1177" n="2" facs="#facsZone-m-1177">
-                <layer xml:id="m-1178" n="1">
+                <layer n="1">
                   <note xml:id="m-1179" dots="1" dur="4" oct="3" pname="d"/>
                   <note xml:id="m-1180" dots="1" dur="4" oct="2" pname="a"/>
                   <rest xml:id="m-1181" dur="8"/>
@@ -2222,8 +2270,8 @@
               </app>
             </measure>
             <measure xml:id="m-1191" n="27">
-              <staff xml:id="m-1193" n="1">
-                <layer xml:id="m-1194" n="1">
+              <staff n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-1195" dur="16" oct="5" pname="a"/>
                     <note xml:id="m-1197" dur="16" oct="5" pname="d"/>
@@ -2249,7 +2297,7 @@
                 </layer>
               </staff>
               <staff xml:id="m-1218" n="2" facs="#facsZone-m-1218">
-                <layer xml:id="m-1219" n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-1220" dur="8" oct="3" pname="f" accid.ges="s"/>
                     <note xml:id="m-1223" dur="8" oct="3" pname="b"/>
@@ -2328,8 +2376,8 @@
               </harm>
             </measure>
             <measure xml:id="m-1247" n="28">
-              <staff xml:id="m-1249" n="1">
-                <layer xml:id="m-1250" n="1">
+              <staff n="1">
+                <layer n="1">
                   <space xml:id="m-1251" dots="1" dur="4"/>
                   <rest xml:id="m-1252" dur="16"/>
                   <beam>
@@ -2364,7 +2412,7 @@
                 </layer>
               </staff>
               <staff xml:id="m-1284" n="2" facs="#facsZone-m-1284">
-                <layer xml:id="m-1285" n="1">
+                <layer n="1">
                   <rest xml:id="m-1286" dur="16"/>
                   <beam>
                     <note xml:id="m-1287" dur="16" oct="2" pname="b"/>
@@ -2450,8 +2498,8 @@
               </harm>
             </measure>
             <measure xml:id="m-1315" n="29">
-              <staff xml:id="m-1317" n="1">
-                <layer xml:id="m-1318" n="1">
+              <staff n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-1319" dur="16" oct="5" pname="a"/>
                     <note xml:id="m-1321" dur="16" oct="5" pname="d">
@@ -2467,7 +2515,7 @@
                 </layer>
               </staff>
               <staff xml:id="m-1333" n="2" facs="#facsZone-m-1333 #facsZone-m-1333-2">
-                <layer xml:id="m-1334" n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-1335" dur="8" oct="2" pname="f" accid.ges="s"/>
                     <note xml:id="m-1338" dur="8" oct="2" pname="b"/>
@@ -2543,9 +2591,13 @@
               </harm>
             </measure>
             <measure xml:id="m-1373" n="30">
-              <staff xml:id="m-1374" n="1"/>
+              <staff n="1">
+                <layer>
+                  <mSpace/>
+                </layer>
+              </staff>
               <staff xml:id="m-1375" n="2">
-                <layer xml:id="m-1376" n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-1377" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-1379" dur="16" oct="3" pname="e"/>
@@ -2615,9 +2667,13 @@
               </harm>
             </measure>
             <measure xml:id="m-1408" n="31">
-              <staff xml:id="m-1410" n="1"/>
+              <staff n="1">
+                <layer>
+                  <mSpace/>
+                </layer>
+              </staff>
               <staff xml:id="m-1411" n="2" facs="#facsZone-m-1411">
-                <layer xml:id="m-1412" n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-1413" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-1415" dur="16" oct="4" pname="e"/>
@@ -2694,9 +2750,13 @@
             <pb n="323" source="#secondEdition" facs="#facs-p407"/>
             <pb n="287" source="#firstEdition" facs="#facs-p287"/>
             <measure xml:id="m-1451" n="32">
-              <staff xml:id="m-1453" n="1"/>
+              <staff n="1">
+                <layer>
+                  <mSpace/>
+                </layer>
+              </staff>
               <staff xml:id="m-1454" n="2" facs="#facsZone-m-1454 #facsZone-m-1454-2">
-                <layer xml:id="m-1455" n="1">
+                <layer n="1">
                   <beam>
                     <note xml:id="m-1456" dur="32" oct="3" pname="e"/>
                     <note xml:id="m-1458" dur="32" oct="3" pname="f" accid.ges="s"/>
@@ -2782,9 +2842,13 @@
               </harm>
             </measure>
             <measure xml:id="m-1509" n="33" right="end">
-              <staff xml:id="m-1510" n="1"/>
+              <staff n="1">
+                <layer>
+                  <mSpace/>
+                </layer>
+              </staff>
               <staff xml:id="m-1511" n="2" facs="#facsZone-m-1511">
-                <layer xml:id="m-1512" n="1">
+                <layer n="1">
                   <note xml:id="m-1513" dots="1" dur="1" oct="3" pname="e"/>
                 </layer>
               </staff>

--- a/encodings/5/mattheson/score.xml
+++ b/encodings/5/mattheson/score.xml
@@ -138,32 +138,32 @@
             <pb source="#firstEdition" n="126" facs="#facs-p290"/>
             <pb source="#secondEdition" n="326" facs="#facs-p410"/>
             <measure xml:id="m-35" label="1" n="1">
-              <staff xml:id="m-37" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-39" n="2" facs="#facsZone-m-39">
-                <layer xml:id="m-40" n="1">
-                  <beam xml:id="m-42">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-41" dur="16" oct="3" pname="c"/>
                     <note xml:id="m-43" dur="16" oct="3" pname="c"/>
                     <note xml:id="m-44" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-45" dur="16" oct="3" pname="d"/>
                   </beam>
-                  <beam xml:id="m-47">
+                  <beam>
                     <note xml:id="m-46" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-48" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-49" dur="16" oct="3" pname="f"/>
                     <note xml:id="m-50" dur="16" oct="3" pname="f"/>
                   </beam>
-                  <beam xml:id="m-52">
+                  <beam>
                     <note xml:id="m-51" dur="16" oct="3" pname="g"/>
                     <note xml:id="m-53" dur="16" oct="3" pname="g"/>
                     <note xml:id="m-54" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-55" dur="16" oct="3" pname="a"/>
                   </beam>
-                  <beam xml:id="m-57">
+                  <beam>
                     <note xml:id="m-56" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-58" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-59" dur="16" oct="4" pname="c"/>
@@ -202,34 +202,34 @@
               </harm>
             </measure>
             <measure xml:id="m-64" n="2">
-              <staff xml:id="m-65" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-66" n="2" facs="#facsZone-m-66">
-                <layer xml:id="m-67" n="1">
+                <layer n="1">
                   <clef line="4" shape="C"/>
-                  <beam xml:id="m-69">
+                  <beam>
                     <note xml:id="m-68" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-70" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-71" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-72" dur="16" oct="4" pname="e"/>
                   </beam>
-                  <beam xml:id="m-74">
+                  <beam>
                     <note xml:id="m-73" dur="16" oct="4" pname="f"/>
                     <note xml:id="m-75" dur="16" oct="4" pname="f"/>
                     <note xml:id="m-76" dur="16" oct="4" pname="g"/>
                     <note xml:id="m-77" dur="16" oct="4" pname="g"/>
                   </beam>
                   <clef line="3" shape="C"/>
-                  <beam xml:id="m-79">
+                  <beam>
                     <note xml:id="m-78" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-80" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-81" dur="16" oct="4" pname="b"/>
                     <note xml:id="m-82" dur="16" oct="4" pname="b"/>
                   </beam>
-                  <beam xml:id="m-84">
+                  <beam>
                     <note xml:id="m-83" dur="16" oct="5" pname="c"/>
                     <note xml:id="m-85" dur="16" oct="5" pname="c"/>
                     <note xml:id="m-86" dur="16" oct="4" pname="g"/>
@@ -259,32 +259,32 @@
               </harm>
             </measure>
             <measure xml:id="m-88" n="3">
-              <staff xml:id="m-90" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-91" n="2" facs="#facsZone-m-91">
-                <layer xml:id="m-92" n="1">
-                  <beam xml:id="m-94">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-93" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-95" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-96" dur="16" oct="4" pname="g"/>
                     <note xml:id="m-97" dur="16" oct="4" pname="g"/>
                   </beam>
-                  <beam xml:id="m-99">
+                  <beam>
                     <note xml:id="m-98" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-100" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-101" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-102" dur="16" oct="4" pname="e"/>
                   </beam>
-                  <beam xml:id="m-104">
+                  <beam>
                     <note xml:id="m-103" dur="16" oct="4" pname="f"/>
                     <note xml:id="m-105" dur="16" oct="4" pname="f"/>
                     <note xml:id="m-106" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-107" dur="16" oct="4" pname="d"/>
                   </beam>
-                  <beam xml:id="m-109">
+                  <beam>
                     <note xml:id="m-108" dur="16" oct="4" pname="g"/>
                     <note xml:id="m-110" dur="16" oct="4" pname="g"/>
                     <note xml:id="m-111" dur="16" oct="3" pname="g"/>
@@ -311,13 +311,13 @@
               </harm>
             </measure>
             <measure xml:id="m-114" n="4">
-              <staff xml:id="m-115" n="1">
-                <layer xml:id="m-116" n="1">
+              <staff n="1">
+                <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-117" n="2" facs="#facsZone-m-117">
-                <layer xml:id="m-118" n="1">
+                <layer n="1">
                   <clef xml:id="m-113" line="4" shape="F" staff="2" tstamp="5"/>
                   <note xml:id="m-119" dur="4" oct="3" pname="c"/>
                   <note xml:id="m-121" dur="4" oct="3" pname="b"/>
@@ -344,13 +344,13 @@
               </harm>
             </measure>
             <measure xml:id="m-124" n="5">
-              <staff xml:id="m-125" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-126" n="2" facs="#facsZone-m-126">
-                <layer xml:id="m-127" n="1">
+                <layer n="1">
                   <note xml:id="m-128" dur="4" oct="3" pname="f"/>
                   <note xml:id="m-129" dur="4" oct="3" pname="g"/>
                   <note xml:id="m-130" dur="4" oct="3" pname="c"/>
@@ -365,14 +365,14 @@
               </harm>
             </measure>
             <measure xml:id="m-133" n="6">
-              <staff xml:id="m-134" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-135" n="2" facs="#facsZone-m-135 #facsZone-m-135-2">
-                <layer xml:id="m-136" n="1">
-                  <beam xml:id="m-138">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-137" dur="8" oct="2" pname="a"/>
                     <note xml:id="m-139" dur="8" oct="3" pname="a"/>
                     <note xml:id="m-140" dur="8" oct="3" pname="f">
@@ -391,14 +391,14 @@
               </harm>
             </measure>
             <measure xml:id="m-145" n="7">
-              <staff xml:id="m-147" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-148" n="2" facs="#facsZone-m-148">
-                <layer xml:id="m-149" n="1">
-                  <beam xml:id="m-151">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-150" dur="8" oct="3" pname="c"/>
                     <note xml:id="m-152" dur="8" oct="3" pname="d"/>
                     <note xml:id="m-153" dur="8" oct="3" pname="e"/>
@@ -425,16 +425,16 @@
               </harm>
             </measure>
             <measure xml:id="m-157" n="8">
-              <staff xml:id="m-158" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-159" n="2" facs="#facsZone-m-159">
-                <layer xml:id="m-160" n="1">
+                <layer n="1">
                   <note xml:id="m-161" dur="4" oct="3" pname="c"/>
                   <note xml:id="m-162" dur="4" oct="3" pname="d"/>
-                  <beam xml:id="m-164">
+                  <beam>
                     <note xml:id="m-163" dur="8" oct="3" pname="e"/>
                     <note xml:id="m-165" dur="8" oct="3" pname="f">
                       <accid accid="s"/>
@@ -451,20 +451,20 @@
               </harm>
             </measure>
             <measure xml:id="m-169" n="9">
-              <staff xml:id="m-170" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-171" n="2" facs="#facsZone-m-171">
-                <layer xml:id="m-172" n="1">
-                  <beam xml:id="m-174">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-173" dur="8" oct="3" pname="b"/>
                     <note xml:id="m-175" dur="8" oct="4" pname="c"/>
                     <note xml:id="m-176" dur="8" oct="4" pname="d"/>
                     <note xml:id="m-177" dur="8" oct="4" pname="e"/>
                   </beam>
-                  <beam xml:id="m-179">
+                  <beam>
                     <note xml:id="m-178" dur="8" oct="3" pname="a"/>
                     <note xml:id="m-180" dur="8" oct="3" pname="g"/>
                     <note xml:id="m-181" dur="8" oct="4" pname="d"/>
@@ -496,32 +496,32 @@
               </harm>
             </measure>
             <measure xml:id="m-183" n="10">
-              <staff xml:id="m-184" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-186" n="2" facs="#facsZone-m-186 #facsZone-m-186-2">
-                <layer xml:id="m-187" n="1">
-                  <beam xml:id="m-189">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-188" dur="16" oct="2" pname="g"/>
                     <note xml:id="m-190" dur="16" oct="2" pname="g"/>
                     <note xml:id="m-191" dur="16" oct="2" pname="a"/>
                     <note xml:id="m-192" dur="16" oct="2" pname="a"/>
                   </beam>
-                  <beam xml:id="m-194">
+                  <beam>
                     <note xml:id="m-193" dur="16" oct="2" pname="b"/>
                     <note xml:id="m-195" dur="16" oct="2" pname="b"/>
                     <note xml:id="m-196" dur="16" oct="3" pname="c"/>
                     <note xml:id="m-197" dur="16" oct="3" pname="c"/>
                   </beam>
-                  <beam xml:id="m-199">
+                  <beam>
                     <note xml:id="m-198" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-200" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-201" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-202" dur="16" oct="3" pname="e"/>
                   </beam>
-                  <beam xml:id="m-205">
+                  <beam>
                     <note xml:id="m-203" dur="16" oct="3" pname="f">
                       <accid accid="s"/>
                     </note>
@@ -561,27 +561,27 @@
               </harm>
             </measure>
             <measure xml:id="m-210" n="11">
-              <staff xml:id="m-212" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-213" n="2" facs="#facsZone-m-213">
-                <layer xml:id="m-214" n="1">
-                  <beam xml:id="m-216">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-215" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-217" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-218" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-219" dur="16" oct="3" pname="b"/>
                   </beam>
-                  <beam xml:id="m-221">
+                  <beam>
                     <note xml:id="m-220" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-222" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-223" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-224" dur="16" oct="4" pname="d"/>
                   </beam>
                   <clef shape="C" line="4"/>
-                  <beam xml:id="m-226">
+                  <beam>
                     <note xml:id="m-225" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-227" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-228" dur="16" oct="4" pname="f">
@@ -589,7 +589,7 @@
                     </note>
                     <note xml:id="m-230" dur="16" oct="4" pname="f" accid.ges="s"/>
                   </beam>
-                  <beam xml:id="m-233">
+                  <beam>
                     <note xml:id="m-232" dur="16" oct="4" pname="g"/>
                     <note xml:id="m-234" dur="16" oct="4" pname="g"/>
                     <note xml:id="m-235" dur="16" oct="4" pname="d"/>
@@ -636,33 +636,33 @@
               </harm>
             </measure>
             <measure xml:id="m-237" n="12">
-              <staff xml:id="m-238" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-239" n="2" facs="#facsZone-m-239 #facsZone-m-239-2">
-                <layer xml:id="m-240" n="1">
-                  <beam xml:id="m-242">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-241" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-243" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-244" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-245" dur="16" oct="4" pname="d"/>
                   </beam>
-                  <beam xml:id="m-247">
+                  <beam>
                     <note xml:id="m-246" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-248" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-249" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-250" dur="16" oct="3" pname="b"/>
                   </beam>
                   <clef shape="F" line="4"/>
-                  <beam xml:id="m-252">
+                  <beam>
                     <note xml:id="m-251" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-253" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-254" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-255" dur="16" oct="3" pname="a"/>
                   </beam>
-                  <beam xml:id="m-257">
+                  <beam>
                     <note xml:id="m-256" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-258" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-259" dur="16" oct="3" pname="d"/>
@@ -688,13 +688,13 @@
               </harm>
             </measure>
             <measure xml:id="m-261" n="13">
-              <staff xml:id="m-262" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-264" n="2" facs="#facsZone-m-264">
-                <layer xml:id="m-265" n="1">
+                <layer n="1">
                   <note xml:id="m-266" dur="2" oct="3" pname="g"/>
                   <note xml:id="m-267" dur="4" oct="4" pname="c"/>
                   <note xml:id="m-268" dur="4" oct="3" pname="c"/>
@@ -708,13 +708,13 @@
               </dir>
             </measure>
             <measure xml:id="m-269" n="14">
-              <staff xml:id="m-270" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-271" n="2" facs="#facsZone-m-271">
-                <layer xml:id="m-272" n="1">
+                <layer n="1">
                   <note xml:id="m-273" dur="2" oct="3" pname="f"/>
                   <note xml:id="m-274" dur="2" oct="3" pname="e"/>
                 </layer>
@@ -737,14 +737,14 @@
               </harm>
             </measure>
             <measure xml:id="m-275" n="15">
-              <staff xml:id="m-277" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-278" n="2" facs="#facsZone-m-278">
-                <layer xml:id="m-279" n="1">
-                  <beam xml:id="m-281">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-280" dur="8" oct="3" pname="a"/>
                     <note xml:id="m-282" dur="8" oct="3" pname="g"/>
                     <note xml:id="m-283" dur="8" oct="3" pname="f"/>
@@ -755,14 +755,14 @@
               </staff>
             </measure>
             <measure xml:id="m-286" n="16">
-              <staff xml:id="m-287" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-288" n="2" facs="#facsZone-m-288">
-                <layer xml:id="m-289" n="1">
-                  <beam xml:id="m-291">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-290" dur="8" oct="3" pname="g"/>
                     <note xml:id="m-292" dur="8" oct="3" pname="f"/>
                     <note xml:id="m-293" dur="8" oct="3" pname="e"/>
@@ -773,14 +773,14 @@
               </staff>
             </measure>
             <measure xml:id="m-296" n="17">
-              <staff xml:id="m-297" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-298" n="2" facs="#facsZone-m-298">
-                <layer xml:id="m-299" n="1">
-                  <beam xml:id="m-301">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-300" dur="8" oct="3" pname="f"/>
                     <note xml:id="m-302" dur="8" oct="3" pname="e"/>
                     <note xml:id="m-303" dur="8" oct="3" pname="d"/>
@@ -798,16 +798,16 @@
               </harm>
             </measure>
             <measure xml:id="m-307" n="18">
-              <staff xml:id="m-308" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-309" n="2" facs="#facsZone-m-309">
-                <layer xml:id="m-310" n="1">
+                <layer n="1">
                   <note xml:id="m-311" dur="4" oct="2" pname="a"/>
                   <note xml:id="m-312" dur="4" oct="2" pname="b"/>
-                  <beam xml:id="m-314">
+                  <beam>
                     <note xml:id="m-313" dur="8" oct="3" pname="c"/>
                     <note xml:id="m-315" dur="8" oct="3" pname="d"/>
                   </beam>
@@ -829,13 +829,13 @@
               </harm>
             </measure>
             <measure xml:id="m-318" n="19">
-              <staff xml:id="m-319" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-320" n="2" facs="#facsZone-m-320">
-                <layer xml:id="m-321" n="1">
+                <layer n="1">
                   <note xml:id="m-322" dots="1" dur="4" oct="3" pname="f"/>
                   <note xml:id="m-323" dur="8" oct="3" pname="d"/>
                   <note xml:id="m-324" dur="4" oct="3" pname="e"/>
@@ -855,20 +855,20 @@
               </harm>
             </measure>
             <measure xml:id="m-326" n="20">
-              <staff xml:id="m-328" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-330" n="2" facs="#facsZone-m-330">
-                <layer xml:id="m-331" n="1">
-                  <beam xml:id="m-333">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-332" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-334" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-335" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-336" dur="16" oct="3" pname="b"/>
                   </beam>
-                  <beam xml:id="m-338">
+                  <beam>
                     <note xml:id="m-337" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-339" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-340" dur="16" oct="3" pname="g">
@@ -876,13 +876,13 @@
                     </note>
                     <note xml:id="m-342" dur="16" oct="3" pname="g" accid.ges="s"/>
                   </beam>
-                  <beam xml:id="m-345">
+                  <beam>
                     <note xml:id="m-344" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-346" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-347" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-348" dur="16" oct="3" pname="b"/>
                   </beam>
-                  <beam xml:id="m-350">
+                  <beam>
                     <note xml:id="m-349" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-351" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-352" dur="16" oct="3" pname="g" accid.ges="s">
@@ -929,20 +929,20 @@
               </harm>
             </measure>
             <measure xml:id="m-356" n="21">
-              <staff xml:id="m-357" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-358" n="2" facs="#facsZone-m-358 #facsZone-m-358-2">
-                <layer xml:id="m-359" n="1">
-                  <beam xml:id="m-361">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-360" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-362" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-363" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-364" dur="16" oct="3" pname="e"/>
                   </beam>
-                  <beam xml:id="m-366">
+                  <beam>
                     <note xml:id="m-365" dur="16" oct="3" pname="f"/>
                     <note xml:id="m-367" dur="16" oct="3" pname="f"/>
                     <note xml:id="m-368" dur="16" oct="3" pname="d"/>
@@ -950,7 +950,7 @@
                   </beam>
                   <pb source="#secondEdition" n="327" facs="#facs-p411"/>
                   <pb source="#firstEdition" n="127" facs="#facs-p291"/>
-                  <beam xml:id="m-372">
+                  <beam>
                     <note xml:id="m-370" dur="16" oct="3" pname="g">
                       <accid accid="n"/>
                     </note>
@@ -958,7 +958,7 @@
                     <note xml:id="m-374" dur="16" oct="3" pname="d"/>
                     <note xml:id="m-375" dur="16" oct="3" pname="d"/>
                   </beam>
-                  <beam xml:id="m-377">
+                  <beam>
                     <note xml:id="m-376" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-378" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-379" dur="16" oct="3" pname="c"/>
@@ -988,15 +988,15 @@
               </harm>
             </measure>
             <measure xml:id="m-381" n="22">
-              <staff xml:id="m-384" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-385" n="2" facs="#facsZone-m-385">
-                <layer xml:id="m-386" n="1">
+                <layer n="1">
                   <rest xml:id="m-387" dur="32"/>
-                  <beam xml:id="m-389">
+                  <beam>
                     <note xml:id="m-388" dur="32" oct="3" pname="d"/>
                     <note xml:id="m-390" dur="32" oct="3" pname="e"/>
                     <note xml:id="m-391" dur="32" oct="3" pname="f"/>
@@ -1005,14 +1005,14 @@
                     <note xml:id="m-394" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-395" dur="32" oct="4" pname="c"/>
                   </beam>
-                  <beam xml:id="m-397">
+                  <beam>
                     <note xml:id="m-396" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-398" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-399" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-400" dur="16" oct="3" pname="a"/>
                   </beam>
                   <rest xml:id="m-401" dur="32"/>
-                  <beam xml:id="m-403">
+                  <beam>
                     <note xml:id="m-402" dur="32" oct="3" pname="e"/>
                     <note xml:id="m-404" dur="32" oct="3" pname="f">
                       <accid accid="s"/>
@@ -1027,7 +1027,7 @@
                     <note xml:id="m-409" dur="32" oct="4" pname="c"/>
                     <note xml:id="m-410" dur="32" oct="4" pname="d"/>
                   </beam>
-                  <beam xml:id="m-412">
+                  <beam>
                     <note xml:id="m-411" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-413" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-414" dur="16" oct="4" pname="c"/>
@@ -1047,16 +1047,16 @@
               </harm>
             </measure>
             <measure xml:id="m-416" n="23">
-              <staff xml:id="m-417" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-418" n="2" facs="#facsZone-m-418">
-                <layer xml:id="m-419" n="1">
+                <layer n="1">
                   <clef shape="C" line="3"/>
                   <rest xml:id="m-420" dur="32"/>
-                  <beam xml:id="m-422">
+                  <beam>
                     <note xml:id="m-421" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-423" dur="32" oct="3" pname="b"/>
                     <note xml:id="m-424" dur="32" oct="4" pname="c"/>
@@ -1071,19 +1071,19 @@
                     </note>
                     <note xml:id="m-429" dur="32" oct="4" pname="g"/>
                   </beam>
-                  <beam xml:id="m-431">
+                  <beam>
                     <note xml:id="m-430" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-432" dur="16" oct="4" pname="g"/>
                     <note xml:id="m-433" dur="16" oct="4" pname="f"/>
                     <note xml:id="m-434" dur="16" oct="4" pname="e"/>
                   </beam>
-                  <beam xml:id="m-436">
+                  <beam>
                     <note xml:id="m-435" dur="16" oct="4" pname="f"/>
                     <note xml:id="m-437" dur="16" oct="4" pname="f"/>
                     <note xml:id="m-438" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-439" dur="16" oct="4" pname="c"/>
                   </beam>
-                  <beam xml:id="m-441">
+                  <beam>
                     <note xml:id="m-440" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-442" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-443" dur="16" oct="4" pname="e"/>
@@ -1109,20 +1109,20 @@
               </harm>
             </measure>
             <measure xml:id="m-445" n="24">
-              <staff xml:id="m-447" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-448" n="2" facs="#facsZone-m-448">
-                <layer xml:id="m-449" n="1">
-                  <beam xml:id="m-451">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-450" dur="16" oct="4" pname="f"/>
                     <note xml:id="m-452" dur="16" oct="4" pname="f"/>
                     <note xml:id="m-453" dur="16" oct="4" pname="c"/>
                     <note xml:id="m-454" dur="16" oct="4" pname="c"/>
                   </beam>
-                  <beam xml:id="m-456">
+                  <beam>
                     <note xml:id="m-455" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-457" dur="16" oct="4" pname="d"/>
                     <note xml:id="m-458" dur="16" oct="4" pname="e"/>
@@ -1154,13 +1154,13 @@
               </harm>
             </measure>
             <measure xml:id="m-461" n="25">
-              <staff xml:id="m-462" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-464" n="2" facs="#facsZone-m-464">
-                <layer xml:id="m-465" n="1">
+                <layer n="1">
                   <clef shape="F" line="4"/>
                   <note xml:id="m-466" dur="2" oct="3" pname="c">
                     <accid accid="s"/>
@@ -1183,18 +1183,18 @@
               </harm>
             </measure>
             <measure xml:id="m-469" n="26">
-              <staff xml:id="m-470" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-471" n="2" facs="#facsZone-m-471">
-                <layer xml:id="m-472" n="1">
+                <layer n="1">
                   <note xml:id="m-473" dur="2" oct="2" pname="f">
                     <accid accid="s"/>
                   </note>
                   <note xml:id="m-475" dur="4" oct="2" pname="g"/>
-                  <beam xml:id="m-477">
+                  <beam>
                     <note xml:id="m-476" dur="8" oct="3" pname="g"/>
                     <note xml:id="m-478" dur="8" oct="3" pname="f">
                       <accid accid="s"/>
@@ -1219,14 +1219,14 @@
               </harm>
             </measure>
             <measure xml:id="m-480" n="27">
-              <staff xml:id="m-481" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-482" n="2" facs="#facsZone-m-482">
-                <layer xml:id="m-483" n="1">
-                  <beam xml:id="m-485">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-484" dur="8" oct="3" pname="e"/>
                     <note xml:id="m-486" dur="8" oct="3" pname="d">
                       <accid accid="s"/>
@@ -1238,7 +1238,7 @@
                       <accid accid="s"/>
                     </note>
                   </beam>
-                  <beam xml:id="m-492">
+                  <beam>
                     <note xml:id="m-491" dur="8" oct="3" pname="g"/>
                     <note xml:id="m-493" dur="8" oct="3" pname="d" accid.ges="s">
                       <supplied resp="#pfeffer">
@@ -1276,20 +1276,20 @@
               </harm>
             </measure>
             <measure xml:id="m-498" n="28">
-              <staff xml:id="m-499" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-500" n="2" facs="#facsZone-m-500">
-                <layer xml:id="m-501" n="1">
-                  <beam xml:id="m-503">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-502" dur="8" oct="3" pname="g"/>
                     <note xml:id="m-504" dur="8" oct="2" pname="g"/>
                   </beam>
                   <note xml:id="m-505" dur="4" oct="3" pname="c"/>
                   <note xml:id="m-506" dur="4" oct="2" pname="b"/>
-                  <beam xml:id="m-508">
+                  <beam>
                     <note xml:id="m-507" dur="8" oct="3" pname="b"/>
                     <note xml:id="m-509" dur="8" oct="3" pname="a"/>
                   </beam>
@@ -1317,13 +1317,13 @@
               </harm>
             </measure>
             <measure xml:id="m-510" n="29">
-              <staff xml:id="m-511" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-512" n="2" facs="#facsZone-m-512">
-                <layer xml:id="m-513" n="1">
+                <layer n="1">
                   <note xml:id="m-514" dur="4" oct="3" pname="g"/>
                   <note xml:id="m-515" dur="4" oct="3" pname="f">
                     <supplied resp="#pfeffer">
@@ -1351,13 +1351,13 @@
               </harm>
             </measure>
             <measure xml:id="m-519" n="30">
-              <staff xml:id="m-521" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-522" n="2" facs="#facsZone-m-522">
-                <layer xml:id="m-523" n="1">
+                <layer n="1">
                   <note xml:id="m-524" dur="4" oct="3" pname="a"/>
                   <note xml:id="m-525" dur="4" oct="3" pname="f">
                     <accid accid="s"/>
@@ -1378,20 +1378,20 @@
               </harm>
             </measure>
             <measure xml:id="m-529" n="31">
-              <staff xml:id="m-530" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-531" n="2" facs="#facsZone-m-531">
-                <layer xml:id="m-532" n="1">
-                  <beam xml:id="m-534">
+                <layer n="1">
+                  <beam>
                     <note xml:id="m-533" dur="8" oct="4" pname="c"/>
                     <note xml:id="m-535" dur="8" oct="3" pname="b"/>
                     <note xml:id="m-536" dur="8" oct="3" pname="a"/>
                     <note xml:id="m-537" dur="8" oct="3" pname="g"/>
                   </beam>
-                  <beam xml:id="m-540">
+                  <beam>
                     <note xml:id="m-538" dur="8" oct="3" pname="f">
                       <accid accid="s"/>
                     </note>
@@ -1417,13 +1417,13 @@
               </harm>
             </measure>
             <measure xml:id="m-545" n="32">
-              <staff xml:id="m-546" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-547" n="2" facs="#facsZone-m-547">
-                <layer xml:id="m-548" n="1">
+                <layer n="1">
                   <note xml:id="m-549" dur="2" oct="2" pname="b"/>
                   <note xml:id="m-550" dur="2" oct="2" pname="e"/>
                 </layer>
@@ -1436,15 +1436,15 @@
               </harm>
             </measure>
             <measure xml:id="m-552" n="33">
-              <staff xml:id="m-553" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-555" n="2" facs="#facsZone-m-555">
-                <layer xml:id="m-556" n="1">
+                <layer n="1">
                   <clef xml:id="m-551" line="3" shape="C"/>
-                  <beam xml:id="m-558">
+                  <beam>
                     <note xml:id="m-557" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-559" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-560" dur="16" oct="4" pname="f">
@@ -1452,19 +1452,19 @@
                     </note>
                     <note xml:id="m-562" dur="16" oct="4" pname="f" accid.ges="s"/>
                   </beam>
-                  <beam xml:id="m-565">
+                  <beam>
                     <note xml:id="m-564" dur="16" oct="4" pname="g"/>
                     <note xml:id="m-566" dur="16" oct="4" pname="g"/>
                     <note xml:id="m-567" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-568" dur="16" oct="4" pname="a"/>
                   </beam>
-                  <beam xml:id="m-570">
+                  <beam>
                     <note xml:id="m-569" dur="16" oct="4" pname="b"/>
                     <note xml:id="m-571" dur="16" oct="4" pname="b"/>
                     <note xml:id="m-572" dur="16" oct="4" pname="f" accid.ges="s"/>
                     <note xml:id="m-574" dur="16" oct="4" pname="f" accid.ges="s"/>
                   </beam>
-                  <beam xml:id="m-579">
+                  <beam>
                     <note xml:id="m-577" dur="16" oct="4" pname="d">
                       <accid accid="s"/>
                     </note>
@@ -1497,15 +1497,15 @@
               </harm>
             </measure>
             <measure xml:id="m-583" n="34">
-              <staff xml:id="m-585" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-586" n="2" facs="#facsZone-m-586">
-                <layer xml:id="m-587" n="1">
+                <layer n="1">
                   <clef xml:id="m-576" line="4" shape="F"/>
-                  <beam xml:id="m-589">
+                  <beam>
                     <note xml:id="m-588" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-590" dur="16" oct="3" pname="e"/>
                     <note xml:id="m-591" dur="16" oct="3" pname="f">
@@ -1513,13 +1513,13 @@
                     </note>
                     <note xml:id="m-593" dur="16" oct="3" pname="f" accid.ges="s"/>
                   </beam>
-                  <beam xml:id="m-596">
+                  <beam>
                     <note xml:id="m-595" dur="16" oct="3" pname="g"/>
                     <note xml:id="m-597" dur="16" oct="3" pname="g"/>
                     <note xml:id="m-598" dur="16" oct="3" pname="a"/>
                     <note xml:id="m-599" dur="16" oct="3" pname="a"/>
                   </beam>
-                  <beam xml:id="m-601">
+                  <beam>
                     <note xml:id="m-600" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-602" dur="16" oct="3" pname="b"/>
                     <note xml:id="m-603" dur="16" oct="4" pname="c">
@@ -1527,7 +1527,7 @@
                     </note>
                     <note xml:id="m-605" dur="16" oct="4" pname="c" accid.ges="s"/>
                   </beam>
-                  <beam xml:id="m-609">
+                  <beam>
                     <note xml:id="m-607" dur="16" oct="4" pname="d">
                       <accid accid="s"/>
                     </note>
@@ -1559,15 +1559,15 @@
               </harm>
             </measure>
             <measure xml:id="m-615" n="35">
-              <staff xml:id="m-616" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-618" n="2" facs="#facsZone-m-618 #facsZone-m-618-2">
-                <layer xml:id="m-619" n="1">
+                <layer n="1">
                   <clef line="3" shape="C"/>
-                  <beam xml:id="m-622">
+                  <beam>
                     <note xml:id="m-620" dur="16" oct="4" pname="f">
                       <accid accid="s"/>
                     </note>
@@ -1575,14 +1575,14 @@
                     <note xml:id="m-625" dur="16" oct="4" pname="g"/>
                     <note xml:id="m-626" dur="16" oct="4" pname="g"/>
                   </beam>
-                  <beam xml:id="m-628">
+                  <beam>
                     <note xml:id="m-627" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-629" dur="16" oct="4" pname="a"/>
                     <note xml:id="m-630" dur="16" oct="4" pname="b"/>
                     <note xml:id="m-631" dur="16" oct="4" pname="b"/>
                   </beam>
                   <clef line="2" shape="C"/>
-                  <beam xml:id="m-634">
+                  <beam>
                     <note xml:id="m-632" dur="16" oct="4" pname="c">
                       <accid accid="s"/>
                     </note>
@@ -1592,7 +1592,7 @@
                     </note>
                     <note xml:id="m-639" dur="16" oct="4" pname="d" accid.ges="s"/>
                   </beam>
-                  <beam xml:id="m-642">
+                  <beam>
                     <note xml:id="m-641" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-643" dur="16" oct="4" pname="e"/>
                     <note xml:id="m-644" dur="16" oct="4" pname="d" accid.ges="s"/>
@@ -1638,13 +1638,13 @@
               </harm>
             </measure>
             <measure xml:id="m-648" n="36">
-              <staff xml:id="m-649" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-650" n="2" facs="#facsZone-m-650">
-                <layer xml:id="m-651" n="1">
+                <layer n="1">
                   <note xml:id="m-652" dur="4" oct="4" pname="e"/>
                   <note xml:id="m-653" dur="4" oct="3" pname="b"/>
                   <note xml:id="m-654" dur="4" oct="4" pname="c">
@@ -1675,13 +1675,13 @@
               </dir>
             </measure>
             <measure xml:id="m-657" n="37" right="end">
-              <staff xml:id="m-658" n="1">
+              <staff n="1">
                 <layer n="1">
                   <mSpace/>
                 </layer>
               </staff>
               <staff xml:id="m-659" n="2" facs="#facsZone-m-659">
-                <layer xml:id="m-660" n="1">
+                <layer n="1">
                   <note xml:id="m-661" dur="2" oct="3" pname="a"/>
                   <note xml:id="m-662" dur="2" oct="3" pname="g"/>
                 </layer>

--- a/encodings/5/mattheson/score.xml
+++ b/encodings/5/mattheson/score.xml
@@ -999,7 +999,7 @@
                   <beam xml:id="m-389">
                     <note xml:id="m-388" dur="32" oct="3" pname="d"/>
                     <note xml:id="m-390" dur="32" oct="3" pname="e"/>
-                    <note xml:id="m-391" breaksec="1" dur="32" oct="3" pname="f"/>
+                    <note xml:id="m-391" dur="32" oct="3" pname="f"/>
                     <note xml:id="m-392" dur="32" oct="3" pname="g"/>
                     <note xml:id="m-393" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-394" dur="32" oct="3" pname="b"/>
@@ -1017,7 +1017,7 @@
                     <note xml:id="m-404" dur="32" oct="3" pname="f">
                       <accid accid="s"/>
                     </note>
-                    <note xml:id="m-406" breaksec="1" dur="32" oct="3" pname="g">
+                    <note xml:id="m-406" dur="32" oct="3" pname="g">
                       <supplied resp="#pfeffer">
                         <accid accid="s"/>
                       </supplied>
@@ -1059,7 +1059,7 @@
                   <beam xml:id="m-422">
                     <note xml:id="m-421" dur="32" oct="3" pname="a"/>
                     <note xml:id="m-423" dur="32" oct="3" pname="b"/>
-                    <note xml:id="m-424" breaksec="1" dur="32" oct="4" pname="c"/>
+                    <note xml:id="m-424" dur="32" oct="4" pname="c"/>
                     <note xml:id="m-425" dur="32" oct="4" pname="d"/>
                     <note xml:id="m-426" dur="32" oct="4" pname="e"/>
                     <note xml:id="m-427" dur="32" oct="4" pname="f">

--- a/encodings/6/mattheson/music-example1.xml
+++ b/encodings/6/mattheson/music-example1.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 6, Example 1</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -35,7 +35,7 @@
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure>
+                        <measure corresp="#m-282">
                             <staff n="1">
                                 <layer>
                                     <note dur="2" oct="3" pname="a" stem.dir="up" />
@@ -48,7 +48,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure>
+                        <measure corresp="#m-310">
                             <staff n="1">
                                 <layer>
                                     <note dots="1" dur="2" oct="3" pname="g" stem.dir="up" />
@@ -60,7 +60,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure>
+                        <measure corresp="#m-340">
                             <staff n="1">
                                 <layer>
                                     <note dur="2" oct="3" pname="g" stem.dir="up" />
@@ -73,7 +73,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure>
+                        <measure corresp="#m-369">
                             <staff n="1">
                                 <layer>
                                     <note dots="1" dur="2" oct="3" pname="f" stem.dir="up" />
@@ -85,7 +85,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure>
+                        <measure corresp="#m-399">
                             <staff n="1">
                                 <layer>
                                     <note dur="2" oct="3" pname="f" stem.dir="up" />
@@ -98,7 +98,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure>
+                        <measure corresp="#m-427" right="invis">
                             <staff n="1">
                                 <layer>
                                     <note dots="1" dur="2" oct="3" pname="e" stem.dir="up" />

--- a/encodings/6/mattheson/music-example2.xml
+++ b/encodings/6/mattheson/music-example2.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 6, Example 2</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -35,7 +35,7 @@
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure n="31">
+                        <measure corresp="#m-954">
                             <staff n="1">
                                 <layer>
                                     <note dur="4" oct="2" pname="c" />
@@ -49,7 +49,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure n="32">
+                        <measure corresp="#m-983">
                             <staff n="1">
                                 <layer>
                                     <note dur="4" oct="2" pname="f" />
@@ -63,7 +63,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure n="33">
+                        <measure corresp="#m-1013">
                             <staff n="1">
                                 <layer>
                                     <note dur="4" oct="2" pname="b" />
@@ -81,7 +81,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure n="34">
+                        <measure corresp="#m-1043">
                             <staff n="1">
                                 <layer>
                                     <note dur="4" oct="2" pname="a" />
@@ -100,7 +100,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure n="35">
+                        <measure corresp="#m-1079">
                             <staff n="1">
                                 <layer>
                                     <note dur="4" oct="3" pname="d" />
@@ -117,7 +117,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure n="36">
+                        <measure corresp="#m-1110">
                             <staff n="1">
                                 <layer>
                                     <note dur="2" oct="3" pname="a" />
@@ -131,7 +131,7 @@
                             </harm>
                         </measure>
                         <sb/>
-                        <measure n="37">
+                        <measure corresp="#m-1145">
                             <staff n="1">
                                 <layer>
                                     <note dur="4" oct="3" pname="f" />
@@ -145,7 +145,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure n="38">
+                        <measure corresp="#m-1177">
                             <staff n="1">
                                 <layer>
                                     <note dur="2" oct="3" pname="b" />
@@ -163,7 +163,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure n="39">
+                        <measure corresp="#m-1213">
                             <staff n="1">
                                 <layer>
                                     <note dur="4" oct="3" pname="f" />
@@ -178,8 +178,8 @@
                             </harm>
                             <harm place="above" staff="1" tstamp="2">
                                 <fb>
-                                    <f>5</f>
                                     <f>7</f>
+                                    <f>5</f>
                                 </fb>
                             </harm>
                             <harm place="above" staff="1" tstamp="3">
@@ -188,7 +188,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure n="40">
+                        <measure corresp="#m-1245">
                             <staff n="1">
                                 <layer>
                                     <chord dur="4" stem.dir="up">
@@ -205,7 +205,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure n="41" right="invis">
+                        <measure right="invis">
                             <staff n="1">
                                 <layer>
                                     <custos oct="3" pname="g" />

--- a/encodings/6/mattheson/score.xml
+++ b/encodings/6/mattheson/score.xml
@@ -176,20 +176,20 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-46" n="2" facs="#facsZone-m-46">
-                  <layer xml:id="m-47" n="1">
-                    <beam xml:id="m-49">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-48" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-50" dur="16" oct="3" pname="c"/>
                       <note xml:id="m-51" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-52" dur="16" oct="3" pname="e"/>
                     </beam>
-                    <beam xml:id="m-54">
+                    <beam>
                       <note xml:id="m-53" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-55" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-56" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-57" dur="16" oct="3" pname="b" accid.ges="f"/>
                     </beam>
-                    <beam xml:id="m-60">
+                    <beam>
                       <note xml:id="m-59" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-61" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-62" dur="16" oct="3" pname="g"/>
@@ -216,22 +216,22 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-74" n="2" facs="#facsZone-m-74">
-                  <layer xml:id="m-75" n="1">
-                    <beam xml:id="m-77">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-76" dur="32" oct="3" pname="e"/>
                       <note xml:id="m-78" dur="32" oct="3" pname="f"/>
                       <note xml:id="m-79" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-80" dur="16" oct="3" pname="c"/>
                       <note xml:id="m-81" dur="16" oct="3" pname="g"/>
                     </beam>
-                    <beam xml:id="m-83">
+                    <beam>
                       <note xml:id="m-82" dur="32" oct="3" pname="e"/>
                       <note xml:id="m-84" dur="32" oct="3" pname="f"/>
                       <note xml:id="m-85" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-86" dur="16" oct="3" pname="c"/>
                       <note xml:id="m-87" dur="16" oct="3" pname="g"/>
                     </beam>
-                    <beam xml:id="m-89">
+                    <beam>
                       <note xml:id="m-88" dur="32" oct="3" pname="e"/>
                       <note xml:id="m-90" dur="32" oct="3" pname="f"/>
                       <note xml:id="m-91" dur="16" oct="3" pname="g"/>
@@ -258,20 +258,20 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-104" n="2" facs="#facsZone-m-104">
-                  <layer xml:id="m-105" n="1">
-                    <beam xml:id="m-107">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-106" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-108" dur="16" oct="3" pname="c"/>
                       <note xml:id="m-109" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-110" dur="16" oct="3" pname="e"/>
                     </beam>
-                    <beam xml:id="m-112">
+                    <beam>
                       <note xml:id="m-111" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-113" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-114" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-115" dur="16" oct="3" pname="b" accid.ges="f"/>
                     </beam>
-                    <beam xml:id="m-118">
+                    <beam>
                       <note xml:id="m-117" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-119" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-120" dur="16" oct="3" pname="g"/>
@@ -298,22 +298,22 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-132" n="2" facs="#facsZone-m-132">
-                  <layer xml:id="m-133" n="1">
-                    <beam xml:id="m-135">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-134" dur="32" oct="3" pname="e"/>
                       <note xml:id="m-136" dur="32" oct="3" pname="f"/>
                       <note xml:id="m-137" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-138" dur="16" oct="3" pname="c"/>
                       <note xml:id="m-139" dur="16" oct="3" pname="g"/>
                     </beam>
-                    <beam xml:id="m-141">
+                    <beam>
                       <note xml:id="m-140" dur="32" oct="3" pname="e"/>
                       <note xml:id="m-142" dur="32" oct="3" pname="f"/>
                       <note xml:id="m-143" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-144" dur="16" oct="3" pname="c"/>
                       <note xml:id="m-145" dur="16" oct="3" pname="g"/>
                     </beam>
-                    <beam xml:id="m-147">
+                    <beam>
                       <note xml:id="m-146" dur="32" oct="3" pname="e"/>
                       <note xml:id="m-148" dur="32" oct="3" pname="f"/>
                       <note xml:id="m-149" dur="16" oct="3" pname="g"/>
@@ -340,21 +340,21 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-163" n="2" facs="#facsZone-m-163">
-                  <layer xml:id="m-164" n="1">
-                    <beam xml:id="m-166">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-165" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-167" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-168" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-169" dur="16" oct="3" pname="a"/>
                     </beam>
                     <clef shape="C" line="4"/>
-                    <beam xml:id="m-172">
+                    <beam>
                       <note xml:id="m-170" dur="16" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-173" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-174" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-175" dur="16" oct="4" pname="e"/>
                     </beam>
-                    <beam xml:id="m-177">
+                    <beam>
                       <note xml:id="m-176" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-178" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-179" dur="16" oct="3" pname="b" accid.ges="f"/>
@@ -380,22 +380,22 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-192" n="2" facs="#facsZone-m-192">
-                  <layer xml:id="m-193" n="1">
-                    <beam xml:id="m-196">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-194" dur="32" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-197" dur="32" oct="4" pname="c"/>
                       <note xml:id="m-198" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-199" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-200" dur="16" oct="4" pname="d"/>
                     </beam>
-                    <beam xml:id="m-203">
+                    <beam>
                       <note xml:id="m-201" dur="32" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-204" dur="32" oct="4" pname="c"/>
                       <note xml:id="m-205" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-206" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-207" dur="16" oct="4" pname="d"/>
                     </beam>
-                    <beam xml:id="m-210">
+                    <beam>
                       <note xml:id="m-208" dur="32" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-211" dur="32" oct="4" pname="c"/>
                       <note xml:id="m-212" dur="16" oct="4" pname="d"/>
@@ -417,8 +417,8 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-225" n="2" facs="#facsZone-m-225">
-                  <layer xml:id="m-226" n="1">
-                    <beam xml:id="m-229">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-227" dur="16" oct="3" pname="b">
                         <accid accid="n"/>
                       </note>
@@ -426,13 +426,13 @@
                       <note xml:id="m-231" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-232" dur="16" oct="3" pname="b"/>
                     </beam>
-                    <beam xml:id="m-235">
+                    <beam>
                       <note xml:id="m-234" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-236" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-237" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-238" dur="16" oct="4" pname="f"/>
                     </beam>
-                    <beam xml:id="m-240">
+                    <beam>
                       <note xml:id="m-239" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-241" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-242" dur="16" oct="4" pname="c"/>
@@ -467,22 +467,22 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-256" n="2">
-                  <layer xml:id="m-257" n="1">
-                    <beam xml:id="m-259">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-258" dur="32" oct="4" pname="c"/>
                       <note xml:id="m-260" dur="32" oct="4" pname="d"/>
                       <note xml:id="m-261" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-262" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-263" dur="16" oct="4" pname="e"/>
                     </beam>
-                    <beam xml:id="m-265">
+                    <beam>
                       <note xml:id="m-264" dur="32" oct="4" pname="c"/>
                       <note xml:id="m-266" dur="32" oct="4" pname="d"/>
                       <note xml:id="m-267" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-268" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-269" dur="16" oct="4" pname="e"/>
                     </beam>
-                    <beam xml:id="m-271">
+                    <beam>
                       <note xml:id="m-270" dur="32" oct="4" pname="c"/>
                       <note xml:id="m-272" dur="32" oct="4" pname="d"/>
                       <note xml:id="m-273" dur="16" oct="4" pname="e"/>
@@ -504,20 +504,20 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-286" n="2" facs="#facsZone-m-286">
-                  <layer xml:id="m-287" n="1">
-                    <beam xml:id="m-289">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-288" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-290" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-291" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-292" dur="16" oct="3" pname="a"/>
                     </beam>
-                    <beam xml:id="m-294">
+                    <beam>
                       <note xml:id="m-293" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-295" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-296" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-297" dur="16" oct="3" pname="a"/>
                     </beam>
-                    <beam xml:id="m-299">
+                    <beam>
                       <note xml:id="m-298" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-300" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-301" dur="16" oct="4" pname="f"/>
@@ -526,7 +526,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-306" n="3">
-                  <layer xml:id="m-307" n="1">
+                  <layer n="1">
                     <note xml:id="m-308" dur="2" oct="3" pname="a"/>
                     <note xml:id="m-309" dur="4" oct="3" pname="a"/>
                   </layer>
@@ -539,22 +539,22 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-314" n="2" facs="#facsZone-m-314">
-                  <layer xml:id="m-315" n="1">
-                    <beam xml:id="m-317">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-316" dur="32" oct="4" pname="d"/>
                       <note xml:id="m-318" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-319" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-320" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-321" dur="16" oct="4" pname="f"/>
                     </beam>
-                    <beam xml:id="m-323">
+                    <beam>
                       <note xml:id="m-322" dur="32" oct="4" pname="d"/>
                       <note xml:id="m-324" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-325" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-326" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-327" dur="16" oct="4" pname="f"/>
                     </beam>
-                    <beam xml:id="m-329">
+                    <beam>
                       <note xml:id="m-328" dur="32" oct="4" pname="d"/>
                       <note xml:id="m-330" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-331" dur="16" oct="4" pname="f"/>
@@ -564,7 +564,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-337" n="3">
-                  <layer xml:id="m-338" n="1">
+                  <layer n="1">
                     <note xml:id="m-339" dots="1" dur="2" oct="3" pname="g"/>
                   </layer>
                 </staff>
@@ -581,20 +581,20 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-345" n="2" facs="#facsZone-m-345">
-                  <layer xml:id="m-346" n="1">
-                    <beam xml:id="m-348">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-347" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-349" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-350" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-351" dur="16" oct="3" pname="g"/>
                     </beam>
-                    <beam xml:id="m-353">
+                    <beam>
                       <note xml:id="m-352" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-354" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-355" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-356" dur="16" oct="3" pname="g"/>
                     </beam>
-                    <beam xml:id="m-358">
+                    <beam>
                       <note xml:id="m-357" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-359" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-360" dur="16" oct="4" pname="e"/>
@@ -603,7 +603,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-365" n="3">
-                  <layer xml:id="m-366" n="1">
+                  <layer n="1">
                     <note xml:id="m-367" dur="2" oct="3" pname="g"/>
                     <note xml:id="m-368" dur="4" oct="3" pname="g"/>
                   </layer>
@@ -621,22 +621,22 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-373" n="2" facs="#facsZone-m-373 #facsZone-m-373-1 #facsZone-m-373-2">
-                  <layer xml:id="m-374" n="1">
-                    <beam xml:id="m-376">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-375" dur="32" oct="4" pname="c"/>
                       <note xml:id="m-377" dur="32" oct="4" pname="d"/>
                       <note xml:id="m-378" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-379" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-380" dur="16" oct="4" pname="e"/>
                     </beam>
-                    <beam xml:id="m-382">
+                    <beam>
                       <note xml:id="m-381" dur="32" oct="4" pname="c"/>
                       <note xml:id="m-383" dur="32" oct="4" pname="d"/>
                       <note xml:id="m-384" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-385" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-386" dur="16" oct="4" pname="e"/>
                     </beam>
-                    <beam xml:id="m-388">
+                    <beam>
                       <note xml:id="m-387" dur="32" oct="4" pname="c"/>
                       <note xml:id="m-389" dur="32" oct="4" pname="d"/>
                       <note xml:id="m-390" dur="16" oct="4" pname="e"/>
@@ -646,7 +646,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-396" n="3">
-                  <layer xml:id="m-397" n="1">
+                  <layer n="1">
                     <note xml:id="m-398" dots="1" dur="2" oct="3" pname="f"/>
                   </layer>
                 </staff>
@@ -663,20 +663,20 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-403" n="2" facs="#facsZone-m-403">
-                  <layer xml:id="m-404" n="1">
-                    <beam xml:id="m-406">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-405" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-407" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-408" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-409" dur="16" oct="3" pname="f"/>
                     </beam>
-                    <beam xml:id="m-411">
+                    <beam>
                       <note xml:id="m-410" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-412" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-413" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-414" dur="16" oct="3" pname="f"/>
                     </beam>
-                    <beam xml:id="m-416">
+                    <beam>
                       <note xml:id="m-415" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-417" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-418" dur="16" oct="4" pname="d"/>
@@ -685,7 +685,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-423" n="3">
-                  <layer xml:id="m-424" n="1">
+                  <layer n="1">
                     <note xml:id="m-425" dur="2" oct="3" pname="f"/>
                     <note xml:id="m-426" dur="4" oct="3" pname="f"/>
                   </layer>
@@ -703,23 +703,23 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-431" n="2" facs="#facsZone-m-431">
-                  <layer xml:id="m-432" n="1">
+                  <layer n="1">
                     <clef shape="F" line="4"/>
                     <pb n="331" source="#secondEdition" facs="#facs-p415"/>
                     <pb n="131" source="#firstEdition" facs="#facs-p295"/>
-                    <beam xml:id="m-434">
+                    <beam>
                       <note xml:id="m-433" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-435" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-436" dur="16" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-438" dur="16" oct="3" pname="a"/>
                     </beam>
-                    <beam xml:id="m-440">
+                    <beam>
                       <note xml:id="m-439" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-441" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-442" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-443" dur="16" oct="3" pname="d"/>
                     </beam>
-                    <beam xml:id="m-445">
+                    <beam>
                       <note xml:id="m-444" dur="16" oct="3" pname="c"/>
                       <note xml:id="m-446" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-447" dur="16" oct="3" pname="c"/>
@@ -728,7 +728,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-453" n="3">
-                  <layer xml:id="m-454" n="1">
+                  <layer n="1">
                     <note xml:id="m-455" dots="1" dur="2" oct="3" pname="e"/>
                   </layer>
                 </staff>
@@ -740,20 +740,20 @@
               </measure>
               <measure xml:id="m-456" n="15">
                 <staff xml:id="m-458" n="1">
-                  <layer xml:id="m-459" n="1">
-                    <beam xml:id="m-461">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-460" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-462" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-463" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-464" dur="16" oct="4" pname="e"/>
                     </beam>
-                    <beam xml:id="m-466">
+                    <beam>
                       <note xml:id="m-465" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-467" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-468" dur="16" oct="4" pname="a"/>
                       <note xml:id="m-469" dur="16" oct="4" pname="b" accid.ges="f"/>
                     </beam>
-                    <beam xml:id="m-472">
+                    <beam>
                       <note xml:id="m-471" dur="16" oct="5" pname="c"/>
                       <note xml:id="m-473" dur="16" oct="4" pname="a"/>
                       <note xml:id="m-474" dur="16" oct="4" pname="g"/>
@@ -762,9 +762,9 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-476" n="2" facs="#facsZone-m-476">
-                  <layer xml:id="m-477" n="1">
+                  <layer n="1">
                     <note xml:id="m-478" dots="1" dur="4" oct="2" pname="a"/>
-                    <beam xml:id="m-480">
+                    <beam>
                       <note xml:id="m-479" dur="8" oct="2" pname="g"/>
                       <note xml:id="m-481" dur="8" oct="2" pname="a"/>
                       <note xml:id="m-482" dur="8" oct="2" pname="b" accid.ges="f"/>
@@ -772,7 +772,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-487" n="3">
-                  <layer xml:id="m-488" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -784,22 +784,22 @@
               </measure>
               <measure xml:id="m-490" n="16">
                 <staff xml:id="m-491" n="1">
-                  <layer xml:id="m-492" n="1">
-                    <beam xml:id="m-494">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-493" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-495" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-496" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-497" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-498" dur="16" oct="4" pname="g"/>
                     </beam>
-                    <beam xml:id="m-500">
+                    <beam>
                       <note xml:id="m-499" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-501" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-502" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-503" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-504" dur="16" oct="4" pname="g"/>
                     </beam>
-                    <beam xml:id="m-506">
+                    <beam>
                       <note xml:id="m-505" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-507" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-508" dur="16" oct="4" pname="g"/>
@@ -809,9 +809,9 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-511" n="2" facs="#facsZone-m-511">
-                  <layer xml:id="m-512" n="1">
+                  <layer n="1">
                     <note xml:id="m-513" dots="1" dur="4" oct="3" pname="c"/>
-                    <beam xml:id="m-515">
+                    <beam>
                       <note xml:id="m-514" dur="8" oct="4" pname="c"/>
                       <note xml:id="m-516" dur="8" oct="4" pname="c"/>
                       <note xml:id="m-517" dur="8" oct="3" pname="b" accid.ges="f"/>
@@ -819,27 +819,27 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-519" n="3">
-                  <layer xml:id="m-520" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
               </measure>
               <measure xml:id="m-525" n="17">
                 <staff xml:id="m-526" n="1">
-                  <layer xml:id="m-527" n="1">
-                    <beam xml:id="m-529">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-528" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-530" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-531" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-532" dur="16" oct="4" pname="e"/>
                     </beam>
-                    <beam xml:id="m-534">
+                    <beam>
                       <note xml:id="m-533" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-535" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-536" dur="16" oct="4" pname="a"/>
                       <note xml:id="m-537" dur="16" oct="4" pname="b" accid.ges="f"/>
                     </beam>
-                    <beam xml:id="m-540">
+                    <beam>
                       <note xml:id="m-539" dur="16" oct="5" pname="c"/>
                       <note xml:id="m-541" dur="16" oct="4" pname="a"/>
                       <note xml:id="m-542" dur="16" oct="4" pname="g"/>
@@ -848,9 +848,9 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-544" n="2" facs="#facsZone-m-544">
-                  <layer xml:id="m-545" n="1">
+                  <layer n="1">
                     <note xml:id="m-546" dots="1" dur="4" oct="3" pname="a"/>
-                    <beam xml:id="m-548">
+                    <beam>
                       <note xml:id="m-547" dur="8" oct="3" pname="g"/>
                       <note xml:id="m-549" dur="8" oct="3" pname="a"/>
                       <note xml:id="m-550" dur="8" oct="3" pname="b" accid.ges="f"/>
@@ -858,7 +858,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-552" n="3">
-                  <layer xml:id="m-553" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -870,22 +870,22 @@
               </measure>
               <measure xml:id="m-558" n="18">
                 <staff xml:id="m-559" n="1">
-                  <layer xml:id="m-560" n="1">
-                    <beam xml:id="m-562">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-561" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-563" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-564" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-565" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-566" dur="16" oct="4" pname="g"/>
                     </beam>
-                    <beam xml:id="m-568">
+                    <beam>
                       <note xml:id="m-567" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-569" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-570" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-571" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-572" dur="16" oct="4" pname="g"/>
                     </beam>
-                    <beam xml:id="m-574">
+                    <beam>
                       <note xml:id="m-573" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-575" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-576" dur="16" oct="4" pname="g"/>
@@ -895,9 +895,9 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-579" n="2" facs="#facsZone-m-579">
-                  <layer xml:id="m-580" n="1">
+                  <layer n="1">
                     <note xml:id="m-581" dots="1" dur="4" oct="4" pname="c"/>
-                    <beam xml:id="m-583">
+                    <beam>
                       <note xml:id="m-582" dur="8" oct="3" pname="c"/>
                       <note xml:id="m-584" dur="8" oct="3" pname="d"/>
                       <note xml:id="m-585" dur="8" oct="3" pname="e"/>
@@ -905,7 +905,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-586" n="3">
-                  <layer xml:id="m-587" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -913,20 +913,20 @@
               <sb xml:id="m-593"/>
               <measure xml:id="m-592" n="19">
                 <staff xml:id="m-594" n="1">
-                  <layer xml:id="m-595" n="1">
-                    <beam xml:id="m-597">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-596" dur="16" oct="4" pname="a"/>
                       <note xml:id="m-598" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-599" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-600" dur="16" oct="4" pname="a"/>
                     </beam>
-                    <beam xml:id="m-603">
+                    <beam>
                       <note xml:id="m-601" dur="16" oct="4" pname="b" accid.ges="f"/>
                       <note xml:id="m-604" dur="16" oct="5" pname="c"/>
                       <note xml:id="m-605" dur="16" oct="5" pname="d"/>
                       <note xml:id="m-606" dur="16" oct="5" pname="e"/>
                     </beam>
-                    <beam xml:id="m-608">
+                    <beam>
                       <note xml:id="m-607" dur="16" oct="5" pname="f"/>
                       <note xml:id="m-609" dur="16" oct="5" pname="c"/>
                       <note xml:id="m-610" dur="16" oct="4" pname="b" accid.ges="f"/>
@@ -935,9 +935,9 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-613" n="2" facs="#facsZone-m-613">
-                  <layer xml:id="m-614" n="1">
+                  <layer n="1">
                     <note xml:id="m-615" dots="1" dur="4" oct="3" pname="f"/>
-                    <beam xml:id="m-617">
+                    <beam>
                       <note xml:id="m-616" dur="8" oct="3" pname="g"/>
                       <note xml:id="m-618" dur="8" oct="3" pname="a"/>
                       <note xml:id="m-619" dur="8" oct="3" pname="f"/>
@@ -945,7 +945,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-620" n="3">
-                  <layer xml:id="m-621" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -957,22 +957,22 @@
               </measure>
               <measure xml:id="m-626" n="20">
                 <staff xml:id="m-627" n="1">
-                  <layer xml:id="m-628" n="1">
-                    <beam xml:id="m-631">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-629" dur="32" oct="4" pname="b" accid.ges="f"/>
                       <note xml:id="m-632" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-633" dur="16" oct="5" pname="d"/>
                       <note xml:id="m-634" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-635" dur="16" oct="5" pname="d"/>
                     </beam>
-                    <beam xml:id="m-638">
+                    <beam>
                       <note xml:id="m-636" dur="32" oct="4" pname="b" accid.ges="f"/>
                       <note xml:id="m-639" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-640" dur="16" oct="5" pname="d"/>
                       <note xml:id="m-641" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-642" dur="16" oct="5" pname="d"/>
                     </beam>
-                    <beam xml:id="m-645">
+                    <beam>
                       <note xml:id="m-643" dur="32" oct="4" pname="b" accid.ges="f"/>
                       <note xml:id="m-646" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-647" dur="16" oct="5" pname="d"/>
@@ -982,9 +982,9 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-650" n="2" facs="#facsZone-m-650">
-                  <layer xml:id="m-651" n="1">
+                  <layer n="1">
                     <note xml:id="m-652" dots="1" dur="4" oct="3" pname="d"/>
-                    <beam xml:id="m-655">
+                    <beam>
                       <note xml:id="m-653" dur="8" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-656" dur="8" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-658" dur="8" oct="3" pname="a"/>
@@ -992,7 +992,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-659" n="3">
-                  <layer xml:id="m-660" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -1004,8 +1004,8 @@
               </measure>
               <measure xml:id="m-665" n="21">
                 <staff xml:id="m-666" n="1">
-                  <layer xml:id="m-667" n="1">
-                    <beam xml:id="m-670">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-668" dur="16" oct="4" pname="b">
                         <accid accid="n"/>
                       </note>
@@ -1015,13 +1015,13 @@
                         <accid accid="n"/>
                       </note>
                     </beam>
-                    <beam xml:id="m-676">
+                    <beam>
                       <note xml:id="m-675" dur="16" oct="5" pname="c"/>
                       <note xml:id="m-677" dur="16" oct="5" pname="d"/>
                       <note xml:id="m-678" dur="16" oct="5" pname="e"/>
                       <note xml:id="m-679" dur="16" oct="5" pname="f"/>
                     </beam>
-                    <beam xml:id="m-681">
+                    <beam>
                       <note xml:id="m-680" dur="16" oct="5" pname="g"/>
                       <note xml:id="m-682" dur="16" oct="5" pname="d"/>
                       <note xml:id="m-683" dur="16" oct="5" pname="c"/>
@@ -1032,9 +1032,9 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-686" n="2" facs="#facsZone-m-686">
-                  <layer xml:id="m-687" n="1">
+                  <layer n="1">
                     <note xml:id="m-688" dots="1" dur="4" oct="3" pname="g"/>
-                    <beam xml:id="m-690">
+                    <beam>
                       <note xml:id="m-689" dur="8" oct="3" pname="a"/>
                       <note xml:id="m-691" dur="8" oct="3" pname="b">
                         <accid accid="n"/>
@@ -1044,7 +1044,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-694" n="3">
-                  <layer xml:id="m-695" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -1056,22 +1056,22 @@
               </measure>
               <measure xml:id="m-700" n="22">
                 <staff xml:id="m-701" n="1">
-                  <layer xml:id="m-702" n="1">
-                    <beam xml:id="m-704">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-703" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-705" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-706" dur="16" oct="5" pname="e"/>
                       <note xml:id="m-707" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-708" dur="16" oct="5" pname="e"/>
                     </beam>
-                    <beam xml:id="m-710">
+                    <beam>
                       <note xml:id="m-709" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-711" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-712" dur="16" oct="5" pname="e"/>
                       <note xml:id="m-713" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-714" dur="16" oct="5" pname="e"/>
                     </beam>
-                    <beam xml:id="m-716">
+                    <beam>
                       <note xml:id="m-715" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-717" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-718" dur="16" oct="5" pname="e"/>
@@ -1081,9 +1081,9 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-721" n="2" facs="#facsZone-m-721">
-                  <layer xml:id="m-722" n="1">
+                  <layer n="1">
                     <note xml:id="m-723" dots="1" dur="4" oct="3" pname="e"/>
-                    <beam xml:id="m-725">
+                    <beam>
                       <note xml:id="m-724" dur="8" oct="4" pname="e"/>
                       <note xml:id="m-726" dur="8" oct="4" pname="e"/>
                       <note xml:id="m-727" dur="8" oct="4" pname="c"/>
@@ -1091,7 +1091,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-728" n="3">
-                  <layer xml:id="m-729" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -1103,20 +1103,20 @@
               </measure>
               <measure xml:id="m-734" n="23">
                 <staff xml:id="m-737" n="1">
-                  <layer xml:id="m-738" n="1">
-                    <beam xml:id="m-740">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-739" dur="16" oct="5" pname="f"/>
                       <note xml:id="m-741" dur="16" oct="5" pname="e"/>
                       <note xml:id="m-742" dur="16" oct="5" pname="f"/>
                       <note xml:id="m-743" dur="16" oct="4" pname="a"/>
                     </beam>
-                    <beam xml:id="m-745">
+                    <beam>
                       <note xml:id="m-744" dur="16" oct="5" pname="f"/>
                       <note xml:id="m-746" dur="16" oct="5" pname="e"/>
                       <note xml:id="m-747" dur="16" oct="5" pname="f"/>
                       <note xml:id="m-748" dur="16" oct="4" pname="a"/>
                     </beam>
-                    <beam xml:id="m-750">
+                    <beam>
                       <note xml:id="m-749" dur="16" oct="5" pname="f"/>
                       <note xml:id="m-751" dur="16" oct="5" pname="e"/>
                       <note xml:id="m-752" dur="16" oct="5" pname="f"/>
@@ -1125,9 +1125,9 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-754" n="2" facs="#facsZone-m-754">
-                  <layer xml:id="m-755" n="1">
+                  <layer n="1">
                     <note xml:id="m-756" dots="1" dur="4" oct="4" pname="d"/>
-                    <beam xml:id="m-758">
+                    <beam>
                       <note xml:id="m-757" dur="8" oct="4" pname="d"/>
                       <note xml:id="m-759" dur="8" oct="4" pname="d"/>
                       <note xml:id="m-760" dur="8" oct="4" pname="c"/>
@@ -1135,29 +1135,29 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-761" n="3">
-                  <layer xml:id="m-762" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
               </measure>
               <measure xml:id="m-767" n="24">
                 <staff xml:id="m-768" n="1">
-                  <layer xml:id="m-769" n="1">
-                    <beam xml:id="m-771">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-770" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-772" dur="32" oct="5" pname="e"/>
                       <note xml:id="m-773" dur="16" oct="5" pname="f"/>
                       <note xml:id="m-774" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-775" dur="16" oct="5" pname="f"/>
                     </beam>
-                    <beam xml:id="m-777">
+                    <beam>
                       <note xml:id="m-776" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-778" dur="32" oct="5" pname="e"/>
                       <note xml:id="m-779" dur="16" oct="5" pname="f"/>
                       <note xml:id="m-780" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-781" dur="16" oct="5" pname="f"/>
                     </beam>
-                    <beam xml:id="m-783">
+                    <beam>
                       <note xml:id="m-782" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-784" dur="32" oct="5" pname="e"/>
                       <note xml:id="m-785" dur="16" oct="5" pname="f"/>
@@ -1167,9 +1167,9 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-788" n="2" facs="#facsZone-m-788 #facsZone-m-788-2">
-                  <layer xml:id="m-789" n="1">
+                  <layer n="1">
                     <note xml:id="m-790" dots="1" dur="4" oct="3" pname="b" accid.ges="f"/>
-                    <beam xml:id="m-793">
+                    <beam>
                       <note xml:id="m-792" dur="8" oct="3" pname="a"/>
                       <note xml:id="m-794" dur="8" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-796" dur="8" oct="3" pname="g"/>
@@ -1177,7 +1177,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-797" n="3">
-                  <layer xml:id="m-798" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -1190,20 +1190,20 @@
               </measure>
               <measure xml:id="m-803" n="25">
                 <staff xml:id="m-804" n="1">
-                  <layer xml:id="m-805" n="1">
-                    <beam xml:id="m-807">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-806" dur="16" oct="5" pname="e"/>
                       <note xml:id="m-808" dur="16" oct="5" pname="d"/>
                       <note xml:id="m-809" dur="16" oct="5" pname="e"/>
                       <note xml:id="m-810" dur="16" oct="4" pname="g"/>
                     </beam>
-                    <beam xml:id="m-812">
+                    <beam>
                       <note xml:id="m-811" dur="16" oct="5" pname="e"/>
                       <note xml:id="m-813" dur="16" oct="5" pname="d"/>
                       <note xml:id="m-814" dur="16" oct="5" pname="e"/>
                       <note xml:id="m-815" dur="16" oct="4" pname="g"/>
                     </beam>
-                    <beam xml:id="m-817">
+                    <beam>
                       <note xml:id="m-816" dur="16" oct="5" pname="e"/>
                       <note xml:id="m-818" dur="16" oct="5" pname="d"/>
                       <note xml:id="m-819" dur="16" oct="5" pname="e"/>
@@ -1212,9 +1212,9 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-821" n="2" facs="#facsZone-m-821">
-                  <layer xml:id="m-822" n="1">
+                  <layer n="1">
                     <note xml:id="m-823" dots="1" dur="4" oct="4" pname="c"/>
-                    <beam xml:id="m-825">
+                    <beam>
                       <note xml:id="m-824" dur="8" oct="4" pname="c"/>
                       <note xml:id="m-826" dur="8" oct="4" pname="c"/>
                       <note xml:id="m-827" dur="8" oct="3" pname="b" accid.ges="f"/>
@@ -1222,29 +1222,29 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-829" n="3">
-                  <layer xml:id="m-830" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
               </measure>
               <measure xml:id="m-835" n="26">
                 <staff xml:id="m-836" n="1">
-                  <layer xml:id="m-837" n="1">
-                    <beam xml:id="m-839">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-838" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-840" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-841" dur="16" oct="5" pname="e"/>
                       <note xml:id="m-842" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-843" dur="16" oct="5" pname="e"/>
                     </beam>
-                    <beam xml:id="m-845">
+                    <beam>
                       <note xml:id="m-844" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-846" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-847" dur="16" oct="5" pname="e"/>
                       <note xml:id="m-848" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-849" dur="16" oct="5" pname="e"/>
                     </beam>
-                    <beam xml:id="m-851">
+                    <beam>
                       <note xml:id="m-850" dur="32" oct="5" pname="c"/>
                       <note xml:id="m-852" dur="32" oct="5" pname="d"/>
                       <note xml:id="m-853" dur="16" oct="5" pname="e"/>
@@ -1254,9 +1254,9 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-856" n="2" facs="#facsZone-m-856 #facsZone-m-856-2">
-                  <layer xml:id="m-857" n="1">
+                  <layer n="1">
                     <note xml:id="m-858" dots="1" dur="4" oct="3" pname="a"/>
-                    <beam xml:id="m-860">
+                    <beam>
                       <note xml:id="m-859" dur="8" oct="3" pname="g"/>
                       <note xml:id="m-861" dur="8" oct="3" pname="a"/>
                       <note xml:id="m-862" dur="8" oct="3" pname="f"/>
@@ -1264,7 +1264,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-863" n="3">
-                  <layer xml:id="m-864" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -1277,20 +1277,20 @@
               </measure>
               <measure xml:id="m-869" n="27">
                 <staff xml:id="m-871" n="1">
-                  <layer xml:id="m-872" n="1">
-                    <beam xml:id="m-874">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-873" dur="16" oct="5" pname="d"/>
                       <note xml:id="m-875" dur="16" oct="5" pname="c"/>
                       <note xml:id="m-876" dur="16" oct="5" pname="d"/>
                       <note xml:id="m-877" dur="16" oct="4" pname="f"/>
                     </beam>
-                    <beam xml:id="m-879">
+                    <beam>
                       <note xml:id="m-878" dur="16" oct="5" pname="d"/>
                       <note xml:id="m-880" dur="16" oct="5" pname="c"/>
                       <note xml:id="m-881" dur="16" oct="5" pname="d"/>
                       <note xml:id="m-882" dur="16" oct="4" pname="f"/>
                     </beam>
-                    <beam xml:id="m-884">
+                    <beam>
                       <note xml:id="m-883" dur="16" oct="5" pname="d"/>
                       <note xml:id="m-885" dur="16" oct="5" pname="c"/>
                       <note xml:id="m-886" dur="16" oct="5" pname="d"/>
@@ -1299,9 +1299,9 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-888" n="2">
-                  <layer xml:id="m-889" n="1">
+                  <layer n="1">
                     <note xml:id="m-890" dots="1" dur="4" oct="3" pname="b" accid.ges="f"/>
-                    <beam xml:id="m-893">
+                    <beam>
                       <note xml:id="m-892" dur="8" oct="3" pname="a"/>
                       <note xml:id="m-894" dur="8" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-896" dur="8" oct="3" pname="g"/>
@@ -1309,21 +1309,21 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-897" n="3">
-                  <layer xml:id="m-898" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
               </measure>
               <measure xml:id="m-903" n="28">
                 <staff xml:id="m-904" n="1">
-                  <layer xml:id="m-905" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-907" n="2">
-                  <layer xml:id="m-908" n="1">
+                  <layer n="1">
                     <note xml:id="m-909" dots="1" dur="4" oct="3" pname="a"/>
-                    <beam xml:id="m-911">
+                    <beam>
                       <note xml:id="m-910" dur="8" oct="3" pname="g"/>
                       <note xml:id="m-912" dur="8" oct="3" pname="a"/>
                       <note xml:id="m-913" dur="8" oct="3" pname="f"/>
@@ -1331,7 +1331,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-914" n="3">
-                  <layer xml:id="m-915" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -1343,14 +1343,14 @@
               </measure>
               <measure xml:id="m-920" n="29">
                 <staff xml:id="m-921" n="1">
-                  <layer xml:id="m-922" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-924" n="2" facs="#facsZone-m-924">
-                  <layer xml:id="m-925" n="1">
+                  <layer n="1">
                     <note xml:id="m-926" dots="1" dur="4" oct="3" pname="g"/>
-                    <beam xml:id="m-928">
+                    <beam>
                       <note xml:id="m-927" dur="8" oct="3" pname="f"/>
                       <note xml:id="m-929" dur="8" oct="3" pname="e"/>
                       <note xml:id="m-930" dur="8" oct="3" pname="d"/>
@@ -1358,7 +1358,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-931" n="3">
-                  <layer xml:id="m-932" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -1370,13 +1370,13 @@
               </measure>
               <measure xml:id="m-937" n="30">
                 <staff xml:id="m-938" n="1">
-                  <layer xml:id="m-939" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-941" n="2" facs="#facsZone-m-941">
-                  <layer xml:id="m-942" n="1">
-                    <beam xml:id="m-944">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-943" dur="8" oct="3" pname="e"/>
                       <note xml:id="m-945" dur="8" oct="3" pname="f"/>
                     </beam>
@@ -1385,7 +1385,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-948" n="3">
-                  <layer xml:id="m-949" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -1403,25 +1403,25 @@
               </measure>
               <measure xml:id="m-954" n="31">
                 <staff xml:id="m-955" n="1">
-                  <layer xml:id="m-956" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-958" n="2" facs="#facsZone-m-958">
-                  <layer xml:id="m-959" n="1">
-                    <beam xml:id="m-961">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-960" dur="16" oct="3" pname="c"/>
                       <note xml:id="m-962" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-963" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-964" dur="16" oct="4" pname="c"/>
                     </beam>
-                    <beam xml:id="m-966">
+                    <beam>
                       <note xml:id="m-965" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-967" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-968" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-969" dur="16" oct="4" pname="c"/>
                     </beam>
-                    <beam xml:id="m-971">
+                    <beam>
                       <note xml:id="m-970" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-972" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-973" dur="16" oct="4" pname="d"/>
@@ -1430,7 +1430,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-975" n="3">
-                  <layer xml:id="m-976" n="1">
+                  <layer n="1">
                     <note xml:id="m-977" dur="4" oct="2" pname="c"/>
                     <note xml:id="m-978" dur="4" oct="2" pname="d"/>
                     <note xml:id="m-979" dur="4" oct="2" pname="e"/>
@@ -1440,25 +1440,25 @@
               <sb xml:id="m-984"/>
               <measure xml:id="m-983" n="32">
                 <staff xml:id="m-985" n="1">
-                  <layer xml:id="m-986" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-988" n="2" facs="#facsZone-m-988">
-                  <layer xml:id="m-989" n="1">
-                    <beam xml:id="m-991">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-990" dur="16" oct="2" pname="f"/>
                       <note xml:id="m-992" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-993" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-994" dur="16" oct="3" pname="f"/>
                     </beam>
-                    <beam xml:id="m-996">
+                    <beam>
                       <note xml:id="m-995" dur="16" oct="2" pname="g"/>
                       <note xml:id="m-997" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-998" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-999" dur="16" oct="3" pname="f"/>
                     </beam>
-                    <beam xml:id="m-1001">
+                    <beam>
                       <note xml:id="m-1000" dur="16" oct="2" pname="a"/>
                       <note xml:id="m-1002" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1003" dur="16" oct="3" pname="g"/>
@@ -1467,7 +1467,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1005" n="3">
-                  <layer xml:id="m-1006" n="1">
+                  <layer n="1">
                     <note xml:id="m-1007" dur="4" oct="2" pname="f"/>
                     <note xml:id="m-1008" dur="4" oct="2" pname="g"/>
                     <note xml:id="m-1009" dur="4" oct="2" pname="a"/>
@@ -1476,25 +1476,25 @@
               </measure>
               <measure xml:id="m-1013" n="33">
                 <staff xml:id="m-1014" n="1">
-                  <layer xml:id="m-1015" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1017" n="2" facs="#facsZone-m-1017">
-                  <layer xml:id="m-1018" n="1">
-                    <beam xml:id="m-1021">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1019" dur="16" oct="2" pname="b" accid.ges="f"/>
                       <note xml:id="m-1022" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1023" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-1024" dur="16" oct="3" pname="f"/>
                     </beam>
-                    <beam xml:id="m-1026">
+                    <beam>
                       <note xml:id="m-1025" dur="16" oct="2" pname="g"/>
                       <note xml:id="m-1027" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-1028" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1029" dur="16" oct="3" pname="e"/>
                     </beam>
-                    <beam xml:id="m-1031">
+                    <beam>
                       <note xml:id="m-1030" dur="16" oct="2" pname="g"/>
                       <note xml:id="m-1032" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1033" dur="16" oct="3" pname="e"/>
@@ -1503,7 +1503,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1035" n="3">
-                  <layer xml:id="m-1036" n="1">
+                  <layer n="1">
                     <note xml:id="m-1037" dur="4" oct="2" pname="b" accid.ges="f"/>
                     <note xml:id="m-1039" dur="2" oct="2" pname="g"/>
                   </layer>
@@ -1511,19 +1511,19 @@
               </measure>
               <measure xml:id="m-1043" n="34">
                 <staff xml:id="m-1044" n="1">
-                  <layer xml:id="m-1045" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1047" n="2" facs="#facsZone-m-1047">
-                  <layer xml:id="m-1048" n="1">
-                    <beam xml:id="m-1050">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1049" dur="16" oct="2" pname="a"/>
                       <note xml:id="m-1051" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-1052" dur="16" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-1054" dur="16" oct="3" pname="a"/>
                     </beam>
-                    <beam xml:id="m-1057">
+                    <beam>
                       <note xml:id="m-1055" dur="16" oct="2" pname="b">
                         <accid accid="n"/>
                       </note>
@@ -1537,7 +1537,7 @@
                       </note>
                       <note xml:id="m-1061" dur="16" oct="3" pname="a"/>
                     </beam>
-                    <beam xml:id="m-1064">
+                    <beam>
                       <note xml:id="m-1062" dur="16" oct="3" pname="c">
                         <accid accid="s"/>
                       </note>
@@ -1548,7 +1548,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1069" n="3">
-                  <layer xml:id="m-1070" n="1">
+                  <layer n="1">
                     <note xml:id="m-1071" dur="4" oct="2" pname="a"/>
                     <note xml:id="m-1072" dur="4" oct="2" pname="b">
                       <accid accid="n"/>
@@ -1571,25 +1571,25 @@
               </measure>
               <measure xml:id="m-1079" n="35">
                 <staff xml:id="m-1080" n="1">
-                  <layer xml:id="m-1081" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1083" n="2" facs="#facsZone-m-1083">
-                  <layer xml:id="m-1084" n="1">
-                    <beam xml:id="m-1086">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1085" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1087" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-1088" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-1089" dur="16" oct="4" pname="d"/>
                     </beam>
-                    <beam xml:id="m-1091">
+                    <beam>
                       <note xml:id="m-1090" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-1092" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-1093" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-1094" dur="16" oct="4" pname="d"/>
                     </beam>
-                    <beam xml:id="m-1096">
+                    <beam>
                       <note xml:id="m-1095" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1097" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-1098" dur="16" oct="4" pname="e"/>
@@ -1598,10 +1598,10 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1100" n="3">
-                  <layer xml:id="m-1101" n="1">
+                  <layer n="1">
                     <note xml:id="m-1102" dur="4" oct="3" pname="d"/>
                     <note xml:id="m-1103" dur="4" oct="3" pname="e"/>
-                    <beam xml:id="m-1105">
+                    <beam>
                       <note xml:id="m-1104" dur="8" oct="3" pname="f"/>
                       <note xml:id="m-1106" dur="8" oct="3" pname="g"/>
                     </beam>
@@ -1615,13 +1615,13 @@
               </measure>
               <measure xml:id="m-1110" n="36">
                 <staff xml:id="m-1112" n="1">
-                  <layer xml:id="m-1113" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1115" n="2" facs="#facsZone-m-1115">
-                  <layer xml:id="m-1116" n="1">
-                    <beam xml:id="m-1119">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1117" dur="32" oct="4" pname="c">
                         <accid accid="s"/>
                       </note>
@@ -1630,7 +1630,7 @@
                       <note xml:id="m-1122" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-1123" dur="16" oct="4" pname="e"/>
                     </beam>
-                    <beam xml:id="m-1126">
+                    <beam>
                       <note xml:id="m-1124" dur="32" oct="4" pname="c" accid.ges="s">
                         <orig>
                           <accid accid="s"/>
@@ -1641,7 +1641,7 @@
                       <note xml:id="m-1129" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-1130" dur="16" oct="4" pname="e"/>
                     </beam>
-                    <beam xml:id="m-1133">
+                    <beam>
                       <note xml:id="m-1131" dur="32" oct="4" pname="c" accid.ges="s">
                         <orig>
                           <accid accid="s"/>
@@ -1655,7 +1655,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1138" n="3">
-                  <layer xml:id="m-1139" n="1">
+                  <layer n="1">
                     <note xml:id="m-1140" dur="2" oct="3" pname="a"/>
                     <note xml:id="m-1141" dur="4" oct="3" pname="g"/>
                   </layer>
@@ -1668,13 +1668,13 @@
               </measure>
               <measure xml:id="m-1145" n="37">
                 <staff xml:id="m-1146" n="1">
-                  <layer xml:id="m-1147" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1149" n="2" facs="#facsZone-m-1149">
-                  <layer xml:id="m-1150" n="1">
-                    <beam xml:id="m-1152">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1151" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1153" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1154" dur="16" oct="3" pname="c">
@@ -1682,7 +1682,7 @@
                       </note>
                       <note xml:id="m-1156" dur="16" oct="3" pname="d"/>
                     </beam>
-                    <beam xml:id="m-1158">
+                    <beam>
                       <note xml:id="m-1157" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-1159" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1160" dur="16" oct="3" pname="c" accid.ges="s">
@@ -1692,7 +1692,7 @@
                       </note>
                       <note xml:id="m-1162" dur="16" oct="3" pname="d"/>
                     </beam>
-                    <beam xml:id="m-1164">
+                    <beam>
                       <note xml:id="m-1163" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-1165" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1166" dur="16" oct="3" pname="c" accid.ges="s">
@@ -1705,7 +1705,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1169" n="3">
-                  <layer xml:id="m-1170" n="1">
+                  <layer n="1">
                     <note xml:id="m-1171" dur="4" oct="3" pname="f"/>
                     <note xml:id="m-1172" dur="4" oct="3" pname="g"/>
                     <note xml:id="m-1173" dur="4" oct="3" pname="a"/>
@@ -1719,13 +1719,13 @@
               </measure>
               <measure xml:id="m-1177" n="38">
                 <staff xml:id="m-1178" n="1">
-                  <layer xml:id="m-1179" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1181" n="2" facs="#facsZone-m-1181">
-                  <layer xml:id="m-1182" n="1">
-                    <beam xml:id="m-1185">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1183" dur="16" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-1186" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1187" dur="16" oct="3" pname="c">
@@ -1733,7 +1733,7 @@
                       </note>
                       <note xml:id="m-1189" dur="16" oct="3" pname="d"/>
                     </beam>
-                    <beam xml:id="m-1192">
+                    <beam>
                       <note xml:id="m-1190" dur="16" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-1193" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1194" dur="16" oct="3" pname="c" accid.ges="s">
@@ -1743,7 +1743,7 @@
                       </note>
                       <note xml:id="m-1196" dur="16" oct="3" pname="d"/>
                     </beam>
-                    <beam xml:id="m-1198">
+                    <beam>
                       <note xml:id="m-1197" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-1199" dur="16" oct="3" pname="c" accid.ges="s">
                         <orig>
@@ -1762,7 +1762,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1205" n="3">
-                  <layer xml:id="m-1206" n="1">
+                  <layer n="1">
                     <note xml:id="m-1207" dur="2" oct="3" pname="b" accid.ges="f"/>
                     <note xml:id="m-1209" dur="4" oct="3" pname="e"/>
                   </layer>
@@ -1780,13 +1780,13 @@
               </measure>
               <measure xml:id="m-1213" n="39">
                 <staff xml:id="m-1214" n="1">
-                  <layer xml:id="m-1215" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1217" n="2" facs="#facsZone-m-1217">
-                  <layer xml:id="m-1218" n="1">
-                    <beam xml:id="m-1220">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1219" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1221" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1222" dur="16" oct="3" pname="c">
@@ -1794,7 +1794,7 @@
                       </note>
                       <note xml:id="m-1224" dur="16" oct="3" pname="d"/>
                     </beam>
-                    <beam xml:id="m-1226">
+                    <beam>
                       <note xml:id="m-1225" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-1227" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1228" dur="16" oct="3" pname="c" accid.ges="s">
@@ -1804,7 +1804,7 @@
                       </note>
                       <note xml:id="m-1230" dur="16" oct="3" pname="d"/>
                     </beam>
-                    <beam xml:id="m-1232">
+                    <beam>
                       <note xml:id="m-1231" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-1233" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1234" dur="16" oct="3" pname="c" accid.ges="s">
@@ -1817,7 +1817,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1237" n="3">
-                  <layer xml:id="m-1238" n="1">
+                  <layer n="1">
                     <note xml:id="m-1239" dur="4" oct="3" pname="f"/>
                     <note xml:id="m-1240" dur="4" oct="3" pname="g"/>
                     <note xml:id="m-1241" dur="4" oct="3" pname="a"/>
@@ -1842,19 +1842,19 @@
               </measure>
               <measure xml:id="m-1245" n="40">
                 <staff xml:id="m-1247" n="1">
-                  <layer xml:id="m-1248" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1250" n="2">
-                  <layer xml:id="m-1251" n="1">
+                  <layer n="1">
                     <note xml:id="m-1252" dur="4" oct="2" pname="d"/>
                     <rest xml:id="m-1253" dur="4"/>
                     <rest xml:id="m-1254" dur="4"/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1255" n="3">
-                  <layer xml:id="m-1256" n="1">
+                  <layer n="1">
                     <chord xml:id="m-1257" dur="4">
                       <note xml:id="m-1258" dur="4" oct="2" pname="d"/>
                       <note xml:id="m-1259" dur="4" oct="3" pname="d"/>
@@ -1873,76 +1873,76 @@
               <pb n="132" source="#firstEdition" facs="#facs-p296"/>
               <measure xml:id="m-1265" n="41">
                 <staff xml:id="m-1266" n="1">
-                  <layer xml:id="m-1267" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1269" n="2" facs="#facsZone-m-1269">
-                  <layer xml:id="m-1270" n="1">
+                  <layer n="1">
                     <note xml:id="m-1271" dur="4" oct="2" pname="g"/>
                     <rest xml:id="m-1272" dur="4"/>
                     <rest xml:id="m-1273" dur="4"/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1274" n="3">
-                  <layer xml:id="m-1275" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
               </measure>
               <measure xml:id="m-1280" n="42">
                 <staff xml:id="m-1281" n="1">
-                  <layer xml:id="m-1282" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1284" n="2" facs="#facsZone-m-1284">
-                  <layer xml:id="m-1285" n="1">
+                  <layer n="1">
                     <note xml:id="m-1286" dur="4" oct="3" pname="c"/>
                     <rest xml:id="m-1287" dur="4"/>
                     <rest xml:id="m-1288" dur="4"/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1289" n="3">
-                  <layer xml:id="m-1290" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
               </measure>
               <measure xml:id="m-1295" n="43">
                 <staff xml:id="m-1296" n="1">
-                  <layer xml:id="m-1297" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1299" n="2" facs="#facsZone-m-1299">
-                  <layer xml:id="m-1300" n="1">
+                  <layer n="1">
                     <note xml:id="m-1301" dur="4" oct="3" pname="f"/>
                     <rest xml:id="m-1302" dur="4"/>
                     <rest xml:id="m-1303" dur="4"/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1304" n="3">
-                  <layer xml:id="m-1305" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
               </measure>
               <measure xml:id="m-1310" n="44">
                 <staff xml:id="m-1311" n="1">
-                  <layer xml:id="m-1312" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1314" n="2" facs="#facsZone-m-1314">
-                  <layer xml:id="m-1315" n="1">
+                  <layer n="1">
                     <note xml:id="m-1316" dur="4" oct="3" pname="a"/>
                     <note xml:id="m-1317" dur="4" oct="3" pname="b" accid.ges="f"/>
                     <note xml:id="m-1319" dur="4" oct="4" pname="c"/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1320" n="3">
-                  <layer xml:id="m-1321" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -1954,38 +1954,38 @@
               </measure>
               <measure xml:id="m-1326" n="45">
                 <staff xml:id="m-1327" n="1">
-                  <layer xml:id="m-1328" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1330" n="2" facs="#facsZone-m-1330">
-                  <layer xml:id="m-1331" n="1">
+                  <layer n="1">
                     <note xml:id="m-1332" dur="4" oct="4" pname="d"/>
                     <rest xml:id="m-1333" dur="4"/>
                     <rest xml:id="m-1334" dur="4"/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1335" n="3">
-                  <layer xml:id="m-1336" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
               </measure>
               <measure xml:id="m-1341" n="46">
                 <staff xml:id="m-1342" n="1">
-                  <layer xml:id="m-1343" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1345" n="2" facs="#facsZone-m-1345">
-                  <layer xml:id="m-1346" n="1">
+                  <layer n="1">
                     <note xml:id="m-1347" dur="4" oct="3" pname="a"/>
                     <note xml:id="m-1348" dur="4" oct="3" pname="b" accid.ges="f"/>
                     <note xml:id="m-1350" dur="4" oct="4" pname="c"/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1351" n="3">
-                  <layer xml:id="m-1352" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -1997,25 +1997,25 @@
               </measure>
               <measure xml:id="m-1357" n="47">
                 <staff xml:id="m-1358" n="1">
-                  <layer xml:id="m-1359" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1361" n="2" facs="#facsZone-m-1361">
-                  <layer xml:id="m-1362" n="1">
-                    <beam xml:id="m-1364">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1363" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1365" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-1366" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-1367" dur="16" oct="3" pname="b" accid.ges="f"/>
                     </beam>
-                    <beam xml:id="m-1370">
+                    <beam>
                       <note xml:id="m-1369" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-1371" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-1372" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1373" dur="16" oct="3" pname="e"/>
                     </beam>
-                    <beam xml:id="m-1375">
+                    <beam>
                       <note xml:id="m-1374" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1376" dur="16" oct="3" pname="c"/>
                       <note xml:id="m-1377" dur="16" oct="2" pname="b" accid.ges="f"/>
@@ -2024,7 +2024,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1380" n="3">
-                  <layer xml:id="m-1381" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -2032,25 +2032,25 @@
               <sb xml:id="m-1387"/>
               <measure xml:id="m-1386" n="48">
                 <staff xml:id="m-1388" n="1">
-                  <layer xml:id="m-1389" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1391" n="2" facs="#facsZone-m-1391">
-                  <layer xml:id="m-1392" n="1">
-                    <beam xml:id="m-1394">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1393" dur="16" oct="2" pname="g"/>
                       <note xml:id="m-1395" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-1396" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-1397" dur="16" oct="3" pname="g"/>
                     </beam>
-                    <beam xml:id="m-1399">
+                    <beam>
                       <note xml:id="m-1398" dur="16" oct="2" pname="a"/>
                       <note xml:id="m-1400" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-1401" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-1402" dur="16" oct="3" pname="g"/>
                     </beam>
-                    <beam xml:id="m-1405">
+                    <beam>
                       <note xml:id="m-1403" dur="16" oct="2" pname="b">
                         <accid accid="n"/>
                       </note>
@@ -2061,7 +2061,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1409" n="3">
-                  <layer xml:id="m-1410" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -2073,19 +2073,19 @@
               </measure>
               <measure xml:id="m-1415" n="49">
                 <staff xml:id="m-1416" n="1">
-                  <layer xml:id="m-1417" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1419" n="2" facs="#facsZone-m-1419">
-                  <layer xml:id="m-1420" n="1">
-                    <beam xml:id="m-1422">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1421" dur="16" oct="3" pname="c"/>
                       <note xml:id="m-1423" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-1424" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-1425" dur="16" oct="4" pname="c"/>
                     </beam>
-                    <beam xml:id="m-1428">
+                    <beam>
                       <note xml:id="m-1426" dur="16" oct="3" pname="b">
                         <accid accid="n"/>
                       </note>
@@ -2093,7 +2093,7 @@
                       <note xml:id="m-1430" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-1431" dur="16" oct="3" pname="f"/>
                     </beam>
-                    <beam xml:id="m-1433">
+                    <beam>
                       <note xml:id="m-1432" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-1434" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1435" dur="16" oct="3" pname="c"/>
@@ -2108,33 +2108,33 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1439" n="3">
-                  <layer xml:id="m-1440" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
               </measure>
               <measure xml:id="m-1445" n="50">
                 <staff xml:id="m-1446" n="1">
-                  <layer xml:id="m-1447" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1449" n="2" facs="#facsZone-m-1449">
-                  <layer xml:id="m-1450" n="1">
+                  <layer n="1">
                     <clef shape="C" line="3"/>
-                    <beam xml:id="m-1452">
+                    <beam>
                       <note xml:id="m-1451" dur="16" oct="4" pname="a"/>
                       <note xml:id="m-1453" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-1454" dur="16" oct="4" pname="a"/>
                       <note xml:id="m-1455" dur="16" oct="4" pname="c"/>
                     </beam>
-                    <beam xml:id="m-1457">
+                    <beam>
                       <note xml:id="m-1456" dur="16" oct="4" pname="a"/>
                       <note xml:id="m-1458" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-1459" dur="16" oct="4" pname="a"/>
                       <note xml:id="m-1460" dur="16" oct="4" pname="c"/>
                     </beam>
-                    <beam xml:id="m-1462">
+                    <beam>
                       <note xml:id="m-1461" dur="16" oct="4" pname="a"/>
                       <note xml:id="m-1463" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-1464" dur="16" oct="4" pname="a"/>
@@ -2143,7 +2143,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1466" n="3">
-                  <layer xml:id="m-1467" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -2156,27 +2156,27 @@
               </measure>
               <measure xml:id="m-1472" n="51">
                 <staff xml:id="m-1475" n="1">
-                  <layer xml:id="m-1476" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1478" n="2" facs="#facsZone-m-1478">
-                  <layer xml:id="m-1479" n="1">
-                    <beam xml:id="m-1481">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1480" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-1482" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-1483" dur="16" oct="4" pname="a"/>
                       <note xml:id="m-1484" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-1485" dur="16" oct="4" pname="a"/>
                     </beam>
-                    <beam xml:id="m-1487">
+                    <beam>
                       <note xml:id="m-1486" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-1488" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-1489" dur="16" oct="4" pname="a"/>
                       <note xml:id="m-1490" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-1491" dur="16" oct="4" pname="a"/>
                     </beam>
-                    <beam xml:id="m-1493">
+                    <beam>
                       <note xml:id="m-1492" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-1494" dur="32" oct="4" pname="g"/>
                       <note xml:id="m-1495" dur="16" oct="4" pname="a"/>
@@ -2186,7 +2186,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1498" n="3">
-                  <layer xml:id="m-1499" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -2198,25 +2198,25 @@
               </measure>
               <measure xml:id="m-1504" n="52">
                 <staff xml:id="m-1505" n="1">
-                  <layer xml:id="m-1506" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1508" n="2" facs="#facsZone-m-1508">
-                  <layer xml:id="m-1509" n="1">
-                    <beam xml:id="m-1511">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1510" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-1512" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1513" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-1514" dur="16" oct="3" pname="b" accid.ges="f"/>
                     </beam>
-                    <beam xml:id="m-1517">
+                    <beam>
                       <note xml:id="m-1516" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-1518" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1519" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-1520" dur="16" oct="3" pname="b" accid.ges="f"/>
                     </beam>
-                    <beam xml:id="m-1523">
+                    <beam>
                       <note xml:id="m-1522" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-1524" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1525" dur="16" oct="4" pname="g"/>
@@ -2225,7 +2225,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1528" n="3">
-                  <layer xml:id="m-1529" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -2238,27 +2238,27 @@
               </measure>
               <measure xml:id="m-1534" n="53">
                 <staff xml:id="m-1535" n="1">
-                  <layer xml:id="m-1536" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1538" n="2" facs="#facsZone-m-1538">
-                  <layer xml:id="m-1539" n="1">
-                    <beam xml:id="m-1541">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1540" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-1542" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-1543" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-1544" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-1545" dur="16" oct="4" pname="g"/>
                     </beam>
-                    <beam xml:id="m-1547">
+                    <beam>
                       <note xml:id="m-1546" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-1548" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-1549" dur="16" oct="4" pname="g"/>
                       <note xml:id="m-1550" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-1551" dur="16" oct="4" pname="g"/>
                     </beam>
-                    <beam xml:id="m-1553">
+                    <beam>
                       <note xml:id="m-1552" dur="32" oct="4" pname="e"/>
                       <note xml:id="m-1554" dur="32" oct="4" pname="f"/>
                       <note xml:id="m-1555" dur="16" oct="4" pname="g"/>
@@ -2268,7 +2268,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1558" n="3">
-                  <layer xml:id="m-1559" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -2280,25 +2280,25 @@
               </measure>
               <measure xml:id="m-1564" n="54">
                 <staff xml:id="m-1565" n="1">
-                  <layer xml:id="m-1566" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1568" n="2" facs="#facsZone-m-1568">
-                  <layer xml:id="m-1569" n="1">
-                    <beam xml:id="m-1571">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1570" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1572" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-1573" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1574" dur="16" oct="3" pname="a"/>
                     </beam>
-                    <beam xml:id="m-1576">
+                    <beam>
                       <note xml:id="m-1575" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1577" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-1578" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1579" dur="16" oct="3" pname="b" accid.ges="f"/>
                     </beam>
-                    <beam xml:id="m-1582">
+                    <beam>
                       <note xml:id="m-1581" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1583" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-1584" dur="16" oct="4" pname="f"/>
@@ -2307,7 +2307,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1586" n="3">
-                  <layer xml:id="m-1587" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -2326,25 +2326,25 @@
               </measure>
               <measure xml:id="m-1592" n="55">
                 <staff xml:id="m-1594" n="1">
-                  <layer xml:id="m-1595" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1597" n="2" facs="#facsZone-m-1597">
-                  <layer xml:id="m-1598" n="1">
-                    <beam xml:id="m-1600">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1599" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1601" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-1602" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1603" dur="16" oct="4" pname="d"/>
                     </beam>
-                    <beam xml:id="m-1605">
+                    <beam>
                       <note xml:id="m-1604" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1606" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-1607" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1608" dur="16" oct="4" pname="d"/>
                     </beam>
-                    <beam xml:id="m-1610">
+                    <beam>
                       <note xml:id="m-1609" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1611" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-1612" dur="16" oct="4" pname="f"/>
@@ -2354,32 +2354,32 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1615" n="3">
-                  <layer xml:id="m-1616" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
               </measure>
               <measure xml:id="m-1621" n="56">
                 <staff xml:id="m-1622" n="1">
-                  <layer xml:id="m-1623" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1625" n="2" facs="#facsZone-m-1625">
-                  <layer xml:id="m-1626" n="1">
-                    <beam xml:id="m-1628">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1627" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1629" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-1630" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1631" dur="16" oct="2" pname="a"/>
                     </beam>
-                    <beam xml:id="m-1633">
+                    <beam>
                       <note xml:id="m-1632" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1634" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-1635" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1636" dur="16" oct="2" pname="b" accid.ges="f"/>
                     </beam>
-                    <beam xml:id="m-1639">
+                    <beam>
                       <note xml:id="m-1638" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1640" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-1641" dur="16" oct="3" pname="f"/>
@@ -2388,7 +2388,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1643" n="3">
-                  <layer xml:id="m-1644" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -2407,27 +2407,27 @@
               </measure>
               <measure xml:id="m-1649" n="57">
                 <staff xml:id="m-1650" n="1">
-                  <layer xml:id="m-1651" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1653" n="2" facs="#facsZone-m-1653">
-                  <layer xml:id="m-1654" n="1">
-                    <beam xml:id="m-1656">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1655" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1657" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-1658" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1659" dur="16" oct="3" pname="d"/>
                     </beam>
                     <clef shape="C" line="3"/>
-                    <beam xml:id="m-1661">
+                    <beam>
                       <note xml:id="m-1660" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1662" dur="16" oct="4" pname="e"/>
                       <note xml:id="m-1663" dur="16" oct="4" pname="f"/>
                       <note xml:id="m-1664" dur="16" oct="4" pname="d"/>
                     </beam>
                     <clef shape="F" line="4"/>
-                    <beam xml:id="m-1666">
+                    <beam>
                       <note xml:id="m-1665" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1667" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-1668" dur="16" oct="3" pname="f"/>
@@ -2436,7 +2436,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1670" n="3">
-                  <layer xml:id="m-1671" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -2448,25 +2448,25 @@
               </measure>
               <measure xml:id="m-1676" n="58">
                 <staff xml:id="m-1677" n="1">
-                  <layer xml:id="m-1678" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1680" n="2" facs="#facsZone-m-1680">
-                  <layer xml:id="m-1681" n="1">
-                    <beam xml:id="m-1683">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1682" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1684" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-1685" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1686" dur="16" oct="2" pname="a"/>
                     </beam>
-                    <beam xml:id="m-1688">
+                    <beam>
                       <note xml:id="m-1687" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1689" dur="16" oct="3" pname="e"/>
                       <note xml:id="m-1690" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1691" dur="16" oct="2" pname="b" accid.ges="f"/>
                     </beam>
-                    <beam xml:id="m-1694">
+                    <beam>
                       <note xml:id="m-1693" dur="32" oct="3" pname="e"/>
                       <note xml:id="m-1695" dur="32" oct="3" pname="f"/>
                       <note xml:id="m-1696" dur="16" oct="3" pname="g"/>
@@ -2476,7 +2476,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1699" n="3">
-                  <layer xml:id="m-1700" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -2494,50 +2494,50 @@
               </measure>
               <measure xml:id="m-1705" n="59">
                 <staff xml:id="m-1707" n="1">
-                  <layer xml:id="m-1708" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1710" n="2" facs="#facsZone-m-1710">
-                  <layer xml:id="m-1711" n="1">
+                  <layer n="1">
                     <note xml:id="m-1712" dur="8" oct="3" pname="f"/>
                     <note xml:id="m-1713" dur="4" oct="2" pname="f"/>
                     <note xml:id="m-1714" dur="8" oct="3" pname="f"/>
-                    <beam xml:id="m-1716">
+                    <beam>
                       <note xml:id="m-1715" dur="8" oct="3" pname="g"/>
                       <note xml:id="m-1717" dur="8" oct="3" pname="a"/>
                     </beam>
                   </layer>
                 </staff>
                 <staff xml:id="m-1718" n="3">
-                  <layer xml:id="m-1719" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
               </measure>
               <measure xml:id="m-1724" n="60">
                 <staff xml:id="m-1725" n="1">
-                  <layer xml:id="m-1726" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1728" n="2" facs="#facsZone-m-1728">
-                  <layer xml:id="m-1729" n="1">
-                    <beam xml:id="m-1732">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1730" dur="32" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-1733" dur="32" oct="4" pname="c"/>
                       <note xml:id="m-1734" dur="16" oct="4" pname="d"/>
                       <note xml:id="m-1735" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-1736" dur="16" oct="3" pname="b" accid.ges="f"/>
                     </beam>
-                    <beam xml:id="m-1739">
+                    <beam>
                       <note xml:id="m-1738" dur="32" oct="3" pname="a"/>
                       <note xml:id="m-1740" dur="32" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-1742" dur="16" oct="4" pname="c"/>
                       <note xml:id="m-1743" dur="16" oct="3" pname="b" accid.ges="f"/>
                       <note xml:id="m-1745" dur="16" oct="3" pname="a"/>
                     </beam>
-                    <beam xml:id="m-1747">
+                    <beam>
                       <note xml:id="m-1746" dur="32" oct="3" pname="g"/>
                       <note xml:id="m-1748" dur="32" oct="3" pname="a"/>
                       <note xml:id="m-1749" dur="16" oct="3" pname="b" accid.ges="f"/>
@@ -2547,7 +2547,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1753" n="3">
-                  <layer xml:id="m-1754" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -2564,27 +2564,27 @@
               </measure>
               <measure xml:id="m-1759" n="61">
                 <staff xml:id="m-1760" n="1">
-                  <layer xml:id="m-1761" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1763" n="2" facs="#facsZone-m-1763">
-                  <layer xml:id="m-1764" n="1">
-                    <beam xml:id="m-1766">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1765" dur="32" oct="3" pname="f"/>
                       <note xml:id="m-1767" dur="32" oct="3" pname="g"/>
                       <note xml:id="m-1768" dur="16" oct="3" pname="a"/>
                       <note xml:id="m-1769" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-1770" dur="16" oct="3" pname="f"/>
                     </beam>
-                    <beam xml:id="m-1772">
+                    <beam>
                       <note xml:id="m-1771" dur="32" oct="3" pname="e"/>
                       <note xml:id="m-1773" dur="32" oct="3" pname="f"/>
                       <note xml:id="m-1774" dur="16" oct="3" pname="g"/>
                       <note xml:id="m-1775" dur="16" oct="3" pname="f"/>
                       <note xml:id="m-1776" dur="16" oct="3" pname="e"/>
                     </beam>
-                    <beam xml:id="m-1778">
+                    <beam>
                       <note xml:id="m-1777" dur="32" oct="3" pname="d"/>
                       <note xml:id="m-1779" dur="32" oct="3" pname="e"/>
                       <note xml:id="m-1780" dur="16" oct="3" pname="f"/>
@@ -2594,7 +2594,7 @@
                   </layer>
                 </staff>
                 <staff xml:id="m-1783" n="3">
-                  <layer xml:id="m-1784" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -2611,29 +2611,29 @@
               </measure>
               <measure xml:id="m-1789" n="62">
                 <staff xml:id="m-1790" n="1">
-                  <layer xml:id="m-1791" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1793" n="2" facs="#facsZone-m-1793">
-                  <layer xml:id="m-1794" n="1">
-                    <beam xml:id="m-1796">
+                  <layer n="1">
+                    <beam>
                       <note xml:id="m-1795" dur="8" oct="3" pname="c"/>
                       <note xml:id="m-1797" dur="16" oct="3" pname="d"/>
                       <note xml:id="m-1798" dur="16" oct="3" pname="e"/>
                     </beam>
-                    <beam xml:id="m-1800">
+                    <beam>
                       <note xml:id="m-1799" dur="8" oct="3" pname="f"/>
                       <note xml:id="m-1801" dur="8" oct="2" pname="b" accid.ges="f"/>
                     </beam>
-                    <beam xml:id="m-1804">
+                    <beam>
                       <note xml:id="m-1803" dur="8" oct="3" pname="c"/>
                       <note xml:id="m-1805" dur="8" oct="2" pname="c"/>
                     </beam>
                   </layer>
                 </staff>
                 <staff xml:id="m-1806" n="3">
-                  <layer xml:id="m-1807" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
@@ -2656,17 +2656,17 @@
               </measure>
               <measure xml:id="m-1812" n="63" right="end">
                 <staff xml:id="m-1813" n="1">
-                  <layer xml:id="m-1814" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1816" n="2" facs="#facsZone-m-1816">
-                  <layer xml:id="m-1817" n="1">
+                  <layer n="1">
                     <note xml:id="m-1818" dots="1" dur="2" oct="2" pname="f"/>
                   </layer>
                 </staff>
                 <staff xml:id="m-1819" n="3">
-                  <layer xml:id="m-1820" n="1">
+                  <layer n="1">
                     <mSpace/>
                   </layer>
                 </staff>


### PR DESCRIPTION
This PR addresses the examples from Prob-Stück 1 to 6 with: 
* encoding accidentals as `orig` 
* adding critical apparatus with differences between editions 1 and 2
* fix typos
* adding titles
* linking to score via `@corresp`

NB: Verovio should be updated to latest stable for correct rendering of custodes with F clef. 