### PR TITLE
improve examples for PS 7–11

### DIFF
--- a/encodings/1/mattheson/comments_1st.xml
+++ b/encodings/1/mattheson/comments_1st.xml
@@ -88,7 +88,7 @@
     <body>
       <div>
         <p>
-          <abbr>vid.</abbr> <persName ref="#ed_fy5_r5x_qlb">Keiſers</persName> <name type="musicalWork" ref="#ed_sbs_x2c_tlb">Erleſene
+          <abbr>vid.</abbr> <persName corresp="#ed_fy5_r5x_qlb">Keiſers</persName> <name type="musicalWork" ref="#ed_sbs_x2c_tlb">Erleſene
           <lb/> Sätze</name> <hi rendition="#aq">p. 50</hi>.
         </p>
       </div>

--- a/encodings/1/mattheson/comments_1st.xml
+++ b/encodings/1/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Erstes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/1/mattheson/comments_de.xml
+++ b/encodings/1/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Erstes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/1/mattheson/comments_en.xml
+++ b/encodings/1/mattheson/comments_en.xml
@@ -6,16 +6,16 @@
         <title type="part">Mattheson: Der Ober-Classe Erstes Probstück (english translation)</title>
         <editor role="translator">
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/10/mattheson/aria-marcello.xml
+++ b/encodings/10/mattheson/aria-marcello.xml
@@ -67,642 +67,644 @@
                             </staffDef>
                         </staffGrp>
                     </scoreDef>
-                    <section xml:id="section-0000001262235770">
+                    <section xml:id="section-1262235770">
                         <pb source="#secondEdition" n="356" facs="#graphic_01DRXXBW7CCJ95KSPMFMF07877" />
-                        <measure xml:id="measure-0000000685332484" metcon="false">
-                            <staff xml:id="staff-0000001631678142" n="1">
-                                <layer xml:id="layer-0000000004586479" n="1">
-                                    <rest xml:id="rest-0000000111549972" dur="8" />
+                        <measure xml:id="measure-0685332484" metcon="false">
+                            <staff xml:id="staff-1631678142" n="1">
+                                <layer xml:id="layer-0004586479" n="1">
+                                    <rest xml:id="rest-0111549972" dur="8" />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001265410568" n="2">
-                                <layer xml:id="layer-0000000463178461" n="1">
-                                    <note xml:id="note-0000001732073373" dur="8" oct="3" pname="c" />
+                            <staff xml:id="staff-1265410568" n="2">
+                                <layer xml:id="layer-0463178461" n="1">
+                                    <note xml:id="note-1732073373" dur="8" oct="3" pname="c" />
                                 </layer>
                             </staff>
-                            <tempo xml:id="tempo-0000001766313299" staff="2" tstamp="1" place="above">Con affeto</tempo>
+                            <tempo xml:id="tempo-1766313299" staff="2" tstamp="1" place="above">Con affeto</tempo>
                         </measure>
-                        <measure xml:id="measure-0000000503792307" n="1">
-                            <staff xml:id="staff-0000000841535946" n="1">
-                                <layer xml:id="layer-0000001674101986" n="1">
+                        <measure xml:id="measure-0503792307" n="1">
+                            <staff xml:id="staff-0841535946" n="1">
+                                <layer xml:id="layer-1674101986" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000582821515" n="2">
-                                <layer xml:id="layer-0000000454242567" n="1">
+                            <staff xml:id="staff-0582821515" n="2">
+                                <layer xml:id="layer-0454242567" n="1">
                                     <beam>
-                                        <note xml:id="note-0000002128011605" dur="16" oct="3" pname="f" />
-                                        <note xml:id="note-0000002102093285" dur="16" oct="3" pname="g" />
-                                        <note xml:id="note-0000000814677567" dur="8" oct="3" pname="a" accid.ges="f" />
-                                        <note xml:id="note-0000002100023888" dur="8" oct="3" pname="g" />
+                                        <note xml:id="note-2128011605" dur="16" oct="3" pname="f" />
+                                        <note xml:id="note-2102093285" dur="16" oct="3" pname="g" />
+                                        <note xml:id="note-0814677567" dur="8" oct="3" pname="a" accid.ges="f" />
+                                        <note xml:id="note-2100023888" dur="8" oct="3" pname="g" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000814208952" n="2">
-                            <staff xml:id="staff-0000000124009092" n="1">
-                                <layer xml:id="layer-0000000869910628" n="1">
+                        <measure xml:id="measure-0814208952" n="2">
+                            <staff xml:id="staff-0124009092" n="1">
+                                <layer xml:id="layer-0869910628" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000594649208" n="2">
-                                <layer xml:id="layer-0000000798874014" n="1">
+                            <staff xml:id="staff-0594649208" n="2">
+                                <layer xml:id="layer-0798874014" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001730257493" dur="16" oct="3" pname="f" />
-                                        <note xml:id="note-0000001324506934" dur="16" oct="3" pname="g" />
-                                        <note xml:id="note-0000000186538147" dur="8" oct="3" pname="a" accid.ges="f" />
-                                        <note xml:id="note-0000001424310187" dur="8" oct="3" pname="g" />
+                                        <note xml:id="note-1730257493" dur="16" oct="3" pname="f" />
+                                        <note xml:id="note-1324506934" dur="16" oct="3" pname="g" />
+                                        <note xml:id="note-0186538147" dur="8" oct="3" pname="a" accid.ges="f" />
+                                        <note xml:id="note-1424310187" dur="8" oct="3" pname="g" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000892070246" n="3">
-                            <staff xml:id="staff-0000001318092288" n="1">
-                                <layer xml:id="layer-0000001993117937" n="1">
+                        <measure xml:id="measure-0892070246" n="3">
+                            <staff xml:id="staff-1318092288" n="1">
+                                <layer xml:id="layer-1993117937" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000002133459524" n="2">
-                                <layer xml:id="layer-0000001092002832" n="1">
+                            <staff xml:id="staff-2133459524" n="2">
+                                <layer xml:id="layer-1092002832" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000187882293" dur="8" oct="3" pname="f" />
-                                        <note xml:id="note-0000001515168038" dur="8" oct="3" pname="d">
+                                        <note xml:id="note-0187882293" dur="8" oct="3" pname="f" />
+                                        <note xml:id="note-1515168038" dur="8" oct="3" pname="d">
                                             <accid accid="f" />
                                         </note>
-                                        <note xml:id="note-0000001139969245" dur="8" oct="2" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1139969245" dur="8" oct="2" pname="b" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000184820604" n="4">
-                            <staff xml:id="staff-0000000052604608" n="1">
-                                <layer xml:id="layer-0000001341974580" n="1">
+                        <measure xml:id="measure-0184820604" n="4">
+                            <staff xml:id="staff-0052604608" n="1">
+                                <layer xml:id="layer-1341974580" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001626142748" n="2">
-                                <layer xml:id="layer-0000000070108352" n="1">
+                            <staff xml:id="staff-1626142748" n="2">
+                                <layer xml:id="layer-0070108352" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000603965370" dur="8" oct="3" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000001654319213" dur="8" oct="3" pname="a" accid.ges="f" />
-                                        <note xml:id="note-0000000080564689" dur="8" oct="3" pname="g" />
+                                        <note xml:id="note-0603965370" dur="8" oct="3" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1654319213" dur="8" oct="3" pname="a" accid.ges="f" />
+                                        <note xml:id="note-0080564689" dur="8" oct="3" pname="g" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000234850136" n="5">
-                            <staff xml:id="staff-0000000875962949" n="1">
-                                <layer xml:id="layer-0000001384555886" n="1">
+                        <measure xml:id="measure-0234850136" n="5">
+                            <staff xml:id="staff-0875962949" n="1">
+                                <layer xml:id="layer-1384555886" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001752426652" n="2">
-                                <layer xml:id="layer-0000001509749310" n="1">
+                            <staff xml:id="staff-1752426652" n="2">
+                                <layer xml:id="layer-1509749310" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001454607302" dur="8" oct="3" pname="a" accid.ges="f" />
-                                        <note xml:id="note-0000001110048415" dur="8" oct="3" pname="g" />
-                                        <note xml:id="note-0000000264105089" dur="8" oct="3" pname="f" />
+                                        <note xml:id="note-1454607302" dur="8" oct="3" pname="a" accid.ges="f" />
+                                        <note xml:id="note-1110048415" dur="8" oct="3" pname="g" />
+                                        <note xml:id="note-0264105089" dur="8" oct="3" pname="f" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001105617309" n="6">
-                            <staff xml:id="staff-0000002013050235" n="1">
-                                <layer xml:id="layer-0000001065658964" n="1">
+                        <measure xml:id="measure-1105617309" n="6">
+                            <staff xml:id="staff-2013050235" n="1">
+                                <layer xml:id="layer-1065658964" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000278278272" n="2">
-                                <layer xml:id="layer-0000000051941078" n="1">
-                                    <note xml:id="note-0000000804254868" dur="4" oct="3" pname="c" />
-                                    <note xml:id="note-0000000731511691" dur="8" oct="4" pname="c" />
+                            <staff xml:id="staff-0278278272" n="2">
+                                <layer xml:id="layer-0051941078" n="1">
+                                    <note xml:id="note-0804254868" dur="4" oct="3" pname="c" />
+                                    <note xml:id="note-0731511691" dur="8" oct="4" pname="c" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001827916444" n="7">
-                            <staff xml:id="staff-0000000373587883" n="1">
-                                <layer xml:id="layer-0000001809149387" n="1">
+                        <measure xml:id="measure-1827916444" n="7">
+                            <staff xml:id="staff-0373587883" n="1">
+                                <layer xml:id="layer-1809149387" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001057751334" n="2">
-                                <layer xml:id="layer-0000000760865189" n="1">
+                            <staff xml:id="staff-1057751334" n="2">
+                                <layer xml:id="layer-0760865189" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001096030956" dur="8" oct="4" pname="d">
+                                        <note xml:id="note-1096030956" dur="8" oct="4" pname="d">
                                             <accid accid="f" />
                                         </note>
-                                        <note xml:id="note-0000001605096871" dur="8" oct="3" pname="e" accid.ges="f" />
-                                        <note xml:id="note-0000000819250794" dur="8" oct="4" pname="d" accid.ges="f" />
+                                        <note xml:id="note-1605096871" dur="8" oct="3" pname="e" accid.ges="f" />
+                                        <note xml:id="note-0819250794" dur="8" oct="4" pname="d" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
                         <sb source="#secondEdition" />
-                        <measure xml:id="measure-0000001219466359" n="8">
-                            <staff xml:id="staff-0000000653887933" n="1">
-                                <layer xml:id="layer-0000000267988018" n="1">
+                        <measure xml:id="measure-1219466359" n="8">
+                            <staff xml:id="staff-0653887933" n="1">
+                                <layer xml:id="layer-0267988018" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001034058815" n="2">
-                                <layer xml:id="layer-0000000605844789" n="1">
+                            <staff xml:id="staff-1034058815" n="2">
+                                <layer xml:id="layer-0605844789" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001035035763" dur="8" oct="4" pname="c" />
-                                        <note xml:id="note-0000000771007576" dur="8" oct="3" pname="d">
+                                        <note xml:id="note-1035035763" dur="8" oct="4" pname="c" />
+                                        <note xml:id="note-0771007576" dur="8" oct="3" pname="d">
                                             <accid accid="f" />
                                         </note>
-                                        <note xml:id="note-0000001177515414" dur="8" oct="4" pname="c" />
+                                        <note xml:id="note-1177515414" dur="8" oct="4" pname="c" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001708734092" n="9">
-                            <staff xml:id="staff-0000000358244741" n="1">
-                                <layer xml:id="layer-0000000715558665" n="1">
+                        <measure xml:id="measure-1708734092" n="9">
+                            <staff xml:id="staff-0358244741" n="1">
+                                <layer xml:id="layer-0715558665" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001729189062" n="2">
-                                <layer xml:id="layer-0000000854680860" n="1">
+                            <staff xml:id="staff-1729189062" n="2">
+                                <layer xml:id="layer-0854680860" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001730265480" dur="8" oct="3" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000001948399246" dur="8" oct="3" pname="c" />
-                                        <note xml:id="note-0000000552284967" dur="8" oct="3" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1730265480" dur="8" oct="3" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1948399246" dur="8" oct="3" pname="c" />
+                                        <note xml:id="note-0552284967" dur="8" oct="3" pname="b" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000917306217" n="10">
-                            <staff xml:id="staff-0000000034107353" n="1">
-                                <layer xml:id="layer-0000000879573650" n="1">
+                        <measure xml:id="measure-0917306217" n="10">
+                            <staff xml:id="staff-0034107353" n="1">
+                                <layer xml:id="layer-0879573650" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001912009346" n="2">
-                                <layer xml:id="layer-0000001757610433" n="1">
+                            <staff xml:id="staff-1912009346" n="2">
+                                <layer xml:id="layer-1757610433" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001504938156" dur="8" oct="3" pname="a" accid.ges="f" />
-                                        <note xml:id="note-0000001748291132" dur="8" oct="2" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000001312314978" dur="8" oct="3" pname="a" accid.ges="f" />
+                                        <note xml:id="note-1504938156" dur="8" oct="3" pname="a" accid.ges="f" />
+                                        <note xml:id="note-1748291132" dur="8" oct="2" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1312314978" dur="8" oct="3" pname="a" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000050073705" n="11">
-                            <staff xml:id="staff-0000002028657876" n="1">
-                                <layer xml:id="layer-0000000343228408" n="1">
+                        <measure xml:id="measure-0050073705" n="11">
+                            <staff xml:id="staff-2028657876" n="1">
+                                <layer xml:id="layer-0343228408" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000980062947" n="2">
-                                <layer xml:id="layer-0000001333299250" n="1">
-                                    <note xml:id="note-0000000844274158" dots="1" dur="4" oct="3" pname="g">
+                            <staff xml:id="staff-0980062947" n="2">
+                                <layer xml:id="layer-1333299250" n="1">
+                                    <note xml:id="note-0844274158" dots="1" dur="4" oct="3" pname="g">
                                         <accid accid="f" />
                                     </note>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000384886776" n="12">
-                            <staff xml:id="staff-0000001857173831" n="1">
-                                <layer xml:id="layer-0000001666738875" n="1">
+                        <measure xml:id="measure-0384886776" n="12">
+                            <staff xml:id="staff-1857173831" n="1">
+                                <layer xml:id="layer-1666738875" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000914446367" n="2">
-                                <layer xml:id="layer-0000000374476540" n="1">
+                            <staff xml:id="staff-0914446367" n="2">
+                                <layer xml:id="layer-0374476540" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001273066016" dur="8" oct="3" pname="g" accid.ges="f">
-                                            <reg resp="#rettinghaus">
-                                                <accid accid="f" enclose="brack" />
-                                            </reg>
+                                        <note xml:id="note-1273066016" dur="8" oct="3" pname="g" accid.ges="f">
+                                            <supplied resp="#rettinghaus">
+                                                <reg>
+                                                    <accid accid="f" />
+                                                </reg>
+                                            </supplied>
                                         </note>
-                                        <note xml:id="note-0000000482508617" dur="8" oct="3" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000001735864794" dur="8" oct="4" pname="d">
+                                        <note xml:id="note-0482508617" dur="8" oct="3" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1735864794" dur="8" oct="4" pname="d">
                                             <accid accid="f" />
                                         </note>
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000691667139" n="13">
-                            <staff xml:id="staff-0000000281557918" n="1">
-                                <layer xml:id="layer-0000000234096654" n="1">
+                        <measure xml:id="measure-0691667139" n="13">
+                            <staff xml:id="staff-0281557918" n="1">
+                                <layer xml:id="layer-0234096654" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000580173841" n="2">
-                                <layer xml:id="layer-0000001103122263" n="1">
+                            <staff xml:id="staff-0580173841" n="2">
+                                <layer xml:id="layer-1103122263" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001454015941" dur="8" oct="3" pname="e">
+                                        <note xml:id="note-1454015941" dur="8" oct="3" pname="e">
                                             <accid accid="n" />
                                         </note>
-                                        <note xml:id="note-0000000104511024" dur="8" oct="3" pname="f" />
-                                        <note xml:id="note-0000000466274151" dur="8" oct="2" pname="a" accid.ges="f" />
+                                        <note xml:id="note-0104511024" dur="8" oct="3" pname="f" />
+                                        <note xml:id="note-0466274151" dur="8" oct="2" pname="a" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000661012659" n="14">
-                            <staff xml:id="staff-0000000023764371" n="1">
-                                <layer xml:id="layer-0000001327831402" n="1">
+                        <measure xml:id="measure-0661012659" n="14">
+                            <staff xml:id="staff-0023764371" n="1">
+                                <layer xml:id="layer-1327831402" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000002132442505" n="2">
-                                <layer xml:id="layer-0000001993129782" n="1">
-                                    <note xml:id="note-0000000764322003" dur="8" oct="2" pname="b" accid.ges="f" />
-                                    <note xml:id="note-0000001570520491" dur="4" oct="3" pname="c" />
+                            <staff xml:id="staff-2132442505" n="2">
+                                <layer xml:id="layer-1993129782" n="1">
+                                    <note xml:id="note-0764322003" dur="8" oct="2" pname="b" accid.ges="f" />
+                                    <note xml:id="note-1570520491" dur="4" oct="3" pname="c" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000108529181" n="15">
-                            <staff xml:id="staff-0000001637690422" n="1">
-                                <layer xml:id="layer-0000001009470934" n="1">
-                                    <rest xml:id="rest-0000001598037749" dur="8" />
-                                    <rest xml:id="rest-0000001961033275" dur="8" />
-                                    <note xml:id="note-0000001814790501" dur="8" oct="4" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000001880076294" n="1">
+                        <measure xml:id="measure-0108529181" n="15">
+                            <staff xml:id="staff-1637690422" n="1">
+                                <layer xml:id="layer-1009470934" n="1">
+                                    <rest xml:id="rest-1598037749" dur="8" />
+                                    <rest xml:id="rest-1961033275" dur="8" />
+                                    <note xml:id="note-1814790501" dur="8" oct="4" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-1880076294" n="1">
                                             <syl con="s">Col</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000745841914" n="2">
-                                <layer xml:id="layer-0000000971128383" n="1">
-                                    <note xml:id="note-0000001240241568" dur="4" oct="2" pname="f" />
-                                    <rest xml:id="rest-0000000596986468" dur="8" />
+                            <staff xml:id="staff-0745841914" n="2">
+                                <layer xml:id="layer-0971128383" n="1">
+                                    <note xml:id="note-1240241568" dur="4" oct="2" pname="f" />
+                                    <rest xml:id="rest-0596986468" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
                         <sb source="#secondEdition" />
-                        <measure xml:id="measure-0000002145318766" n="16">
-                            <staff xml:id="staff-0000002103072538" n="1">
-                                <layer xml:id="layer-0000001480853914" n="1">
+                        <measure xml:id="measure-2145318766" n="16">
+                            <staff xml:id="staff-2103072538" n="1">
+                                <layer xml:id="layer-1480853914" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001215927025" dots="1" dur="16" oct="4" pname="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000001208684823" n="1">
+                                        <note xml:id="note-1215927025" dots="1" dur="16" oct="4" pname="f">
+                                            <verse xml:lang="ita" xml:id="verse-1208684823" n="1">
                                                 <syl con="d" wordpos="i">pian</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000002030691583" dur="32" oct="4" pname="g" />
-                                        <note xml:id="note-0000001581332435" dur="8" oct="4" pname="a" accid.ges="f" />
+                                        <note xml:id="note-2030691583" dur="32" oct="4" pname="g" />
+                                        <note xml:id="note-1581332435" dur="8" oct="4" pname="a" accid.ges="f" />
                                     </beam>
-                                    <note xml:id="note-0000000929966809" dur="8" oct="4" pname="g">
-                                        <verse xml:lang="ita" xml:id="verse-0000001768131531" n="1">
+                                    <note xml:id="note-0929966809" dur="8" oct="4" pname="g">
+                                        <verse xml:lang="ita" xml:id="verse-1768131531" n="1">
                                             <syl con="b" wordpos="t">to</syl>
                                             <syl con="s">e</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000967910291" n="2">
-                                <layer xml:id="layer-0000001551135006" n="1">
-                                    <note xml:id="note-0000001581281908" dur="4" oct="3" pname="f" />
-                                    <rest xml:id="rest-0000000612855549" dur="8" />
+                            <staff xml:id="staff-0967910291" n="2">
+                                <layer xml:id="layer-1551135006" n="1">
+                                    <note xml:id="note-1581281908" dur="4" oct="3" pname="f" />
+                                    <rest xml:id="rest-0612855549" dur="8" />
                                 </layer>
                             </staff>
-                            <slur xml:id="slur-0000001517198506" startid="#note-0000001215927025" endid="#note-0000001581332435" />
+                            <slur xml:id="slur-1517198506" startid="#note-1215927025" endid="#note-1581332435" />
                         </measure>
-                        <measure xml:id="measure-0000000756645138" n="17">
-                            <staff xml:id="staff-0000000645647440" n="1">
-                                <layer xml:id="layer-0000000514225961" n="1">
+                        <measure xml:id="measure-0756645138" n="17">
+                            <staff xml:id="staff-0645647440" n="1">
+                                <layer xml:id="layer-0514225961" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000932728561" dots="1" dur="16" oct="4" pname="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000002070612501" n="1">
+                                        <note xml:id="note-0932728561" dots="1" dur="16" oct="4" pname="f">
+                                            <verse xml:lang="ita" xml:id="verse-2070612501" n="1">
                                                 <syl con="s">coi</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000737822980" dur="32" oct="4" pname="g" />
-                                        <note xml:id="note-0000000224648973" dur="8" oct="4" pname="a" accid.ges="f" />
+                                        <note xml:id="note-0737822980" dur="32" oct="4" pname="g" />
+                                        <note xml:id="note-0224648973" dur="8" oct="4" pname="a" accid.ges="f" />
                                     </beam>
-                                    <note xml:id="note-0000001139719046" dur="8" oct="4" pname="g">
-                                        <verse xml:lang="ita" xml:id="verse-0000001063750461" n="1">
+                                    <note xml:id="note-1139719046" dur="8" oct="4" pname="g">
+                                        <verse xml:lang="ita" xml:id="verse-1063750461" n="1">
                                             <syl con="d" wordpos="i">so</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000378076191" n="2">
-                                <layer xml:id="layer-0000002091756045" n="1">
-                                    <note xml:id="note-0000001331829483" dur="4" oct="3" pname="e" accid.ges="f" />
-                                    <rest xml:id="rest-0000001529719275" dur="8" />
+                            <staff xml:id="staff-0378076191" n="2">
+                                <layer xml:id="layer-2091756045" n="1">
+                                    <note xml:id="note-1331829483" dur="4" oct="3" pname="e" accid.ges="f" />
+                                    <rest xml:id="rest-1529719275" dur="8" />
                                 </layer>
                             </staff>
-                            <slur xml:id="slur-0000002095491120" startid="#note-0000000932728561" endid="#note-0000000224648973" />
+                            <slur xml:id="slur-2095491120" startid="#note-0932728561" endid="#note-0224648973" />
                         </measure>
-                        <measure xml:id="measure-0000001917091425" n="18">
-                            <staff xml:id="staff-0000001795211292" n="1">
-                                <layer xml:id="layer-0000001984284969" n="1">
-                                    <note xml:id="note-0000000892815219" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000002121608490" n="1">
+                        <measure xml:id="measure-1917091425" n="18">
+                            <staff xml:id="staff-1795211292" n="1">
+                                <layer xml:id="layer-1984284969" n="1">
+                                    <note xml:id="note-0892815219" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-2121608490" n="1">
                                             <syl con="d" wordpos="m">spi</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001219352476" dur="8" oct="4" pname="d">
+                                    <note xml:id="note-1219352476" dur="8" oct="4" pname="d">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000001587152393" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-1587152393" n="1">
                                             <syl con="d" wordpos="m">ri</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001971761426" dur="8" oct="3" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000296617721" n="1">
+                                    <note xml:id="note-1971761426" dur="8" oct="3" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0296617721" n="1">
                                             <syl con="s" wordpos="t">ti</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000648825506" n="2">
-                                <layer xml:id="layer-0000000138971976" n="1">
-                                    <note xml:id="note-0000000383547730" dur="4" oct="3" pname="d">
+                            <staff xml:id="staff-0648825506" n="2">
+                                <layer xml:id="layer-0138971976" n="1">
+                                    <note xml:id="note-0383547730" dur="4" oct="3" pname="d">
                                         <accid accid="f" />
                                     </note>
-                                    <rest xml:id="rest-0000000518232585" dur="8" />
+                                    <rest xml:id="rest-0518232585" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001421558646" n="19">
-                            <staff xml:id="staff-0000001898866620" n="1">
-                                <layer xml:id="layer-0000000728736916" n="1">
+                        <measure xml:id="measure-1421558646" n="19">
+                            <staff xml:id="staff-1898866620" n="1">
+                                <layer xml:id="layer-0728736916" n="1">
                                     <beam>
-                                        <note xml:id="note-0000002049712729" dur="8" oct="4" pname="b" accid.ges="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000001395455856" n="1">
+                                        <note xml:id="note-2049712729" dur="8" oct="4" pname="b" accid.ges="f">
+                                            <verse xml:lang="ita" xml:id="verse-1395455856" n="1">
                                                 <syl con="d" wordpos="i">par</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001769834254" dur="8" oct="4" pname="a" accid.ges="f" />
+                                        <note xml:id="note-1769834254" dur="8" oct="4" pname="a" accid.ges="f" />
                                     </beam>
-                                    <note xml:id="note-0000001986338709" dur="8" oct="4" pname="g">
-                                        <verse xml:lang="ita" xml:id="verse-0000000977327519" n="1">
+                                    <note xml:id="note-1986338709" dur="8" oct="4" pname="g">
+                                        <verse xml:lang="ita" xml:id="verse-0977327519" n="1">
                                             <syl con="s" wordpos="t">la</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000737959577" n="2">
-                                <layer xml:id="layer-0000001340190511" n="1">
-                                    <note xml:id="note-0000001532364963" dur="4" oct="2" pname="g" />
-                                    <rest xml:id="rest-0000000103782071" dur="8" />
+                            <staff xml:id="staff-0737959577" n="2">
+                                <layer xml:id="layer-1340190511" n="1">
+                                    <note xml:id="note-1532364963" dur="4" oct="2" pname="g" />
+                                    <rest xml:id="rest-0103782071" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000960152314" n="20">
-                            <staff xml:id="staff-0000002113883653" n="1">
-                                <layer xml:id="layer-0000000208737765" n="1">
+                        <measure xml:id="measure-0960152314" n="20">
+                            <staff xml:id="staff-2113883653" n="1">
+                                <layer xml:id="layer-0208737765" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000620880341" dur="8" oct="4" pname="a" accid.ges="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000001445813047" n="1">
+                                        <note xml:id="note-0620880341" dur="8" oct="4" pname="a" accid.ges="f">
+                                            <verse xml:lang="ita" xml:id="verse-1445813047" n="1">
                                                 <syl con="d" wordpos="i">ques</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001109870577" dur="8" oct="4" pname="g" />
+                                        <note xml:id="note-1109870577" dur="8" oct="4" pname="g" />
                                     </beam>
-                                    <note xml:id="note-0000002003371592" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001987273451" n="1">
+                                    <note xml:id="note-2003371592" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-1987273451" n="1">
                                             <syl con="s" wordpos="t">to</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000375790665" n="2">
-                                <layer xml:id="layer-0000000424430694" n="1">
-                                    <note xml:id="note-0000001031826635" dur="4" oct="2" pname="f" />
-                                    <note xml:id="note-0000000263272216" dur="8" oct="2" pname="b">
+                            <staff xml:id="staff-0375790665" n="2">
+                                <layer xml:id="layer-0424430694" n="1">
+                                    <note xml:id="note-1031826635" dur="4" oct="2" pname="f" />
+                                    <note xml:id="note-0263272216" dur="8" oct="2" pname="b">
                                         <accid accid="n" />
                                     </note>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001513174665" n="21">
-                            <staff xml:id="staff-0000002087075449" n="1">
-                                <layer xml:id="layer-0000000837081638" n="1">
-                                    <note xml:id="note-0000001672158452" dots="1" dur="4" oct="4" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000000435211880" n="1">
+                        <measure xml:id="measure-1513174665" n="21">
+                            <staff xml:id="staff-2087075449" n="1">
+                                <layer xml:id="layer-0837081638" n="1">
+                                    <note xml:id="note-1672158452" dots="1" dur="4" oct="4" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-0435211880" n="1">
                                             <syl con="s">cor,</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000009201613" n="2">
-                                <layer xml:id="layer-0000000264547525" n="1">
-                                    <note xml:id="note-0000001713215212" dots="1" dur="4" oct="3" pname="c" />
+                            <staff xml:id="staff-0009201613" n="2">
+                                <layer xml:id="layer-0264547525" n="1">
+                                    <note xml:id="note-1713215212" dots="1" dur="4" oct="3" pname="c" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000453711286" n="22">
-                            <staff xml:id="staff-0000001647427297" n="1">
-                                <layer xml:id="layer-0000000948475840" n="1">
-                                    <rest xml:id="rest-0000000133329168" dur="8" />
-                                    <rest xml:id="rest-0000001472212112" dur="8" />
-                                    <note xml:id="note-0000000317604648" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001780190268" n="1">
+                        <measure xml:id="measure-0453711286" n="22">
+                            <staff xml:id="staff-1647427297" n="1">
+                                <layer xml:id="layer-0948475840" n="1">
+                                    <rest xml:id="rest-0133329168" dur="8" />
+                                    <rest xml:id="rest-1472212112" dur="8" />
+                                    <note xml:id="note-0317604648" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1780190268" n="1">
                                             <syl con="s">a</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000586472255" n="2">
-                                <layer xml:id="layer-0000000163787991" n="1">
-                                    <rest xml:id="rest-0000000860350311" dur="8" />
-                                    <rest xml:id="rest-0000000576577705" dur="8" />
-                                    <note xml:id="note-0000000758140947" dur="8" oct="3" pname="c" />
+                            <staff xml:id="staff-0586472255" n="2">
+                                <layer xml:id="layer-0163787991" n="1">
+                                    <rest xml:id="rest-0860350311" dur="8" />
+                                    <rest xml:id="rest-0576577705" dur="8" />
+                                    <note xml:id="note-0758140947" dur="8" oct="3" pname="c" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000998876952" n="23">
-                            <staff xml:id="staff-0000000848425591" n="1">
-                                <layer xml:id="layer-0000000096893161" n="1">
+                        <measure xml:id="measure-0998876952" n="23">
+                            <staff xml:id="staff-0848425591" n="1">
+                                <layer xml:id="layer-0096893161" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001859940064" dur="8" oct="4" pname="a" accid.ges="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000001631551472" n="1">
+                                        <note xml:id="note-1859940064" dur="8" oct="4" pname="a" accid.ges="f">
+                                            <verse xml:lang="ita" xml:id="verse-1631551472" n="1">
                                                 <syl con="d" wordpos="i">tan</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001031166398" dur="8" oct="4" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1031166398" dur="8" oct="4" pname="b" accid.ges="f" />
                                     </beam>
-                                    <note xml:id="note-0000000556613824" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000002124228073" n="1">
+                                    <note xml:id="note-0556613824" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-2124228073" n="1">
                                             <syl con="s" wordpos="t">to</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000657748008" n="2">
-                                <layer xml:id="layer-0000000188634170" n="1">
-                                    <note xml:id="note-0000002140839214" dots="1" dur="4" oct="3" pname="d">
+                            <staff xml:id="staff-0657748008" n="2">
+                                <layer xml:id="layer-0188634170" n="1">
+                                    <note xml:id="note-2140839214" dots="1" dur="4" oct="3" pname="d">
                                         <accid accid="f" />
                                     </note>
                                 </layer>
                             </staff>
                         </measure>
                         <sb source="#secondEdition" />
-                        <measure xml:id="measure-0000001358819756" n="24">
-                            <staff xml:id="staff-0000001604133899" n="1">
-                                <layer xml:id="layer-0000002126004103" n="1">
+                        <measure xml:id="measure-1358819756" n="24">
+                            <staff xml:id="staff-1604133899" n="1">
+                                <layer xml:id="layer-2126004103" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000936329633" dur="8" oct="4" pname="a" accid.ges="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000001490875880" n="1">
+                                        <note xml:id="note-0936329633" dur="8" oct="4" pname="a" accid.ges="f">
+                                            <verse xml:lang="ita" xml:id="verse-1490875880" n="1">
                                                 <syl con="s">suo</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001013612383" dur="8" oct="4" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1013612383" dur="8" oct="4" pname="b" accid.ges="f" />
                                     </beam>
-                                    <note xml:id="note-0000000082280571" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001616467457" n="1">
+                                    <note xml:id="note-0082280571" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1616467457" n="1">
                                             <syl con="d" wordpos="i">do</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000002058561327" n="2">
-                                <layer xml:id="layer-0000001639977878" n="1">
-                                    <note xml:id="note-0000000918817073" dur="4" oct="3" pname="c" />
-                                    <rest xml:id="rest-0000001339199786" dur="8" />
+                            <staff xml:id="staff-2058561327" n="2">
+                                <layer xml:id="layer-1639977878" n="1">
+                                    <note xml:id="note-0918817073" dur="4" oct="3" pname="c" />
+                                    <rest xml:id="rest-1339199786" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001860579090" n="25">
-                            <staff xml:id="staff-0000000315619146" n="1">
-                                <layer xml:id="layer-0000000329748333" n="1">
-                                    <note xml:id="note-0000001067890531" dur="8" oct="4" pname="d">
+                        <measure xml:id="measure-1860579090" n="25">
+                            <staff xml:id="staff-0315619146" n="1">
+                                <layer xml:id="layer-0329748333" n="1">
+                                    <note xml:id="note-1067890531" dur="8" oct="4" pname="d">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000000465996941" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-0465996941" n="1">
                                             <syl con="s" wordpos="t">lor</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001899023365" dur="4" oct="4" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001978290147" n="1">
+                                    <note xml:id="note-1899023365" dur="4" oct="4" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1978290147" n="1">
                                             <syl con="s">ti</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001976959101" n="2">
-                                <layer xml:id="layer-0000001411534159" n="1">
+                            <staff xml:id="staff-1976959101" n="2">
+                                <layer xml:id="layer-1411534159" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001264118317" dur="8" oct="2" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000000827746511" dur="8" oct="3" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000000452983938" dur="8" oct="3" pname="a" accid.ges="f" />
+                                        <note xml:id="note-1264118317" dur="8" oct="2" pname="b" accid.ges="f" />
+                                        <note xml:id="note-0827746511" dur="8" oct="3" pname="b" accid.ges="f" />
+                                        <note xml:id="note-0452983938" dur="8" oct="3" pname="a" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000000735776553" startid="#note-0000001899023365" endid="#note-0000000582264386" />
+                            <tie xml:id="tie-0735776553" startid="#note-1899023365" endid="#note-0582264386" />
                         </measure>
-                        <measure xml:id="measure-0000001299804348" n="26">
-                            <staff xml:id="staff-0000000328490981" n="1">
-                                <layer xml:id="layer-0000001058540631" n="1">
-                                    <note xml:id="note-0000000582264386" dur="8" oct="4" pname="b" accid.ges="f" />
-                                    <note xml:id="note-0000001246920931" dur="8" oct="4" pname="g">
-                                        <verse xml:lang="ita" xml:id="verse-0000001741327341" n="1">
+                        <measure xml:id="measure-1299804348" n="26">
+                            <staff xml:id="staff-0328490981" n="1">
+                                <layer xml:id="layer-1058540631" n="1">
+                                    <note xml:id="note-0582264386" dur="8" oct="4" pname="b" accid.ges="f" />
+                                    <note xml:id="note-1246920931" dur="8" oct="4" pname="g">
+                                        <verse xml:lang="ita" xml:id="verse-1741327341" n="1">
                                             <syl con="d" wordpos="i">chie</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001111733139" dur="8" oct="4" pname="e" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000061929255" n="1">
+                                    <note xml:id="note-1111733139" dur="8" oct="4" pname="e" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0061929255" n="1">
                                             <syl con="b" wordpos="t">de</syl>
                                             <syl con="s">un</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001174359211" n="2">
-                                <layer xml:id="layer-0000001892970365" n="1">
-                                    <note xml:id="note-0000001763443980" dots="1" dur="4" oct="3" pname="g" />
+                            <staff xml:id="staff-1174359211" n="2">
+                                <layer xml:id="layer-1892970365" n="1">
+                                    <note xml:id="note-1763443980" dots="1" dur="4" oct="3" pname="g" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000677258776" n="27">
-                            <staff xml:id="staff-0000002034360815" n="1">
-                                <layer xml:id="layer-0000001118848376" n="1">
-                                    <note xml:id="note-0000001633430295" dur="8" oct="5" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000000076750464" n="1">
+                        <measure xml:id="measure-0677258776" n="27">
+                            <staff xml:id="staff-2034360815" n="1">
+                                <layer xml:id="layer-1118848376" n="1">
+                                    <note xml:id="note-1633430295" dur="8" oct="5" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-0076750464" n="1">
                                             <syl con="d" wordpos="i">guar</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001008611208" dur="8" oct="4" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001223828249" n="1">
+                                    <note xml:id="note-1008611208" dur="8" oct="4" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1223828249" n="1">
                                             <syl con="s" wordpos="t">do</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000539211838" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001156733369" n="1">
+                                    <note xml:id="note-0539211838" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1156733369" n="1">
                                             <syl con="s">ti</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000002112036986" n="2">
-                                <layer xml:id="layer-0000000768733971" n="1">
-                                    <note xml:id="note-0000001795035526" dur="4" oct="3" pname="a" accid.ges="f" />
-                                    <rest xml:id="rest-0000000365263651" dur="8" />
+                            <staff xml:id="staff-2112036986" n="2">
+                                <layer xml:id="layer-0768733971" n="1">
+                                    <note xml:id="note-1795035526" dur="4" oct="3" pname="a" accid.ges="f" />
+                                    <rest xml:id="rest-0365263651" dur="8" />
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000000462860732" startid="#note-0000000539211838" endid="#note-0000000777616988" />
+                            <tie xml:id="tie-0462860732" startid="#note-0539211838" endid="#note-0777616988" />
                         </measure>
-                        <measure xml:id="measure-0000000060567660" n="28">
-                            <staff xml:id="staff-0000000820071541" n="1">
-                                <layer xml:id="layer-0000001226722001" n="1">
-                                    <note xml:id="note-0000000777616988" dur="8" oct="4" pname="a" accid.ges="f" />
-                                    <note xml:id="note-0000001677248163" dur="8" oct="4" pname="g">
-                                        <verse xml:lang="ita" xml:id="verse-0000000915484166" n="1">
+                        <measure xml:id="measure-0060567660" n="28">
+                            <staff xml:id="staff-0820071541" n="1">
+                                <layer xml:id="layer-1226722001" n="1">
+                                    <note xml:id="note-0777616988" dur="8" oct="4" pname="a" accid.ges="f" />
+                                    <note xml:id="note-1677248163" dur="8" oct="4" pname="g">
+                                        <verse xml:lang="ita" xml:id="verse-0915484166" n="1">
                                             <syl con="d" wordpos="i">chie</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001703835378" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000144428039" n="1">
+                                    <note xml:id="note-1703835378" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-0144428039" n="1">
                                             <syl con="b" wordpos="t">de</syl>
                                             <syl con="s">un</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000349974925" n="2">
-                                <layer xml:id="layer-0000000291572574" n="1">
-                                    <note xml:id="note-0000001961286267" dur="4" oct="3" pname="b" accid.ges="f" />
-                                    <rest xml:id="rest-0000000375534799" dur="8" />
+                            <staff xml:id="staff-0349974925" n="2">
+                                <layer xml:id="layer-0291572574" n="1">
+                                    <note xml:id="note-1961286267" dur="4" oct="3" pname="b" accid.ges="f" />
+                                    <rest xml:id="rest-0375534799" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000898945523" n="29">
-                            <staff xml:id="staff-0000000739382211" n="1">
-                                <layer xml:id="layer-0000001901931716" n="1">
-                                    <note xml:id="note-0000000387072302" dots="1" dur="4" oct="4" pname="e" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000756076338" n="1">
+                        <measure xml:id="measure-0898945523" n="29">
+                            <staff xml:id="staff-0739382211" n="1">
+                                <layer xml:id="layer-1901931716" n="1">
+                                    <note xml:id="note-0387072302" dots="1" dur="4" oct="4" pname="e" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0756076338" n="1">
                                             <syl con="d" wordpos="i">guar</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000793284130" n="2">
-                                <layer xml:id="layer-0000001677307024" n="1">
+                            <staff xml:id="staff-0793284130" n="2">
+                                <layer xml:id="layer-1677307024" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001180433186" dur="8" oct="4" pname="c" />
-                                        <note xml:id="note-0000000277287565" dur="8" oct="3" pname="c" />
-                                        <note xml:id="note-0000002102141507" dur="8" oct="2" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1180433186" dur="8" oct="4" pname="c" />
+                                        <note xml:id="note-0277287565" dur="8" oct="3" pname="c" />
+                                        <note xml:id="note-2102141507" dur="8" oct="2" pname="b" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000001674717841" startid="#note-0000000387072302" endid="#note-0000000464823757" />
+                            <tie xml:id="tie-1674717841" startid="#note-0387072302" endid="#note-0464823757" />
                         </measure>
-                        <measure xml:id="measure-0000001323731579" n="30">
-                            <staff xml:id="staff-0000001748003436" n="1">
-                                <layer xml:id="layer-0000001115190802" n="1">
+                        <measure xml:id="measure-1323731579" n="30">
+                            <staff xml:id="staff-1748003436" n="1">
+                                <layer xml:id="layer-1115190802" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000464823757" dur="8" oct="4" pname="e" accid.ges="f" />
-                                        <note xml:id="note-0000000008800865" dur="8" oct="5" pname="c" />
-                                        <note xml:id="note-0000001399112655" dur="8" oct="4" pname="e" accid.ges="f" />
+                                        <note xml:id="note-0464823757" dur="8" oct="4" pname="e" accid.ges="f" />
+                                        <note xml:id="note-0008800865" dur="8" oct="5" pname="c" />
+                                        <note xml:id="note-1399112655" dur="8" oct="4" pname="e" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001597453574" n="2">
-                                <layer xml:id="layer-0000000883124871" n="1">
-                                    <note xml:id="note-0000001913121740" dots="1" dur="4" oct="2" pname="a" accid.ges="f" />
+                            <staff xml:id="staff-1597453574" n="2">
+                                <layer xml:id="layer-0883124871" n="1">
+                                    <note xml:id="note-1913121740" dots="1" dur="4" oct="2" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000750776361" n="31">
-                            <staff xml:id="staff-0000000030850372" n="1">
-                                <layer xml:id="layer-0000001812028381" n="1">
-                                    <note xml:id="note-0000001290683804" dots="1" dur="4" oct="4" pname="d">
+                        <measure xml:id="measure-0750776361" n="31">
+                            <staff xml:id="staff-0030850372" n="1">
+                                <layer xml:id="layer-1812028381" n="1">
+                                    <note xml:id="note-1290683804" dots="1" dur="4" oct="4" pname="d">
                                         <choice>
                                             <sic>
                                                 <accid accid="f" oloc="4" ploc="f" />
@@ -714,1009 +716,1015 @@
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000890965384" n="2">
-                                <layer xml:id="layer-0000000008415856" n="1">
+                            <staff xml:id="staff-0890965384" n="2">
+                                <layer xml:id="layer-0008415856" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001949094620" dur="8" oct="2" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000001003312560" dur="8" oct="3" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000000314089393" dur="8" oct="3" pname="a" accid.ges="f" />
+                                        <note xml:id="note-1949094620" dur="8" oct="2" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1003312560" dur="8" oct="3" pname="b" accid.ges="f" />
+                                        <note xml:id="note-0314089393" dur="8" oct="3" pname="a" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000001774720271" startid="#note-0000001290683804" endid="#note-0000000302277523" />
+                            <tie xml:id="tie-1774720271" startid="#note-1290683804" endid="#note-0302277523" />
                         </measure>
                         <pb source="#secondEdition" n="357" facs="#graphic_01DRXXBW81G647M2MA67QV8N86" />
-                        <measure xml:id="measure-0000002113040272" n="32">
-                            <staff xml:id="staff-0000001302629114" n="1">
-                                <layer xml:id="layer-0000000157553020" n="1">
+                        <measure xml:id="measure-2113040272" n="32">
+                            <staff xml:id="staff-1302629114" n="1">
+                                <layer xml:id="layer-0157553020" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000302277523" dur="8" oct="4" pname="d" accid.ges="f">
-                                            <reg resp="#rettinghaus">
-                                                <accid accid="f" enclose="brack" />
-                                            </reg>
+                                        <note xml:id="note-0302277523" dur="8" oct="4" pname="d" accid.ges="f">
+                                            <supplied resp="#rettinghaus">
+                                                <reg>
+                                                    <accid accid="f" />
+                                                </reg>
+                                            </supplied>
                                         </note>
-                                        <note xml:id="note-0000000076787460" dur="8" oct="4" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000001674991584" dur="8" oct="4" pname="d" accid.ges="f" />
+                                        <note xml:id="note-0076787460" dur="8" oct="4" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1674991584" dur="8" oct="4" pname="d" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000137015591" n="2">
-                                <layer xml:id="layer-0000001118661570" n="1">
-                                    <note xml:id="note-0000000296746397" dots="1" dur="4" oct="3" pname="g" />
+                            <staff xml:id="staff-0137015591" n="2">
+                                <layer xml:id="layer-1118661570" n="1">
+                                    <note xml:id="note-0296746397" dots="1" dur="4" oct="3" pname="g" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000002142834759" n="33">
-                            <staff xml:id="staff-0000001275299609" n="1">
-                                <layer xml:id="layer-0000001636821055" n="1">
-                                    <note xml:id="note-0000000451588930" dur="8" oct="4" pname="c" />
-                                    <note xml:id="note-0000000305892006" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001737885016" n="1">
+                        <measure xml:id="measure-2142834759" n="33">
+                            <staff xml:id="staff-1275299609" n="1">
+                                <layer xml:id="layer-1636821055" n="1">
+                                    <note xml:id="note-0451588930" dur="8" oct="4" pname="c" />
+                                    <note xml:id="note-0305892006" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1737885016" n="1">
                                             <syl con="s" wordpos="t">do</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000402109298" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001474208675" n="1">
+                                    <note xml:id="note-0402109298" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-1474208675" n="1">
                                             <syl con="s">ti</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000002061811827" n="2">
-                                <layer xml:id="layer-0000000385440322" n="1">
-                                    <note xml:id="note-0000000854928431" dots="1" dur="4" oct="3" pname="a" accid.ges="f" />
+                            <staff xml:id="staff-2061811827" n="2">
+                                <layer xml:id="layer-0385440322" n="1">
+                                    <note xml:id="note-0854928431" dots="1" dur="4" oct="3" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000000764325985" startid="#note-0000000854928431" endid="#note-0000000212554392" />
+                            <tie xml:id="tie-0764325985" startid="#note-0854928431" endid="#note-0212554392" />
                         </measure>
-                        <measure xml:id="measure-0000000627303796" n="34">
-                            <staff xml:id="staff-0000001786284931" n="1">
-                                <layer xml:id="layer-0000001872057825" n="1">
-                                    <note xml:id="note-0000000918327596" dur="4" oct="3" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000386946332" n="1">
+                        <measure xml:id="measure-0627303796" n="34">
+                            <staff xml:id="staff-1786284931" n="1">
+                                <layer xml:id="layer-1872057825" n="1">
+                                    <note xml:id="note-0918327596" dur="4" oct="3" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0386946332" n="1">
                                             <syl con="d" wordpos="i">chie</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000146063621" dur="8" oct="4" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000522927744" n="1">
+                                    <note xml:id="note-0146063621" dur="8" oct="4" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0522927744" n="1">
                                             <syl con="b" wordpos="t">de</syl>
                                             <syl con="s">un</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001849702246" n="2">
-                                <layer xml:id="layer-0000000014299932" n="1">
-                                    <note xml:id="note-0000000212554392" dur="4" oct="3" pname="a" accid.ges="f" />
-                                    <note xml:id="note-0000000617943395" dur="8" oct="3" pname="g" />
+                            <staff xml:id="staff-1849702246" n="2">
+                                <layer xml:id="layer-0014299932" n="1">
+                                    <note xml:id="note-0212554392" dur="4" oct="3" pname="a" accid.ges="f" />
+                                    <note xml:id="note-0617943395" dur="8" oct="3" pname="g" />
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000000228272805" startid="#note-0000000146063621" endid="#note-0000001635452776" />
+                            <tie xml:id="tie-0228272805" startid="#note-0146063621" endid="#note-1635452776" />
                         </measure>
-                        <measure xml:id="measure-0000000069359454" n="35">
-                            <staff xml:id="staff-0000000079604223" n="1">
-                                <layer xml:id="layer-0000000085901944" n="1">
-                                    <note xml:id="note-0000001635452776" dur="8" oct="4" pname="b" accid.ges="f" />
+                        <measure xml:id="measure-0069359454" n="35">
+                            <staff xml:id="staff-0079604223" n="1">
+                                <layer xml:id="layer-0085901944" n="1">
+                                    <note xml:id="note-1635452776" dur="8" oct="4" pname="b" accid.ges="f" />
                                     <beam>
-                                        <note xml:id="note-0000000611990276" dur="8" oct="4" pname="g">
-                                            <verse xml:lang="ita" xml:id="verse-0000000490104875" n="1">
+                                        <note xml:id="note-0611990276" dur="8" oct="4" pname="g">
+                                            <verse xml:lang="ita" xml:id="verse-0490104875" n="1">
                                                 <syl con="d" wordpos="i">guar</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001351921559" dur="8" oct="4" pname="f" />
+                                        <note xml:id="note-1351921559" dur="8" oct="4" pname="f" />
                                     </beam>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000173829354" n="2">
-                                <layer xml:id="layer-0000001563666921" n="1">
+                            <staff xml:id="staff-0173829354" n="2">
+                                <layer xml:id="layer-1563666921" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001856457799" dur="8" oct="3" pname="a" accid.ges="f" />
-                                        <note xml:id="note-0000002030746299" dur="8" oct="3" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000000406979803" dur="8" oct="2" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1856457799" dur="8" oct="3" pname="a" accid.ges="f" />
+                                        <note xml:id="note-2030746299" dur="8" oct="3" pname="b" accid.ges="f" />
+                                        <note xml:id="note-0406979803" dur="8" oct="2" pname="b" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001424025321" right="rptend" n="36">
-                            <staff xml:id="staff-0000001668342555" n="1">
-                                <layer xml:id="layer-0000002079428290" n="1">
-                                    <note xml:id="note-0000000527129810" dur="4" oct="4" pname="e" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000796691684" n="1">
+                        <measure xml:id="measure-1424025321" right="rptend" n="36">
+                            <staff xml:id="staff-1668342555" n="1">
+                                <layer xml:id="layer-2079428290" n="1">
+                                    <note xml:id="note-0527129810" dur="4" oct="4" pname="e" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0796691684" n="1">
                                             <syl con="s" wordpos="t">do.</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001903950875" n="2">
-                                <layer xml:id="layer-0000000029635491" n="1">
-                                    <note xml:id="note-0000001234562110" dur="4" oct="3" pname="e" accid.ges="f" />
+                            <staff xml:id="staff-1903950875" n="2">
+                                <layer xml:id="layer-0029635491" n="1">
+                                    <note xml:id="note-1234562110" dur="4" oct="3" pname="e" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
                     </section>
                     <section>
-                        <measure xml:id="measure-0000000111778887" left="rptstart" metcon="false">
-                            <staff xml:id="staff-0000001595139735" n="1">
-                                <layer xml:id="layer-0000000467211864" n="1">
-                                    <note xml:id="note-0000000380159253" dur="8" oct="4" pname="e" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000665997100" n="1">
+                        <measure xml:id="measure-0111778887" left="rptstart" metcon="false">
+                            <staff xml:id="staff-1595139735" n="1">
+                                <layer xml:id="layer-0467211864" n="1">
+                                    <note xml:id="note-0380159253" dur="8" oct="4" pname="e" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0665997100" n="1">
                                             <syl con="s">col</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000525237018" n="2">
-                                <layer xml:id="layer-0000001718579440" n="1">
-                                    <note xml:id="note-0000001949813374" dur="8" oct="3" pname="e" accid.ges="f" />
+                            <staff xml:id="staff-0525237018" n="2">
+                                <layer xml:id="layer-1718579440" n="1">
+                                    <note xml:id="note-1949813374" dur="8" oct="3" pname="e" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001836768421" n="37">
-                            <staff xml:id="staff-0000001498453451" n="1">
-                                <layer xml:id="layer-0000001090608190" n="1">
+                        <measure xml:id="measure-1836768421" n="37">
+                            <staff xml:id="staff-1498453451" n="1">
+                                <layer xml:id="layer-1090608190" n="1">
                                     <beam>
-                                        <note xml:id="note-0000002122549200" dur="16" oct="4" pname="a" accid.ges="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000001986284905" n="1">
+                                        <note xml:id="note-2122549200" dur="16" oct="4" pname="a" accid.ges="f">
+                                            <verse xml:lang="ita" xml:id="verse-1986284905" n="1">
                                                 <syl con="d" wordpos="i">pian</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000200569011" dur="16" oct="4" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000001201807458" dur="8" oct="5" pname="c" />
+                                        <note xml:id="note-0200569011" dur="16" oct="4" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1201807458" dur="8" oct="5" pname="c" />
                                     </beam>
-                                    <note xml:id="note-0000000914978581" dur="8" oct="4" pname="e" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000754968903" n="1">
+                                    <note xml:id="note-0914978581" dur="8" oct="4" pname="e" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0754968903" n="1">
                                             <syl con="b" wordpos="t">to</syl>
                                             <syl con="s">e</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000933599683" n="2">
-                                <layer xml:id="layer-0000000528331447" n="1">
-                                    <note xml:id="note-0000001347343441" dur="4" oct="3" pname="c" />
-                                    <rest xml:id="rest-0000001728848806" dur="8" />
+                            <staff xml:id="staff-0933599683" n="2">
+                                <layer xml:id="layer-0528331447" n="1">
+                                    <note xml:id="note-1347343441" dur="4" oct="3" pname="c" />
+                                    <rest xml:id="rest-1728848806" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001201386076" n="38">
-                            <staff xml:id="staff-0000001164738168" n="1">
-                                <layer xml:id="layer-0000001548901498" n="1">
+                        <measure xml:id="measure-1201386076" n="38">
+                            <staff xml:id="staff-1164738168" n="1">
+                                <layer xml:id="layer-1548901498" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000371361127" dur="16" oct="4" pname="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000002110323133" n="1">
+                                        <note xml:id="note-0371361127" dur="16" oct="4" pname="f">
+                                            <verse xml:lang="ita" xml:id="verse-2110323133" n="1">
                                                 <syl con="s">coi</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001549317343" dur="16" oct="4" pname="g" />
-                                        <note xml:id="note-0000001511137468" dur="8" oct="4" pname="a" accid.ges="f" />
+                                        <note xml:id="note-1549317343" dur="16" oct="4" pname="g" />
+                                        <note xml:id="note-1511137468" dur="8" oct="4" pname="a" accid.ges="f" />
                                     </beam>
-                                    <note xml:id="note-0000000118438893" dur="8" oct="4" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000000785203431" n="1">
+                                    <note xml:id="note-0118438893" dur="8" oct="4" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-0785203431" n="1">
                                             <syl con="d" wordpos="i">so</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001461799401" n="2">
-                                <layer xml:id="layer-0000001216410947" n="1">
-                                    <note xml:id="note-0000000971654631" dur="4" oct="3" pname="d">
+                            <staff xml:id="staff-1461799401" n="2">
+                                <layer xml:id="layer-1216410947" n="1">
+                                    <note xml:id="note-0971654631" dur="4" oct="3" pname="d">
                                         <accid accid="f" />
                                     </note>
-                                    <note xml:id="note-0000001139422710" dur="8" oct="3" pname="c" />
+                                    <note xml:id="note-1139422710" dur="8" oct="3" pname="c" />
                                 </layer>
                             </staff>
                         </measure>
                         <sb source="#secondEdition" />
-                        <measure xml:id="measure-0000001332910205" n="39">
-                            <staff xml:id="staff-0000001082898990" n="1">
-                                <layer xml:id="layer-0000000512266725" n="1">
-                                    <note xml:id="note-0000000350778122" dur="8" oct="4" pname="d">
+                        <measure xml:id="measure-1332910205" n="39">
+                            <staff xml:id="staff-1082898990" n="1">
+                                <layer xml:id="layer-0512266725" n="1">
+                                    <note xml:id="note-0350778122" dur="8" oct="4" pname="d">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000001005857246" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-1005857246" n="1">
                                             <syl con="d" wordpos="m">spi</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000002052272482" dur="8" oct="4" pname="e" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001505262447" n="1">
+                                    <note xml:id="note-2052272482" dur="8" oct="4" pname="e" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1505262447" n="1">
                                             <syl con="d" wordpos="m">ri</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001959894814" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000687083883" n="1">
+                                    <note xml:id="note-1959894814" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-0687083883" n="1">
                                             <syl con="s" wordpos="t">ti</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000651448767" n="2">
-                                <layer xml:id="layer-0000001255480845" n="1">
-                                    <note xml:id="note-0000000175878008" dur="4" oct="2" pname="b" accid.ges="f" />
-                                    <note xml:id="note-0000001007093696" dur="8" oct="2" pname="a" accid.ges="f" />
+                            <staff xml:id="staff-0651448767" n="2">
+                                <layer xml:id="layer-1255480845" n="1">
+                                    <note xml:id="note-0175878008" dur="4" oct="2" pname="b" accid.ges="f" />
+                                    <note xml:id="note-1007093696" dur="8" oct="2" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001870135903" n="40">
-                            <staff xml:id="staff-0000001832386690" n="1">
-                                <layer xml:id="layer-0000000650415547" n="1">
+                        <measure xml:id="measure-1870135903" n="40">
+                            <staff xml:id="staff-1832386690" n="1">
+                                <layer xml:id="layer-0650415547" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000966550440" dur="8" oct="4" pname="e" accid.ges="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000000117639085" n="1">
+                                        <note xml:id="note-0966550440" dur="8" oct="4" pname="e" accid.ges="f">
+                                            <verse xml:lang="ita" xml:id="verse-0117639085" n="1">
                                                 <syl con="d" wordpos="i">par</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000307852423" dur="8" oct="4" pname="g" />
+                                        <note xml:id="note-0307852423" dur="8" oct="4" pname="g" />
                                     </beam>
-                                    <note xml:id="note-0000000496810511" dur="8" oct="4" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001241477590" n="1">
+                                    <note xml:id="note-0496810511" dur="8" oct="4" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1241477590" n="1">
                                             <syl con="s" wordpos="t">la</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000417407307" n="2">
-                                <layer xml:id="layer-0000000836162246" n="1">
-                                    <note xml:id="note-0000001114277754" dur="4" oct="2" pname="g" />
-                                    <rest xml:id="rest-0000000406273850" dur="8" />
+                            <staff xml:id="staff-0417407307" n="2">
+                                <layer xml:id="layer-0836162246" n="1">
+                                    <note xml:id="note-1114277754" dur="4" oct="2" pname="g" />
+                                    <rest xml:id="rest-0406273850" dur="8" />
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000002072928678" startid="#note-0000000496810511" endid="#note-0000000038452261" />
+                            <tie xml:id="tie-2072928678" startid="#note-0496810511" endid="#note-0038452261" />
                         </measure>
-                        <measure xml:id="measure-0000000578645351" n="41">
-                            <staff xml:id="staff-0000000914165506" n="1">
-                                <layer xml:id="layer-0000000684008652" n="1">
-                                    <note xml:id="note-0000000038452261" dur="8" oct="4" pname="b" accid.ges="f" />
-                                    <note xml:id="note-0000001819298005" dur="8" oct="4" pname="g">
-                                        <verse xml:lang="ita" xml:id="verse-0000001727953077" n="1">
+                        <measure xml:id="measure-0578645351" n="41">
+                            <staff xml:id="staff-0914165506" n="1">
+                                <layer xml:id="layer-0684008652" n="1">
+                                    <note xml:id="note-0038452261" dur="8" oct="4" pname="b" accid.ges="f" />
+                                    <note xml:id="note-1819298005" dur="8" oct="4" pname="g">
+                                        <verse xml:lang="ita" xml:id="verse-1727953077" n="1">
                                             <syl con="d" wordpos="i">que</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000235375210" dur="8" oct="4" pname="e" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000970070095" n="1">
+                                    <note xml:id="note-0235375210" dur="8" oct="4" pname="e" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0970070095" n="1">
                                             <syl con="s" wordpos="t">sto</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001835206225" n="2">
-                                <layer xml:id="layer-0000001696114566" n="1">
-                                    <note xml:id="note-0000001092822974" dur="4" oct="2" pname="e" accid.ges="f" />
-                                    <rest xml:id="rest-0000000250375195" dur="8" />
+                            <staff xml:id="staff-1835206225" n="2">
+                                <layer xml:id="layer-1696114566" n="1">
+                                    <note xml:id="note-1092822974" dur="4" oct="2" pname="e" accid.ges="f" />
+                                    <rest xml:id="rest-0250375195" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000632578327" n="42">
-                            <staff xml:id="staff-0000001745067751" n="1">
-                                <layer xml:id="layer-0000001115609048" n="1">
-                                    <note xml:id="note-0000000279113823" dur="4" oct="4" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000001593394119" n="1">
+                        <measure xml:id="measure-0632578327" n="42">
+                            <staff xml:id="staff-1745067751" n="1">
+                                <layer xml:id="layer-1115609048" n="1">
+                                    <note xml:id="note-0279113823" dur="4" oct="4" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-1593394119" n="1">
                                             <syl con="s">cor</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001368438025" dur="8" oct="5" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000000299938559" n="1">
+                                    <note xml:id="note-1368438025" dur="8" oct="5" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-0299938559" n="1">
                                             <syl con="b">e</syl>
                                             <syl con="s">a</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000162382985" n="2">
-                                <layer xml:id="layer-0000002086883618" n="1">
-                                    <note xml:id="note-0000001050495376" dur="4" oct="2" pname="a" accid.ges="f" />
-                                    <note xml:id="note-0000001703507802" dur="8" oct="3" pname="a" accid.ges="f" />
+                            <staff xml:id="staff-0162382985" n="2">
+                                <layer xml:id="layer-2086883618" n="1">
+                                    <note xml:id="note-1050495376" dur="4" oct="2" pname="a" accid.ges="f" />
+                                    <note xml:id="note-1703507802" dur="8" oct="3" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001485201246" n="43">
-                            <staff xml:id="staff-0000001560437322" n="1">
-                                <layer xml:id="layer-0000001955997997" n="1">
+                        <measure xml:id="measure-1485201246" n="43">
+                            <staff xml:id="staff-1560437322" n="1">
+                                <layer xml:id="layer-1955997997" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000126570859" dur="8" oct="5" pname="d">
+                                        <note xml:id="note-0126570859" dur="8" oct="5" pname="d">
                                             <accid accid="f" />
-                                            <verse xml:lang="ita" xml:id="verse-0000001069456724" n="1">
+                                            <verse xml:lang="ita" xml:id="verse-1069456724" n="1">
                                                 <syl con="d" wordpos="i">tan</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000281548083" dur="8" oct="4" pname="c" />
+                                        <note xml:id="note-0281548083" dur="8" oct="4" pname="c" />
                                     </beam>
-                                    <note xml:id="note-0000001190840635" dur="8" oct="5" pname="d" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000928368787" n="1">
+                                    <note xml:id="note-1190840635" dur="8" oct="5" pname="d" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0928368787" n="1">
                                             <syl con="s" wordpos="t">to</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001098005516" n="2">
-                                <layer xml:id="layer-0000001700355061" n="1">
-                                    <note xml:id="note-0000002077559792" dur="8" oct="3" pname="b" accid.ges="f" />
-                                    <note xml:id="note-0000001412143244" dur="4" oct="3" pname="g" />
+                            <staff xml:id="staff-1098005516" n="2">
+                                <layer xml:id="layer-1700355061" n="1">
+                                    <note xml:id="note-2077559792" dur="8" oct="3" pname="b" accid.ges="f" />
+                                    <note xml:id="note-1412143244" dur="4" oct="3" pname="g" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000278050295" n="44">
-                            <staff xml:id="staff-0000000015149877" n="1">
-                                <layer xml:id="layer-0000001650900449" n="1">
+                        <measure xml:id="measure-0278050295" n="44">
+                            <staff xml:id="staff-0015149877" n="1">
+                                <layer xml:id="layer-1650900449" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000580361983" dur="8" oct="5" pname="c">
-                                            <verse xml:lang="ita" xml:id="verse-0000000665514921" n="1">
+                                        <note xml:id="note-0580361983" dur="8" oct="5" pname="c">
+                                            <verse xml:lang="ita" xml:id="verse-0665514921" n="1">
                                                 <syl con="s">suo</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000810407422" dur="8" oct="4" pname="d">
+                                        <note xml:id="note-0810407422" dur="8" oct="4" pname="d">
                                             <accid accid="f" />
                                         </note>
                                     </beam>
-                                    <note xml:id="note-0000000426198928" dur="8" oct="5" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000000686566332" n="1">
+                                    <note xml:id="note-0426198928" dur="8" oct="5" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-0686566332" n="1">
                                             <syl con="d" wordpos="i">do</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001622424169" n="2">
-                                <layer xml:id="layer-0000001462516370" n="1">
-                                    <note xml:id="note-0000002132712142" dur="8" oct="3" pname="a" accid.ges="f" />
-                                    <note xml:id="note-0000000603396193" dur="4" oct="3" pname="f" />
+                            <staff xml:id="staff-1622424169" n="2">
+                                <layer xml:id="layer-1462516370" n="1">
+                                    <note xml:id="note-2132712142" dur="8" oct="3" pname="a" accid.ges="f" />
+                                    <note xml:id="note-0603396193" dur="4" oct="3" pname="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000836241476" n="45">
-                            <staff xml:id="staff-0000000343749369" n="1">
-                                <layer xml:id="layer-0000000941276257" n="1">
+                        <measure xml:id="measure-0836241476" n="45">
+                            <staff xml:id="staff-0343749369" n="1">
+                                <layer xml:id="layer-0941276257" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001487501225" dur="8" oct="4" pname="b" accid.ges="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000000780254194" n="1">
+                                        <note xml:id="note-1487501225" dur="8" oct="4" pname="b" accid.ges="f">
+                                            <verse xml:lang="ita" xml:id="verse-0780254194" n="1">
                                                 <syl con="s" wordpos="t">lor</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001486226219" dur="8" oct="4" pname="c" />
+                                        <note xml:id="note-1486226219" dur="8" oct="4" pname="c" />
                                     </beam>
-                                    <note xml:id="note-0000001988180088" dur="8" oct="4" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000159496267" n="1">
+                                    <note xml:id="note-1988180088" dur="8" oct="4" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0159496267" n="1">
                                             <syl con="s">ti</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000954954693" n="2">
-                                <layer xml:id="layer-0000001613791596" n="1">
-                                    <note xml:id="note-0000001323426560" dur="8" oct="3" pname="g" />
-                                    <note xml:id="note-0000001182786542" dur="4" oct="3" pname="e">
+                            <staff xml:id="staff-0954954693" n="2">
+                                <layer xml:id="layer-1613791596" n="1">
+                                    <note xml:id="note-1323426560" dur="8" oct="3" pname="g" />
+                                    <note xml:id="note-1182786542" dur="4" oct="3" pname="e">
                                         <accid accid="n" />
                                     </note>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000002090530145" n="46">
-                            <staff xml:id="staff-0000000512999510" n="1">
-                                <layer xml:id="layer-0000001335574552" n="1">
+                        <measure xml:id="measure-2090530145" n="46">
+                            <staff xml:id="staff-0512999510" n="1">
+                                <layer xml:id="layer-1335574552" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000572751606" dur="8" oct="4" pname="a" accid.ges="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000001048395254" n="1">
+                                        <note xml:id="note-0572751606" dur="8" oct="4" pname="a" accid.ges="f">
+                                            <verse xml:lang="ita" xml:id="verse-1048395254" n="1">
                                                 <syl con="d" wordpos="i">chie</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001889382306" dur="8" oct="3" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1889382306" dur="8" oct="3" pname="b" accid.ges="f" />
                                     </beam>
-                                    <note xml:id="note-0000000913800791" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000227181097" n="1">
+                                    <note xml:id="note-0913800791" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0227181097" n="1">
                                             <syl con="b" wordpos="t">de</syl>
                                             <syl con="s">un</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000934982376" n="2">
-                                <layer xml:id="layer-0000002071018196" n="1">
-                                    <note xml:id="note-0000000781472131" dur="8" oct="3" pname="f" />
-                                    <note xml:id="note-0000001633630122" dur="4" oct="3" pname="d" />
+                            <staff xml:id="staff-0934982376" n="2">
+                                <layer xml:id="layer-2071018196" n="1">
+                                    <note xml:id="note-0781472131" dur="8" oct="3" pname="f" />
+                                    <note xml:id="note-1633630122" dur="4" oct="3" pname="d" />
                                 </layer>
                             </staff>
                         </measure>
                         <sb source="#secondEdition" />
-                        <measure xml:id="measure-0000000126058140" n="47">
-                            <staff xml:id="staff-0000000915261889" n="1">
-                                <layer xml:id="layer-0000002119713160" n="1">
-                                    <note xml:id="note-0000001701696640" dots="1" dur="4" oct="4" pname="g">
+                        <measure xml:id="measure-0126058140" n="47">
+                            <staff xml:id="staff-0915261889" n="1">
+                                <layer xml:id="layer-2119713160" n="1">
+                                    <note xml:id="note-1701696640" dots="1" dur="4" oct="4" pname="g">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000001242172518" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-1242172518" n="1">
                                             <syl con="d" wordpos="i">guar</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001931597485" n="2">
-                                <layer xml:id="layer-0000001507525396" n="1">
+                            <staff xml:id="staff-1931597485" n="2">
+                                <layer xml:id="layer-1507525396" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000213716034" dur="8" oct="3" pname="e" accid.ges="f" />
-                                        <note xml:id="note-0000000180388836" dur="8" oct="3" pname="d">
+                                        <note xml:id="note-0213716034" dur="8" oct="3" pname="e" accid.ges="f" />
+                                        <note xml:id="note-0180388836" dur="8" oct="3" pname="d">
                                             <accid accid="f" />
                                         </note>
-                                        <note xml:id="note-0000001058355779" dur="8" oct="3" pname="c" />
+                                        <note xml:id="note-1058355779" dur="8" oct="3" pname="c" />
                                     </beam>
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000000076612965" startid="#note-0000001701696640" endid="#note-0000000690205892" />
+                            <tie xml:id="tie-0076612965" startid="#note-1701696640" endid="#note-0690205892" />
                         </measure>
-                        <measure xml:id="measure-0000001896409306" n="48">
-                            <staff xml:id="staff-0000000832793282" n="1">
-                                <layer xml:id="layer-0000000349914723" n="1">
-                                    <note xml:id="note-0000000690205892" dur="8" oct="4" pname="g" accid.ges="f">
-                                        <reg resp="#rettinghaus">
-                                            <accid accid="f" enclose="brack" />
-                                        </reg>
+                        <measure xml:id="measure-1896409306" n="48">
+                            <staff xml:id="staff-0832793282" n="1">
+                                <layer xml:id="layer-0349914723" n="1">
+                                    <note xml:id="note-0690205892" dur="8" oct="4" pname="g" accid.ges="f">
+                                        <supplied resp="#rettinghaus">
+                                            <reg>
+                                                <accid accid="f" />
+                                            </reg>
+                                        </supplied>
                                     </note>
-                                    <note xml:id="note-0000002004616624" dur="8" oct="4" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000569921083" n="1">
+                                    <note xml:id="note-2004616624" dur="8" oct="4" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0569921083" n="1">
                                             <syl con="s" wordpos="t">do</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001260989164" dur="8" oct="5" pname="d">
+                                    <note xml:id="note-1260989164" dur="8" oct="5" pname="d">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000001780589873" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-1780589873" n="1">
                                             <syl con="s">ti</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001438196763" n="2">
-                                <layer xml:id="layer-0000001392383078" n="1">
-                                    <note xml:id="note-0000001452964113" dots="1" dur="4" oct="2" pname="b" accid.ges="f" />
+                            <staff xml:id="staff-1438196763" n="2">
+                                <layer xml:id="layer-1392383078" n="1">
+                                    <note xml:id="note-1452964113" dots="1" dur="4" oct="2" pname="b" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001581692632" n="49">
-                            <staff xml:id="staff-0000001369348953" n="1">
-                                <layer xml:id="layer-0000002092079035" n="1">
+                        <measure xml:id="measure-1581692632" n="49">
+                            <staff xml:id="staff-1369348953" n="1">
+                                <layer xml:id="layer-2092079035" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000015487870" dur="8" oct="4" pname="c">
-                                            <verse xml:lang="ita" xml:id="verse-0000001960420055" n="1">
+                                        <note xml:id="note-0015487870" dur="8" oct="4" pname="c">
+                                            <verse xml:lang="ita" xml:id="verse-1960420055" n="1">
                                                 <syl con="d" wordpos="i">chie</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000874336678" dur="8" oct="5" pname="c" />
+                                        <note xml:id="note-0874336678" dur="8" oct="5" pname="c" />
                                     </beam>
-                                    <note xml:id="note-0000002112776078" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000617250359" n="1">
+                                    <note xml:id="note-2112776078" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-0617250359" n="1">
                                             <syl con="s" wordpos="t">de</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001715891227" n="2">
-                                <layer xml:id="layer-0000000079547058" n="1">
-                                    <note xml:id="note-0000000050142109" dur="4" oct="2" pname="b" accid.ges="f" />
-                                    <note xml:id="note-0000001309426703" dur="8" oct="2" pname="a" accid.ges="f" />
+                            <staff xml:id="staff-1715891227" n="2">
+                                <layer xml:id="layer-0079547058" n="1">
+                                    <note xml:id="note-0050142109" dur="4" oct="2" pname="b" accid.ges="f" />
+                                    <note xml:id="note-1309426703" dur="8" oct="2" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000062221577" n="50">
-                            <staff xml:id="staff-0000001540725230" n="1">
-                                <layer xml:id="layer-0000001986753567" n="1">
-                                    <note xml:id="note-0000000864544935" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000324749318" n="1">
+                        <measure xml:id="measure-0062221577" n="50">
+                            <staff xml:id="staff-1540725230" n="1">
+                                <layer xml:id="layer-1986753567" n="1">
+                                    <note xml:id="note-0864544935" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0324749318" n="1">
                                             <syl con="s">un</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001843920395" dur="4" oct="4" pname="g">
-                                        <verse xml:lang="ita" xml:id="verse-0000000416534931" n="1">
+                                    <note xml:id="note-1843920395" dur="4" oct="4" pname="g">
+                                        <verse xml:lang="ita" xml:id="verse-0416534931" n="1">
                                             <syl con="d" wordpos="i">guar</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001214412713" n="2">
-                                <layer xml:id="layer-0000001131002434" n="1">
-                                    <note xml:id="note-0000000915059188" dur="8" oct="2" pname="b" accid.ges="f" />
-                                    <note xml:id="note-0000000658245345" dur="4" oct="3" pname="c" />
+                            <staff xml:id="staff-1214412713" n="2">
+                                <layer xml:id="layer-1131002434" n="1">
+                                    <note xml:id="note-0915059188" dur="8" oct="2" pname="b" accid.ges="f" />
+                                    <note xml:id="note-0658245345" dur="4" oct="3" pname="c" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000002086515176" n="51">
-                            <staff xml:id="staff-0000001717254159" n="1">
-                                <layer xml:id="layer-0000001306947905" n="1">
-                                    <note xml:id="note-0000000531718232" dur="4" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000718207049" n="1">
+                        <measure xml:id="measure-2086515176" n="51">
+                            <staff xml:id="staff-1717254159" n="1">
+                                <layer xml:id="layer-1306947905" n="1">
+                                    <note xml:id="note-0531718232" dur="4" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-0718207049" n="1">
                                             <syl con="s" wordpos="t">do</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000815453161" dur="8" oct="5" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000001600338342" n="1">
+                                    <note xml:id="note-0815453161" dur="8" oct="5" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-1600338342" n="1">
                                             <syl con="s">col</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001453975119" n="2">
-                                <layer xml:id="layer-0000001019354578" n="1">
-                                    <note xml:id="note-0000001485534347" dur="4" oct="3" pname="f" />
-                                    <note xml:id="note-0000001023839715" dur="8" oct="3" pname="f" />
+                            <staff xml:id="staff-1453975119" n="2">
+                                <layer xml:id="layer-1019354578" n="1">
+                                    <note xml:id="note-1485534347" dur="4" oct="3" pname="f" />
+                                    <note xml:id="note-1023839715" dur="8" oct="3" pname="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001161379814" n="52">
-                            <staff xml:id="staff-0000000753053021" n="1">
-                                <layer xml:id="layer-0000001920772533" n="1">
+                        <measure xml:id="measure-1161379814" n="52">
+                            <staff xml:id="staff-0753053021" n="1">
+                                <layer xml:id="layer-1920772533" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000980831729" dur="8" oct="5" pname="d">
+                                        <note xml:id="note-0980831729" dur="8" oct="5" pname="d">
                                             <accid accid="f" />
-                                            <verse xml:lang="ita" xml:id="verse-0000000352578909" n="1">
+                                            <verse xml:lang="ita" xml:id="verse-0352578909" n="1">
                                                 <syl con="d" wordpos="i">pian</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000339430255" dur="8" oct="4" pname="e">
+                                        <note xml:id="note-0339430255" dur="8" oct="4" pname="e">
                                             <accid accid="n" />
                                         </note>
                                     </beam>
-                                    <note xml:id="note-0000000024230526" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001095071546" n="1">
+                                    <note xml:id="note-0024230526" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-1095071546" n="1">
                                             <syl con="s" wordpos="t">to</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000387545145" n="2">
-                                <layer xml:id="layer-0000000855801627" n="1">
-                                    <note xml:id="note-0000000297906996" dur="4" oct="3" pname="b" accid.ges="f" />
-                                    <note xml:id="note-0000000363171979" dur="8" oct="3" pname="a" accid.ges="f" />
+                            <staff xml:id="staff-0387545145" n="2">
+                                <layer xml:id="layer-0855801627" n="1">
+                                    <note xml:id="note-0297906996" dur="4" oct="3" pname="b" accid.ges="f" />
+                                    <note xml:id="note-0363171979" dur="8" oct="3" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000534360783" n="53">
-                            <staff xml:id="staff-0000000150059367" n="1">
-                                <layer xml:id="layer-0000000521238015" n="1">
+                        <measure xml:id="measure-0534360783" n="53">
+                            <staff xml:id="staff-0150059367" n="1">
+                                <layer xml:id="layer-0521238015" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001501896870" dur="8" oct="4" pname="a" accid.ges="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000000401768573" n="1">
+                                        <note xml:id="note-1501896870" dur="8" oct="4" pname="a" accid.ges="f">
+                                            <verse xml:lang="ita" xml:id="verse-0401768573" n="1">
                                                 <syl con="s">coi</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001022595359" dur="8" oct="3" pname="b">
+                                        <note xml:id="note-1022595359" dur="8" oct="3" pname="b">
                                             <accid accid="n" />
                                         </note>
                                     </beam>
-                                    <note xml:id="note-0000001646788070" dur="8" oct="4" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000000849283473" n="1">
+                                    <note xml:id="note-1646788070" dur="8" oct="4" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-0849283473" n="1">
                                             <syl con="d" wordpos="i">so</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001927035404" n="2">
-                                <layer xml:id="layer-0000000104644380" n="1">
-                                    <note xml:id="note-0000001965239152" dur="4" oct="3" pname="f" />
-                                    <note xml:id="note-0000000245173964" dur="8" oct="3" pname="e">
+                            <staff xml:id="staff-1927035404" n="2">
+                                <layer xml:id="layer-0104644380" n="1">
+                                    <note xml:id="note-1965239152" dur="4" oct="3" pname="f" />
+                                    <note xml:id="note-0245173964" dur="8" oct="3" pname="e">
                                         <accid accid="n" />
                                     </note>
                                 </layer>
                             </staff>
                         </measure>
                         <sb source="#secondEdition" />
-                        <measure xml:id="measure-0000000507132249" n="54">
-                            <staff xml:id="staff-0000001677437811" n="1">
-                                <layer xml:id="layer-0000000430407325" n="1">
-                                    <note xml:id="note-0000000820233692" dur="8" oct="4" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001458646192" n="1">
+                        <measure xml:id="measure-0507132249" n="54">
+                            <staff xml:id="staff-1677437811" n="1">
+                                <layer xml:id="layer-0430407325" n="1">
+                                    <note xml:id="note-0820233692" dur="8" oct="4" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1458646192" n="1">
                                             <syl con="d" wordpos="m">spi</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001389363106" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001740754439" n="1">
+                                    <note xml:id="note-1389363106" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1740754439" n="1">
                                             <syl con="d" wordpos="m">ri</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001864003908" dur="8" oct="5" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000001291417083" n="1">
+                                    <note xml:id="note-1864003908" dur="8" oct="5" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-1291417083" n="1">
                                             <syl con="s" wordpos="t">ti</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001114984032" n="2">
-                                <layer xml:id="layer-0000001058983603" n="1">
+                            <staff xml:id="staff-1114984032" n="2">
+                                <layer xml:id="layer-1058983603" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001058248502" dur="8" oct="3" pname="c" />
-                                        <note xml:id="note-0000000285140665" dur="8" oct="3" pname="f" />
-                                        <note xml:id="note-0000001577245901" dur="8" oct="3" pname="a" accid.ges="f" />
+                                        <note xml:id="note-1058248502" dur="8" oct="3" pname="c" />
+                                        <note xml:id="note-0285140665" dur="8" oct="3" pname="f" />
+                                        <note xml:id="note-1577245901" dur="8" oct="3" pname="a" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001308232561" n="55">
-                            <staff xml:id="staff-0000002045899984" n="1">
-                                <layer xml:id="layer-0000000810599421" n="1">
+                        <measure xml:id="measure-1308232561" n="55">
+                            <staff xml:id="staff-2045899984" n="1">
+                                <layer xml:id="layer-0810599421" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001035804017" dur="8" oct="5" pname="d">
+                                        <note xml:id="note-1035804017" dur="8" oct="5" pname="d">
                                             <accid accid="f" />
-                                            <verse xml:lang="ita" xml:id="verse-0000000098423676" n="1">
+                                            <verse xml:lang="ita" xml:id="verse-0098423676" n="1">
                                                 <syl con="d" wordpos="i">par</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000762984754" dur="8" oct="4" pname="e">
+                                        <note xml:id="note-0762984754" dur="8" oct="4" pname="e">
                                             <accid accid="n" />
                                         </note>
                                     </beam>
-                                    <note xml:id="note-0000000791155922" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000888512777" n="1">
+                                    <note xml:id="note-0791155922" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-0888512777" n="1">
                                             <syl con="s" wordpos="t">la</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000596420233" n="2">
-                                <layer xml:id="layer-0000001035220520" n="1">
-                                    <note xml:id="note-0000000862514497" dur="4" oct="3" pname="b" accid.ges="f" />
-                                    <note xml:id="note-0000001207222821" dur="8" oct="3" pname="a" accid.ges="f" />
+                            <staff xml:id="staff-0596420233" n="2">
+                                <layer xml:id="layer-1035220520" n="1">
+                                    <note xml:id="note-0862514497" dur="4" oct="3" pname="b" accid.ges="f" />
+                                    <note xml:id="note-1207222821" dur="8" oct="3" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000878238234" n="56">
-                            <staff xml:id="staff-0000001884315208" n="1">
-                                <layer xml:id="layer-0000001755422808" n="1">
+                        <measure xml:id="measure-0878238234" n="56">
+                            <staff xml:id="staff-1884315208" n="1">
+                                <layer xml:id="layer-1755422808" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000532634358" dur="8" oct="4" pname="a" accid.ges="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000001125288079" n="1">
+                                        <note xml:id="note-0532634358" dur="8" oct="4" pname="a" accid.ges="f">
+                                            <verse xml:lang="ita" xml:id="verse-1125288079" n="1">
                                                 <syl con="d" wordpos="i">que</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001165436994" dur="8" oct="3" pname="b">
+                                        <note xml:id="note-1165436994" dur="8" oct="3" pname="b">
                                             <accid accid="n" />
                                         </note>
                                     </beam>
-                                    <note xml:id="note-0000001128297739" dur="8" oct="4" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000001574807492" n="1">
+                                    <note xml:id="note-1128297739" dur="8" oct="4" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-1574807492" n="1">
                                             <syl con="s" wordpos="t">sto</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000002100353158" n="2">
-                                <layer xml:id="layer-0000000241404377" n="1">
-                                    <note xml:id="note-0000001884178414" dur="4" oct="3" pname="f" />
-                                    <note xml:id="note-0000001577894260" dur="8" oct="3" pname="e">
+                            <staff xml:id="staff-2100353158" n="2">
+                                <layer xml:id="layer-0241404377" n="1">
+                                    <note xml:id="note-1884178414" dur="4" oct="3" pname="f" />
+                                    <note xml:id="note-1577894260" dur="8" oct="3" pname="e">
                                         <accid accid="n" />
                                     </note>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000825901958" n="57">
-                            <staff xml:id="staff-0000000749813110" n="1">
-                                <layer xml:id="layer-0000002025675318" n="1">
-                                    <note xml:id="note-0000001036611080" dur="4" oct="4" pname="a">
+                        <measure xml:id="measure-0825901958" n="57">
+                            <staff xml:id="staff-0749813110" n="1">
+                                <layer xml:id="layer-2025675318" n="1">
+                                    <note xml:id="note-1036611080" dur="4" oct="4" pname="a">
                                         <accid accid="n" />
-                                        <verse xml:lang="ita" xml:id="verse-0000000748527330" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-0748527330" n="1">
                                             <syl con="s">cor</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001068585051" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001462337079" n="1">
+                                    <note xml:id="note-1068585051" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-1462337079" n="1">
                                             <syl con="b">e</syl>
                                             <syl con="s">a</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000159184330" n="2">
-                                <layer xml:id="layer-0000002097929470" n="1">
-                                    <note xml:id="note-0000001508362892" dur="4" oct="3" pname="e">
+                            <staff xml:id="staff-0159184330" n="2">
+                                <layer xml:id="layer-2097929470" n="1">
+                                    <note xml:id="note-1508362892" dur="4" oct="3" pname="e">
                                         <accid accid="f" />
                                     </note>
-                                    <rest xml:id="rest-0000000897583709" dur="8" />
+                                    <rest xml:id="rest-0897583709" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000996981487" n="58">
-                            <staff xml:id="staff-0000002128218996" n="1">
-                                <layer xml:id="layer-0000000000653411" n="1">
+                        <measure xml:id="measure-0996981487" n="58">
+                            <staff xml:id="staff-2128218996" n="1">
+                                <layer xml:id="layer-0000653411" n="1">
                                     <beam>
-                                        <note xml:id="note-0000002143838673" dur="8" oct="5" pname="d">
+                                        <note xml:id="note-2143838673" dur="8" oct="5" pname="d">
                                             <accid accid="f" />
-                                            <verse xml:lang="ita" xml:id="verse-0000001258350579" n="1">
+                                            <verse xml:lang="ita" xml:id="verse-1258350579" n="1">
                                                 <syl con="d" wordpos="i">tan</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000508718519" dur="8" oct="4" pname="a">
+                                        <note xml:id="note-0508718519" dur="8" oct="4" pname="a">
                                             <accid accid="n" />
                                         </note>
                                     </beam>
-                                    <note xml:id="note-0000001189451124" dur="8" oct="4" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001979281316" n="1">
+                                    <note xml:id="note-1189451124" dur="8" oct="4" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1979281316" n="1">
                                             <syl con="s" wordpos="t">to</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000532421076" n="2">
-                                <layer xml:id="layer-0000001817780374" n="1">
+                            <staff xml:id="staff-0532421076" n="2">
+                                <layer xml:id="layer-1817780374" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001998448942" dur="8" oct="2" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000000554647783" dur="8" oct="3" pname="c" />
-                                        <note xml:id="note-0000001465954260" dur="8" oct="3" pname="d">
+                                        <note xml:id="note-1998448942" dur="8" oct="2" pname="b" accid.ges="f" />
+                                        <note xml:id="note-0554647783" dur="8" oct="3" pname="c" />
+                                        <note xml:id="note-1465954260" dur="8" oct="3" pname="d">
                                             <accid accid="f" />
                                         </note>
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001622242376" n="59">
-                            <staff xml:id="staff-0000000905706290" n="1">
-                                <layer xml:id="layer-0000001674438894" n="1">
+                        <measure xml:id="measure-1622242376" n="59">
+                            <staff xml:id="staff-0905706290" n="1">
+                                <layer xml:id="layer-1674438894" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001590518872" dur="8" oct="4" pname="g">
+                                        <note xml:id="note-1590518872" dur="8" oct="4" pname="g">
                                             <accid accid="f" />
-                                            <verse xml:lang="ita" xml:id="verse-0000001372343531" n="1">
+                                            <verse xml:lang="ita" xml:id="verse-1372343531" n="1">
                                                 <syl con="s">suo</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001069281726" dur="8" oct="4" pname="e">
+                                        <note xml:id="note-1069281726" dur="8" oct="4" pname="e">
                                             <accid accid="n" />
                                         </note>
                                     </beam>
-                                    <note xml:id="note-0000002071583312" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000605592962" n="1">
+                                    <note xml:id="note-2071583312" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-0605592962" n="1">
                                             <syl con="d" wordpos="i">do</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000851750498" n="2">
-                                <layer xml:id="layer-0000001027259765" n="1">
+                            <staff xml:id="staff-0851750498" n="2">
+                                <layer xml:id="layer-1027259765" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000123092713" dur="8" oct="2" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000001890580143" dur="8" oct="3" pname="c" />
-                                        <note xml:id="note-0000001512298953" dur="8" oct="3" pname="d">
+                                        <note xml:id="note-0123092713" dur="8" oct="2" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1890580143" dur="8" oct="3" pname="c" />
+                                        <note xml:id="note-1512298953" dur="8" oct="3" pname="d">
                                             <accid accid="f" />
                                         </note>
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001870031136" n="60">
-                            <staff xml:id="staff-0000000279966139" n="1">
-                                <layer xml:id="layer-0000001094140772" n="1">
-                                    <note xml:id="note-0000000912927390" dur="4" oct="4" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001549798315" n="1">
+                        <measure xml:id="measure-1870031136" n="60">
+                            <staff xml:id="staff-0279966139" n="1">
+                                <layer xml:id="layer-1094140772" n="1">
+                                    <note xml:id="note-0912927390" dur="4" oct="4" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1549798315" n="1">
                                             <syl con="s" wordpos="t">lor</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000063399080" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000535203830" n="1">
+                                    <note xml:id="note-0063399080" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0535203830" n="1">
                                             <syl con="s">ti</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000518549244" n="2">
-                                <layer xml:id="layer-0000000672423139" n="1">
+                            <staff xml:id="staff-0518549244" n="2">
+                                <layer xml:id="layer-0672423139" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001530576017" dur="8" oct="2" pname="g" />
-                                        <note xml:id="note-0000001354406965" dur="8" oct="2" pname="e">
+                                        <note xml:id="note-1530576017" dur="8" oct="2" pname="g" />
+                                        <note xml:id="note-1354406965" dur="8" oct="2" pname="e">
                                             <accid accid="n" />
                                         </note>
-                                        <note xml:id="note-0000001352905806" dur="8" oct="2" pname="f" />
+                                        <note xml:id="note-1352905806" dur="8" oct="2" pname="f" />
                                     </beam>
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000000846432627" startid="#note-0000000063399080" endid="#note-0000001175774428" />
+                            <tie xml:id="tie-0846432627" startid="#note-0063399080" endid="#note-1175774428" />
                         </measure>
                         <pb source="#secondEdition" n="358" facs="#graphic_01DRXXBW8TDF2VZZ3FDRVB0FQW" />
-                        <measure xml:id="measure-0000000108211109" n="61">
-                            <staff xml:id="staff-0000001669005315" n="1">
-                                <layer xml:id="layer-0000002103028031" n="1">
-                                    <note xml:id="note-0000001175774428" dur="8" oct="4" pname="a" accid.ges="f" />
-                                    <note xml:id="note-0000002020758775" dur="8" oct="4" pname="g">
+                        <measure xml:id="measure-0108211109" n="61">
+                            <staff xml:id="staff-1669005315" n="1">
+                                <layer xml:id="layer-2103028031" n="1">
+                                    <note xml:id="note-1175774428" dur="8" oct="4" pname="a" accid.ges="f" />
+                                    <note xml:id="note-2020758775" dur="8" oct="4" pname="g">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000000466990168" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-0466990168" n="1">
                                             <syl con="d" wordpos="i">chie</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001768328095" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001794263299" n="1">
+                                    <note xml:id="note-1768328095" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-1794263299" n="1">
                                             <syl con="b" wordpos="t">de</syl>
                                             <syl con="s">un</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000084431686" n="2">
-                                <layer xml:id="layer-0000000070348189" n="1">
-                                    <note xml:id="note-0000000247814389" dots="1" dur="4" oct="2" pname="b" accid.ges="f" />
+                            <staff xml:id="staff-0084431686" n="2">
+                                <layer xml:id="layer-0070348189" n="1">
+                                    <note xml:id="note-0247814389" dots="1" dur="4" oct="2" pname="b" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000039426911" n="62">
-                            <staff xml:id="staff-0000000755410918" n="1">
-                                <layer xml:id="layer-0000000128666271" n="1">
-                                    <note xml:id="note-0000000785174152" dur="8" oct="4" pname="e">
+                        <measure xml:id="measure-0039426911" n="62">
+                            <staff xml:id="staff-0755410918" n="1">
+                                <layer xml:id="layer-0128666271" n="1">
+                                    <note xml:id="note-0785174152" dur="8" oct="4" pname="e">
                                         <accid accid="n" />
-                                        <verse xml:lang="ita" xml:id="verse-0000001802518825" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-1802518825" n="1">
                                             <syl con="d" wordpos="i">guar</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000994029514" dur="8" oct="4" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000001671912723" n="1">
+                                    <note xml:id="note-0994029514" dur="8" oct="4" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-1671912723" n="1">
                                             <syl con="s" wordpos="t">do,</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000318556380" dur="8" oct="5" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000001086441902" n="1">
+                                    <note xml:id="note-0318556380" dur="8" oct="5" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-1086441902" n="1">
                                             <syl con="s">a</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001669705573" n="2">
-                                <layer xml:id="layer-0000001818949351" n="1">
-                                    <note xml:id="note-0000000154314368" dur="4" oct="3" pname="c" />
-                                    <note xml:id="note-0000001328225345" dur="8" oct="3" pname="a" accid.ges="f" />
+                            <staff xml:id="staff-1669705573" n="2">
+                                <layer xml:id="layer-1818949351" n="1">
+                                    <note xml:id="note-0154314368" dur="4" oct="3" pname="c" />
+                                    <note xml:id="note-1328225345" dur="8" oct="3" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000173914305" n="63">
-                            <staff xml:id="staff-0000000127171504" n="1">
-                                <layer xml:id="layer-0000000964067393" n="1">
+                        <measure xml:id="measure-0173914305" n="63">
+                            <staff xml:id="staff-0127171504" n="1">
+                                <layer xml:id="layer-0964067393" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001356979422" dur="16" oct="5" pname="d">
+                                        <note xml:id="note-1356979422" dur="16" oct="5" pname="d">
                                             <accid accid="f" />
-                                            <verse xml:lang="ita" xml:id="verse-0000001278395310" n="1">
+                                            <verse xml:lang="ita" xml:id="verse-1278395310" n="1">
                                                 <syl con="d" wordpos="i">tan</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000670946431" dur="16" oct="4" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000000647718926" dur="8" oct="4" pname="e">
+                                        <note xml:id="note-0670946431" dur="16" oct="4" pname="b" accid.ges="f" />
+                                        <note xml:id="note-0647718926" dur="8" oct="4" pname="e">
                                             <accid accid="f" />
                                         </note>
                                     </beam>
-                                    <note xml:id="note-0000000151838483" dur="8" oct="5" pname="d" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001149701540" n="1">
+                                    <note xml:id="note-0151838483" dur="8" oct="5" pname="d" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1149701540" n="1">
                                             <syl con="s" wordpos="t">to</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001262767273" n="2">
-                                <layer xml:id="layer-0000001984813085" n="1">
+                            <staff xml:id="staff-1262767273" n="2">
+                                <layer xml:id="layer-1984813085" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001878427451" dur="8" oct="3" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000000253072912" dur="8" oct="3" pname="g" />
+                                        <note xml:id="note-1878427451" dur="8" oct="3" pname="b" accid.ges="f" />
+                                        <note xml:id="note-0253072912" dur="8" oct="3" pname="g" />
                                     </beam>
-                                    <rest xml:id="rest-0000000850298778" dur="8" />
+                                    <rest xml:id="rest-0850298778" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000951445429" n="64">
-                            <staff xml:id="staff-0000000349323582" n="1">
-                                <layer xml:id="layer-0000001488828688" n="1">
+                        <measure xml:id="measure-0951445429" n="64">
+                            <staff xml:id="staff-0349323582" n="1">
+                                <layer xml:id="layer-1488828688" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000225156504" dur="16" oct="5" pname="c">
-                                            <verse xml:lang="ita" xml:id="verse-0000000465810824" n="1">
+                                        <note xml:id="note-0225156504" dur="16" oct="5" pname="c">
+                                            <verse xml:lang="ita" xml:id="verse-0465810824" n="1">
                                                 <syl con="s">suo</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000749860590" dur="16" oct="4" pname="a" accid.ges="f" />
-                                        <note xml:id="note-0000001800903796" dur="8" oct="4" pname="d">
+                                        <note xml:id="note-0749860590" dur="16" oct="4" pname="a" accid.ges="f" />
+                                        <note xml:id="note-1800903796" dur="8" oct="4" pname="d">
                                             <accid accid="f" />
                                         </note>
                                     </beam>
-                                    <note xml:id="note-0000000579936297" dur="8" oct="5" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000001205234784" n="1">
+                                    <note xml:id="note-0579936297" dur="8" oct="5" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-1205234784" n="1">
                                             <syl con="d" wordpos="i">do</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000511768123" n="2">
-                                <layer xml:id="layer-0000000900553612" n="1">
+                            <staff xml:id="staff-0511768123" n="2">
+                                <layer xml:id="layer-0900553612" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001360382734" dur="8" oct="3" pname="a" accid.ges="f" />
-                                        <note xml:id="note-0000001616307740" dur="8" oct="3" pname="f" />
+                                        <note xml:id="note-1360382734" dur="8" oct="3" pname="a" accid.ges="f" />
+                                        <note xml:id="note-1616307740" dur="8" oct="3" pname="f" />
                                     </beam>
-                                    <rest xml:id="rest-0000001045344172" dur="8" />
+                                    <rest xml:id="rest-1045344172" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001787336593" n="65">
-                            <staff xml:id="staff-0000001453378118" n="1">
-                                <layer xml:id="layer-0000001211205720" n="1">
+                        <measure xml:id="measure-1787336593" n="65">
+                            <staff xml:id="staff-1453378118" n="1">
+                                <layer xml:id="layer-1211205720" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001674621567" dur="16" oct="4" pname="b" accid.ges="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000001422923261" n="1">
+                                        <note xml:id="note-1674621567" dur="16" oct="4" pname="b" accid.ges="f">
+                                            <verse xml:lang="ita" xml:id="verse-1422923261" n="1">
                                                 <syl con="s" wordpos="t">lor</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000200655574" dur="16" oct="4" pname="g" />
-                                        <note xml:id="note-0000000389132655" dur="8" oct="4" pname="c" />
+                                        <note xml:id="note-0200655574" dur="16" oct="4" pname="g" />
+                                        <note xml:id="note-0389132655" dur="8" oct="4" pname="c" />
                                     </beam>
-                                    <note xml:id="note-0000000421311648" dur="8" oct="4" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000002034967226" n="1">
+                                    <note xml:id="note-0421311648" dur="8" oct="4" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-2034967226" n="1">
                                             <syl con="s">ti</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000487094038" n="2">
-                                <layer xml:id="layer-0000001840247703" n="1">
+                            <staff xml:id="staff-0487094038" n="2">
+                                <layer xml:id="layer-1840247703" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000473698776" dur="8" oct="3" pname="g" />
-                                        <note xml:id="note-0000001936681429" dur="8" oct="3" pname="e">
+                                        <note xml:id="note-0473698776" dur="8" oct="3" pname="g" />
+                                        <note xml:id="note-1936681429" dur="8" oct="3" pname="e">
                                             <accid accid="n" />
                                         </note>
                                     </beam>
-                                    <rest xml:id="rest-0000002043198343" dur="8" />
+                                    <rest xml:id="rest-2043198343" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000002139178326" n="66">
-                            <staff xml:id="staff-0000000422344179" n="1">
-                                <layer xml:id="layer-0000002059282601" n="1">
+                        <measure xml:id="measure-2139178326" n="66">
+                            <staff xml:id="staff-0422344179" n="1">
+                                <layer xml:id="layer-2059282601" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001058331736" dur="16" oct="4" pname="a" accid.ges="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000000293188938" n="1">
+                                        <note xml:id="note-1058331736" dur="16" oct="4" pname="a" accid.ges="f">
+                                            <verse xml:lang="ita" xml:id="verse-0293188938" n="1">
                                                 <syl con="d" wordpos="i">chie</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000493273939" dur="16" oct="4" pname="f" />
-                                        <note xml:id="note-0000001594461882" dur="8" oct="3" pname="b" accid.ges="f" />
+                                        <note xml:id="note-0493273939" dur="16" oct="4" pname="f" />
+                                        <note xml:id="note-1594461882" dur="8" oct="3" pname="b" accid.ges="f" />
                                     </beam>
-                                    <note xml:id="note-0000000028194672" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000954873236" n="1">
+                                    <note xml:id="note-0028194672" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0954873236" n="1">
                                             <syl con="b" wordpos="t">de</syl>
                                             <syl con="s">un</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000050443779" n="2">
-                                <layer xml:id="layer-0000001688645573" n="1">
+                            <staff xml:id="staff-0050443779" n="2">
+                                <layer xml:id="layer-1688645573" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000187082798" dur="8" oct="3" pname="f" />
-                                        <note xml:id="note-0000001937910908" dur="8" oct="3" pname="d" />
+                                        <note xml:id="note-0187082798" dur="8" oct="3" pname="f" />
+                                        <note xml:id="note-1937910908" dur="8" oct="3" pname="d" />
                                     </beam>
-                                    <rest xml:id="rest-0000000645267779" dur="8" />
+                                    <rest xml:id="rest-0645267779" dur="8" />
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000001161679833" startid="#note-0000000028194672" endid="#note-0000000018339257" />
+                            <tie xml:id="tie-1161679833" startid="#note-0028194672" endid="#note-0018339257" />
                         </measure>
-                        <measure xml:id="measure-0000001917616435" n="67">
-                            <staff xml:id="staff-0000000561689495" n="1">
-                                <layer xml:id="layer-0000000312314930" n="1">
-                                    <note xml:id="note-0000000018339257" dur="8" oct="4" pname="a" accid.ges="f" />
+                        <measure xml:id="measure-1917616435" n="67">
+                            <staff xml:id="staff-0561689495" n="1">
+                                <layer xml:id="layer-0312314930" n="1">
+                                    <note xml:id="note-0018339257" dur="8" oct="4" pname="a" accid.ges="f" />
                                     <beam>
-                                        <note xml:id="note-0000001286546057" dur="16" oct="4" pname="g">
+                                        <note xml:id="note-1286546057" dur="16" oct="4" pname="g">
                                             <accid accid="f" />
-                                            <verse xml:lang="ita" xml:id="verse-0000001325884115" n="1">
+                                            <verse xml:lang="ita" xml:id="verse-1325884115" n="1">
                                                 <syl con="d" wordpos="i">guar</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001812305134" dur="16" oct="4" pname="f" />
-                                        <note xml:id="note-0000001991798293" dur="8" oct="4" pname="g" accid.ges="f" />
+                                        <note xml:id="note-1812305134" dur="16" oct="4" pname="f" />
+                                        <note xml:id="note-1991798293" dur="8" oct="4" pname="g" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001946341324" n="2">
-                                <layer xml:id="layer-0000000520323794" n="1">
+                            <staff xml:id="staff-1946341324" n="2">
+                                <layer xml:id="layer-0520323794" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000628100273" dur="8" oct="3" pname="e" accid.ges="f" />
-                                        <note xml:id="note-0000000751602866" dur="8" oct="3" pname="d">
+                                        <note xml:id="note-0628100273" dur="8" oct="3" pname="e" accid.ges="f" />
+                                        <note xml:id="note-0751602866" dur="8" oct="3" pname="d">
                                             <accid accid="f" />
                                         </note>
-                                        <note xml:id="note-0000000551612494" dur="8" oct="3" pname="c" />
+                                        <note xml:id="note-0551612494" dur="8" oct="3" pname="c" />
                                     </beam>
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000000999296621" startid="#note-0000001991798293" endid="#note-0000002117553986" />
+                            <tie xml:id="tie-0999296621" startid="#note-1991798293" endid="#note-2117553986" />
                         </measure>
                         <sb source="#secondEdition" />
-                        <measure xml:id="measure-0000001332810412" n="68">
-                            <staff xml:id="staff-0000001105748506" n="1">
-                                <layer xml:id="layer-0000001193994069" n="1">
-                                    <note xml:id="note-0000002117553986" dur="8" oct="4" pname="g" accid.ges="f">
-                                        <reg resp="#rettinghaus">
-                                            <accid accid="f" enclose="brack" />
-                                        </reg>
+                        <measure xml:id="measure-1332810412" n="68">
+                            <staff xml:id="staff-1105748506" n="1">
+                                <layer xml:id="layer-1193994069" n="1">
+                                    <note xml:id="note-2117553986" dur="8" oct="4" pname="g" accid.ges="f">
+                                        <supplied resp="#rettinghaus">
+                                            <reg>
+                                                <accid accid="f" />
+                                            </reg>
+                                        </supplied>
                                     </note>
-                                    <note xml:id="note-0000000876657499" dur="8" oct="4" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001802991605" n="1">
+                                    <note xml:id="note-0876657499" dur="8" oct="4" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1802991605" n="1">
                                             <syl con="s" wordpos="t">
                                                 <choice>
                                                     <corr confidence="1" resp="#rettinghaus">do</corr>
@@ -1725,879 +1733,879 @@
                                             </syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000040320827" dur="8" oct="5" pname="d">
+                                    <note xml:id="note-0040320827" dur="8" oct="5" pname="d">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000001292427547" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-1292427547" n="1">
                                             <syl con="s">ti</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001828555839" n="2">
-                                <layer xml:id="layer-0000001772191004" n="1">
-                                    <note xml:id="note-0000000880379962" dots="1" dur="4" oct="2" pname="b" accid.ges="f" />
+                            <staff xml:id="staff-1828555839" n="2">
+                                <layer xml:id="layer-1772191004" n="1">
+                                    <note xml:id="note-0880379962" dots="1" dur="4" oct="2" pname="b" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001566929762" n="69">
-                            <staff xml:id="staff-0000000093433268" n="1">
-                                <layer xml:id="layer-0000001290047301" n="1">
+                        <measure xml:id="measure-1566929762" n="69">
+                            <staff xml:id="staff-0093433268" n="1">
+                                <layer xml:id="layer-1290047301" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001437442959" dur="8" oct="4" pname="c">
-                                            <verse xml:lang="ita" xml:id="verse-0000000326971835" n="1">
+                                        <note xml:id="note-1437442959" dur="8" oct="4" pname="c">
+                                            <verse xml:lang="ita" xml:id="verse-0326971835" n="1">
                                                 <syl con="d" wordpos="i">chie</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001669805879" dur="8" oct="5" pname="c" />
+                                        <note xml:id="note-1669805879" dur="8" oct="5" pname="c" />
                                     </beam>
-                                    <note xml:id="note-0000002023957982" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000113369246" n="1">
+                                    <note xml:id="note-2023957982" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-0113369246" n="1">
                                             <syl con="s" wordpos="t">de</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001596711186" n="2">
-                                <layer xml:id="layer-0000000217588361" n="1">
-                                    <note xml:id="note-0000002111203917" dur="4" oct="2" pname="b" accid.ges="f" />
-                                    <note xml:id="note-0000000686731612" dur="8" oct="2" pname="a" accid.ges="f" />
+                            <staff xml:id="staff-1596711186" n="2">
+                                <layer xml:id="layer-0217588361" n="1">
+                                    <note xml:id="note-2111203917" dur="4" oct="2" pname="b" accid.ges="f" />
+                                    <note xml:id="note-0686731612" dur="8" oct="2" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001626690465" n="70">
-                            <staff xml:id="staff-0000002100970767" n="1">
-                                <layer xml:id="layer-0000001731331705" n="1">
-                                    <note xml:id="note-0000000725008550" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001903367000" n="1">
+                        <measure xml:id="measure-1626690465" n="70">
+                            <staff xml:id="staff-2100970767" n="1">
+                                <layer xml:id="layer-1731331705" n="1">
+                                    <note xml:id="note-0725008550" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1903367000" n="1">
                                             <syl con="s">un</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000095176523" dur="4" oct="4" pname="g">
-                                        <verse xml:lang="ita" xml:id="verse-0000001051934404" n="1">
+                                    <note xml:id="note-0095176523" dur="4" oct="4" pname="g">
+                                        <verse xml:lang="ita" xml:id="verse-1051934404" n="1">
                                             <syl con="d" wordpos="i">guar</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001797174334" n="2">
-                                <layer xml:id="layer-0000000169018978" n="1">
-                                    <note xml:id="note-0000001314548850" dur="8" oct="2" pname="b" accid.ges="f" />
-                                    <note xml:id="note-0000000287229090" dur="4" oct="3" pname="c" />
+                            <staff xml:id="staff-1797174334" n="2">
+                                <layer xml:id="layer-0169018978" n="1">
+                                    <note xml:id="note-1314548850" dur="8" oct="2" pname="b" accid.ges="f" />
+                                    <note xml:id="note-0287229090" dur="4" oct="3" pname="c" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001921637871" n="71">
-                            <staff xml:id="staff-0000000075684376" n="1">
-                                <layer xml:id="layer-0000001465688623" n="1">
-                                    <note xml:id="note-0000001473197335" dur="4" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001587232876" n="1">
+                        <measure xml:id="measure-1921637871" n="71">
+                            <staff xml:id="staff-0075684376" n="1">
+                                <layer xml:id="layer-1465688623" n="1">
+                                    <note xml:id="note-1473197335" dur="4" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-1587232876" n="1">
                                             <syl con="s" wordpos="t">do.</syl>
                                         </verse>
                                     </note>
-                                    <rest xml:id="rest-0000000503534692" dur="8" />
+                                    <rest xml:id="rest-0503534692" dur="8" />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000446109528" n="2">
-                                <layer xml:id="layer-0000001133188234" n="1">
-                                    <note xml:id="note-0000001270689628" dur="4" oct="2" pname="f" />
-                                    <note xml:id="note-0000000640702395" dur="8" oct="4" pname="c" />
+                            <staff xml:id="staff-0446109528" n="2">
+                                <layer xml:id="layer-1133188234" n="1">
+                                    <note xml:id="note-1270689628" dur="4" oct="2" pname="f" />
+                                    <note xml:id="note-0640702395" dur="8" oct="4" pname="c" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000281280139" n="72">
-                            <staff xml:id="staff-0000001159703309" n="1">
-                                <layer xml:id="layer-0000002005958035" n="1">
+                        <measure xml:id="measure-0281280139" n="72">
+                            <staff xml:id="staff-1159703309" n="1">
+                                <layer xml:id="layer-2005958035" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000231152662" n="2">
-                                <layer xml:id="layer-0000001356991854" n="1">
+                            <staff xml:id="staff-0231152662" n="2">
+                                <layer xml:id="layer-1356991854" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001015753710" dur="8" oct="4" pname="d">
+                                        <note xml:id="note-1015753710" dur="8" oct="4" pname="d">
                                             <accid accid="f" />
                                         </note>
-                                        <note xml:id="note-0000001704969170" dur="8" oct="3" pname="e">
+                                        <note xml:id="note-1704969170" dur="8" oct="3" pname="e">
                                             <accid accid="n" />
                                         </note>
-                                        <note xml:id="note-0000001805554709" dur="8" oct="3" pname="f" />
+                                        <note xml:id="note-1805554709" dur="8" oct="3" pname="f" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
                         <sb source="#secondEdition" />
-                        <measure xml:id="measure-0000002136770805" n="73">
-                            <staff xml:id="staff-0000002096745664" n="1">
-                                <layer xml:id="layer-0000001175994981" n="1">
+                        <measure xml:id="measure-2136770805" n="73">
+                            <staff xml:id="staff-2096745664" n="1">
+                                <layer xml:id="layer-1175994981" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000799699531" n="2">
-                                <layer xml:id="layer-0000001159605757" n="1">
+                            <staff xml:id="staff-0799699531" n="2">
+                                <layer xml:id="layer-1159605757" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000917423007" dur="8" oct="3" pname="g" />
-                                        <note xml:id="note-0000001925275433" dur="8" oct="2" pname="b">
+                                        <note xml:id="note-0917423007" dur="8" oct="3" pname="g" />
+                                        <note xml:id="note-1925275433" dur="8" oct="2" pname="b">
                                             <accid accid="n" />
                                         </note>
-                                        <note xml:id="note-0000001313282346" dur="8" oct="3" pname="c" />
+                                        <note xml:id="note-1313282346" dur="8" oct="3" pname="c" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000396974075" n="74">
-                            <staff xml:id="staff-0000001899293022" n="1">
-                                <layer xml:id="layer-0000000762369603" n="1">
+                        <measure xml:id="measure-0396974075" n="74">
+                            <staff xml:id="staff-1899293022" n="1">
+                                <layer xml:id="layer-0762369603" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001516149956" n="2">
-                                <layer xml:id="layer-0000001080164504" n="1">
+                            <staff xml:id="staff-1516149956" n="2">
+                                <layer xml:id="layer-1080164504" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000761934573" dur="8" oct="3" pname="b">
+                                        <note xml:id="note-0761934573" dur="8" oct="3" pname="b">
                                             <accid accid="f" />
                                         </note>
-                                        <note xml:id="note-0000000040021032" dur="8" oct="3" pname="a" accid.ges="f" />
-                                        <note xml:id="note-0000001714093764" dur="8" oct="4" pname="c" />
+                                        <note xml:id="note-0040021032" dur="8" oct="3" pname="a" accid.ges="f" />
+                                        <note xml:id="note-1714093764" dur="8" oct="4" pname="c" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000303720556" n="75">
-                            <staff xml:id="staff-0000002010343677" n="1">
-                                <layer xml:id="layer-0000000402583717" n="1">
+                        <measure xml:id="measure-0303720556" n="75">
+                            <staff xml:id="staff-2010343677" n="1">
+                                <layer xml:id="layer-0402583717" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001979104269" n="2">
-                                <layer xml:id="layer-0000001462533810" n="1">
+                            <staff xml:id="staff-1979104269" n="2">
+                                <layer xml:id="layer-1462533810" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001288011849" dur="8" oct="4" pname="d">
+                                        <note xml:id="note-1288011849" dur="8" oct="4" pname="d">
                                             <accid accid="f" />
                                         </note>
-                                        <note xml:id="note-0000000960451900" dur="8" oct="3" pname="e">
+                                        <note xml:id="note-0960451900" dur="8" oct="3" pname="e">
                                             <accid accid="n" />
                                         </note>
-                                        <note xml:id="note-0000001206411014" dur="8" oct="3" pname="f" />
+                                        <note xml:id="note-1206411014" dur="8" oct="3" pname="f" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000954919583" n="76">
-                            <staff xml:id="staff-0000001781232731" n="1">
-                                <layer xml:id="layer-0000001353940855" n="1">
+                        <measure xml:id="measure-0954919583" n="76">
+                            <staff xml:id="staff-1781232731" n="1">
+                                <layer xml:id="layer-1353940855" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000618272127" n="2">
-                                <layer xml:id="layer-0000000700227420" n="1">
+                            <staff xml:id="staff-0618272127" n="2">
+                                <layer xml:id="layer-0700227420" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000548097019" dur="8" oct="3" pname="a" accid.ges="f" />
-                                        <note xml:id="note-0000001328920614" dur="8" oct="2" pname="b">
+                                        <note xml:id="note-0548097019" dur="8" oct="3" pname="a" accid.ges="f" />
+                                        <note xml:id="note-1328920614" dur="8" oct="2" pname="b">
                                             <accid accid="n" />
                                         </note>
-                                        <note xml:id="note-0000001037714080" dur="8" oct="3" pname="c" />
+                                        <note xml:id="note-1037714080" dur="8" oct="3" pname="c" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000471952848" n="77">
-                            <staff xml:id="staff-0000000516346174" n="1">
-                                <layer xml:id="layer-0000001042366273" n="1">
+                        <measure xml:id="measure-0471952848" n="77">
+                            <staff xml:id="staff-0516346174" n="1">
+                                <layer xml:id="layer-1042366273" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000388632908" n="2">
-                                <layer xml:id="layer-0000000651392143" n="1">
+                            <staff xml:id="staff-0388632908" n="2">
+                                <layer xml:id="layer-0651392143" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000006847465" dur="8" oct="3" pname="a">
+                                        <note xml:id="note-0006847465" dur="8" oct="3" pname="a">
                                             <accid accid="n" />
                                         </note>
-                                        <note xml:id="note-0000001971571519" dur="8" oct="3" pname="b">
+                                        <note xml:id="note-1971571519" dur="8" oct="3" pname="b">
                                             <accid accid="f" />
                                         </note>
-                                        <note xml:id="note-0000000363829378" dur="8" oct="3" pname="e">
+                                        <note xml:id="note-0363829378" dur="8" oct="3" pname="e">
                                             <accid accid="n" />
                                         </note>
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001636844199" n="78">
-                            <staff xml:id="staff-0000001472244207" n="1">
-                                <layer xml:id="layer-0000001057777948" n="1">
+                        <measure xml:id="measure-1636844199" n="78">
+                            <staff xml:id="staff-1472244207" n="1">
+                                <layer xml:id="layer-1057777948" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001609612833" n="2">
-                                <layer xml:id="layer-0000000170590012" n="1">
+                            <staff xml:id="staff-1609612833" n="2">
+                                <layer xml:id="layer-0170590012" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001879759508" dur="8" oct="3" pname="f" />
-                                        <note xml:id="note-0000001015396680" dur="8" oct="3" pname="d">
+                                        <note xml:id="note-1879759508" dur="8" oct="3" pname="f" />
+                                        <note xml:id="note-1015396680" dur="8" oct="3" pname="d">
                                             <accid accid="f" />
                                         </note>
-                                        <note xml:id="note-0000000283490733" dur="8" oct="2" pname="a">
+                                        <note xml:id="note-0283490733" dur="8" oct="2" pname="a">
                                             <accid accid="f" />
                                         </note>
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000593073484" n="79">
-                            <staff xml:id="staff-0000000973161220" n="1">
-                                <layer xml:id="layer-0000000932537850" n="1">
+                        <measure xml:id="measure-0593073484" n="79">
+                            <staff xml:id="staff-0973161220" n="1">
+                                <layer xml:id="layer-0932537850" n="1">
                                     <mRest />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001831815519" n="2">
-                                <layer xml:id="layer-0000001435157309" n="1">
-                                    <note xml:id="note-0000001187356550" dur="8" oct="2" pname="b" accid.ges="f" />
-                                    <note xml:id="note-0000000538300124" dur="4" oct="3" pname="c" />
+                            <staff xml:id="staff-1831815519" n="2">
+                                <layer xml:id="layer-1435157309" n="1">
+                                    <note xml:id="note-1187356550" dur="8" oct="2" pname="b" accid.ges="f" />
+                                    <note xml:id="note-0538300124" dur="4" oct="3" pname="c" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001687106982" n="80">
-                            <staff xml:id="staff-0000000072161522" n="1">
-                                <layer xml:id="layer-0000000775449841" n="1">
-                                    <rest xml:id="rest-0000000719472473" dur="8" />
-                                    <rest xml:id="rest-0000002132973318" dur="8" />
-                                    <note xml:id="note-0000001175304321" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000867922371" n="1">
+                        <measure xml:id="measure-1687106982" n="80">
+                            <staff xml:id="staff-0072161522" n="1">
+                                <layer xml:id="layer-0775449841" n="1">
+                                    <rest xml:id="rest-0719472473" dur="8" />
+                                    <rest xml:id="rest-2132973318" dur="8" />
+                                    <note xml:id="note-1175304321" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0867922371" n="1">
                                             <syl con="s">se</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000882368228" n="2">
-                                <layer xml:id="layer-0000000560306727" n="1">
-                                    <note xml:id="note-0000000973249202" dur="4" oct="2" pname="f" />
-                                    <rest xml:id="rest-0000000998966638" dur="8" />
+                            <staff xml:id="staff-0882368228" n="2">
+                                <layer xml:id="layer-0560306727" n="1">
+                                    <note xml:id="note-0973249202" dur="4" oct="2" pname="f" />
+                                    <rest xml:id="rest-0998966638" dur="8" />
                                 </layer>
                             </staff>
-                            <fermata xml:id="fermata-0000000125641022" staff="2" startid="#note-0000000973249202" shape="curved" />
+                            <fermata xml:id="fermata-0125641022" staff="2" startid="#note-0973249202" shape="curved" />
                         </measure>
-                        <measure xml:id="measure-0000001172013243" n="81">
-                            <staff xml:id="staff-0000001208106578" n="1">
-                                <layer xml:id="layer-0000002008810787" n="1">
+                        <measure xml:id="measure-1172013243" n="81">
+                            <staff xml:id="staff-1208106578" n="1">
+                                <layer xml:id="layer-2008810787" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000351282848" dur="8" oct="5" pname="c">
-                                            <verse xml:lang="ita" xml:id="verse-0000001621331494" n="1">
+                                        <note xml:id="note-0351282848" dur="8" oct="5" pname="c">
+                                            <verse xml:lang="ita" xml:id="verse-1621331494" n="1">
                                                 <syl con="s">pur</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000402600795" dur="8" oct="5" pname="d">
+                                        <note xml:id="note-0402600795" dur="8" oct="5" pname="d">
                                             <accid accid="f" />
                                         </note>
                                     </beam>
-                                    <note xml:id="note-0000000990264407" dur="8" oct="5" pname="e" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000112021551" n="1">
+                                    <note xml:id="note-0990264407" dur="8" oct="5" pname="e" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0112021551" n="1">
                                             <syl con="d" wordpos="i">de</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001086881020" n="2">
-                                <layer xml:id="layer-0000000339382202" n="1">
-                                    <note xml:id="note-0000001800353224" dur="4" oct="2" pname="a" accid.ges="f" />
-                                    <rest xml:id="rest-0000002042590275" dur="8" />
+                            <staff xml:id="staff-1086881020" n="2">
+                                <layer xml:id="layer-0339382202" n="1">
+                                    <note xml:id="note-1800353224" dur="4" oct="2" pname="a" accid.ges="f" />
+                                    <rest xml:id="rest-2042590275" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001064351360" n="82">
-                            <staff xml:id="staff-0000000566318644" n="1">
-                                <layer xml:id="layer-0000002033916095" n="1">
-                                    <note xml:id="note-0000001086129045" dur="8" oct="4" pname="e" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001077692897" n="1">
+                        <measure xml:id="measure-1064351360" n="82">
+                            <staff xml:id="staff-0566318644" n="1">
+                                <layer xml:id="layer-2033916095" n="1">
+                                    <note xml:id="note-1086129045" dur="8" oct="4" pname="e" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1077692897" n="1">
                                             <syl con="s" wordpos="t">ve</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001371261584" dur="4" oct="4" pname="g">
-                                        <verse xml:lang="ita" xml:id="verse-0000001251014513" n="1">
+                                    <note xml:id="note-1371261584" dur="4" oct="4" pname="g">
+                                        <verse xml:lang="ita" xml:id="verse-1251014513" n="1">
                                             <syl con="d" wordpos="i">mo</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000002087657948" n="2">
-                                <layer xml:id="layer-0000000037517683" n="1">
+                            <staff xml:id="staff-2087657948" n="2">
+                                <layer xml:id="layer-0037517683" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001846749277" dur="8" oct="2" pname="g" />
-                                        <note xml:id="note-0000001189178973" dur="8" oct="3" pname="e" accid.ges="f" />
-                                        <note xml:id="note-0000001467407424" dur="8" oct="3" pname="d">
+                                        <note xml:id="note-1846749277" dur="8" oct="2" pname="g" />
+                                        <note xml:id="note-1189178973" dur="8" oct="3" pname="e" accid.ges="f" />
+                                        <note xml:id="note-1467407424" dur="8" oct="3" pname="d">
                                             <accid accid="f" />
                                         </note>
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000196862472" n="83">
-                            <staff xml:id="staff-0000001908659843" n="1">
-                                <layer xml:id="layer-0000002000787143" n="1">
-                                    <note xml:id="note-0000000460342959" dur="4" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001368172335" n="1">
+                        <measure xml:id="measure-0196862472" n="83">
+                            <staff xml:id="staff-1908659843" n="1">
+                                <layer xml:id="layer-2000787143" n="1">
+                                    <note xml:id="note-0460342959" dur="4" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1368172335" n="1">
                                             <syl con="s" wordpos="t">rir</syl>
                                         </verse>
                                     </note>
-                                    <rest xml:id="rest-0000000213657435" dur="8" />
+                                    <rest xml:id="rest-0213657435" dur="8" />
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001427315650" n="2">
-                                <layer xml:id="layer-0000001053715023" n="1">
-                                    <note xml:id="note-0000001271338331" dur="4" oct="3" pname="c" />
-                                    <rest xml:id="rest-0000000273964122" dur="8" />
+                            <staff xml:id="staff-1427315650" n="2">
+                                <layer xml:id="layer-1053715023" n="1">
+                                    <note xml:id="note-1271338331" dur="4" oct="3" pname="c" />
+                                    <rest xml:id="rest-0273964122" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
                         <sb source="#secondEdition" />
-                        <measure xml:id="measure-0000000691549882" n="84">
-                            <staff xml:id="staff-0000001854275977" n="1">
-                                <layer xml:id="layer-0000001779978432" n="1">
-                                    <note xml:id="note-0000001731406703" dots="1" dur="8" oct="5" pname="c">
+                        <measure xml:id="measure-0691549882" n="84">
+                            <staff xml:id="staff-1854275977" n="1">
+                                <layer xml:id="layer-1779978432" n="1">
+                                    <note xml:id="note-1731406703" dots="1" dur="8" oct="5" pname="c">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000002128640616" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-2128640616" n="1">
                                             <syl con="d" wordpos="i">mo</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000357307864" dur="16" oct="4" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000536816582" n="1">
+                                    <note xml:id="note-0357307864" dur="16" oct="4" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0536816582" n="1">
                                             <syl con="s" wordpos="t">ra</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000233796864" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000721853298" n="1">
+                                    <note xml:id="note-0233796864" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0721853298" n="1">
                                             <syl con="s">pria</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000369897919" n="2">
-                                <layer xml:id="layer-0000001670986553" n="1">
-                                    <note xml:id="note-0000000862377990" dur="4" oct="3" pname="d">
+                            <staff xml:id="staff-0369897919" n="2">
+                                <layer xml:id="layer-1670986553" n="1">
+                                    <note xml:id="note-0862377990" dur="4" oct="3" pname="d">
                                         <accid accid="n" />
                                     </note>
-                                    <rest xml:id="rest-0000001581763924" dur="8" />
+                                    <rest xml:id="rest-1581763924" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001376118233" n="85">
-                            <staff xml:id="staff-0000000086184646" n="1">
-                                <layer xml:id="layer-0000002078305814" n="1">
-                                    <note xml:id="note-0000000711195065" dur="8" oct="4" pname="g">
+                        <measure xml:id="measure-1376118233" n="85">
+                            <staff xml:id="staff-0086184646" n="1">
+                                <layer xml:id="layer-2078305814" n="1">
+                                    <note xml:id="note-0711195065" dur="8" oct="4" pname="g">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000001412453713" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-1412453713" n="1">
                                             <syl con="s">di</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001207223698" dur="4" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000391988744" n="1">
+                                    <note xml:id="note-1207223698" dur="4" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-0391988744" n="1">
                                             <syl con="d" wordpos="i">par</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001301725108" n="2">
-                                <layer xml:id="layer-0000000359776378" n="1">
+                            <staff xml:id="staff-1301725108" n="2">
+                                <layer xml:id="layer-0359776378" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001154244109" dur="8" oct="3" pname="e" accid.ges="f" />
-                                        <note xml:id="note-0000000454727745" dur="8" oct="3" pname="b" accid.ges="f" />
-                                        <note xml:id="note-0000002128647140" dur="8" oct="2" pname="b" accid.ges="f" />
+                                        <note xml:id="note-1154244109" dur="8" oct="3" pname="e" accid.ges="f" />
+                                        <note xml:id="note-0454727745" dur="8" oct="3" pname="b" accid.ges="f" />
+                                        <note xml:id="note-2128647140" dur="8" oct="2" pname="b" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001955991517" n="86">
-                            <staff xml:id="staff-0000001373654359" n="1">
-                                <layer xml:id="layer-0000000852176185" n="1">
-                                    <note xml:id="note-0000000541182579" dur="8" oct="4" pname="e" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001567159044" n="1">
+                        <measure xml:id="measure-1955991517" n="86">
+                            <staff xml:id="staff-1373654359" n="1">
+                                <layer xml:id="layer-0852176185" n="1">
+                                    <note xml:id="note-0541182579" dur="8" oct="4" pname="e" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1567159044" n="1">
                                             <syl con="s" wordpos="t">tir,</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001866442766" dur="4" oct="5" pname="c">
+                                    <note xml:id="note-1866442766" dur="4" oct="5" pname="c">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000001598122411" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-1598122411" n="1">
                                             <syl con="s">mà</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000253034415" n="2">
-                                <layer xml:id="layer-0000002001739797" n="1">
-                                    <note xml:id="note-0000000055763974" dur="4" oct="3" pname="e" accid.ges="f" />
-                                    <rest xml:id="rest-0000001482581758" dur="8" />
+                            <staff xml:id="staff-0253034415" n="2">
+                                <layer xml:id="layer-2001739797" n="1">
+                                    <note xml:id="note-0055763974" dur="4" oct="3" pname="e" accid.ges="f" />
+                                    <rest xml:id="rest-1482581758" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000823877767" n="87">
-                            <staff xml:id="staff-0000001442670294" n="1">
-                                <layer xml:id="layer-0000001797730409" n="1">
-                                    <rest xml:id="rest-0000000688186926" dur="8" />
-                                    <note xml:id="note-0000000734104382" dur="8" oct="4" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001835107940" n="1">
+                        <measure xml:id="measure-0823877767" n="87">
+                            <staff xml:id="staff-1442670294" n="1">
+                                <layer xml:id="layer-1797730409" n="1">
+                                    <rest xml:id="rest-0688186926" dur="8" />
+                                    <note xml:id="note-0734104382" dur="8" oct="4" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1835107940" n="1">
                                             <syl con="s">da</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001948837683" dur="8" oct="5" pname="c">
+                                    <note xml:id="note-1948837683" dur="8" oct="5" pname="c">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000001544035634" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-1544035634" n="1">
                                             <syl con="s">begl'</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000795110075" n="2">
-                                <layer xml:id="layer-0000001552539950" n="1">
-                                    <note xml:id="note-0000001017726306" dur="4" oct="3" pname="d">
+                            <staff xml:id="staff-0795110075" n="2">
+                                <layer xml:id="layer-1552539950" n="1">
+                                    <note xml:id="note-1017726306" dur="4" oct="3" pname="d">
                                         <accid accid="n" />
                                     </note>
-                                    <note xml:id="note-0000001686061388" dur="8" oct="3" pname="e" accid.ges="f" />
+                                    <note xml:id="note-1686061388" dur="8" oct="3" pname="e" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001196688037" n="88">
-                            <staff xml:id="staff-0000001641327021" n="1">
-                                <layer xml:id="layer-0000000453469413" n="1">
+                        <measure xml:id="measure-1196688037" n="88">
+                            <staff xml:id="staff-1641327021" n="1">
+                                <layer xml:id="layer-0453469413" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000843339245" dur="8" oct="4" pname="b" accid.ges="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000001036271525" n="1">
+                                        <note xml:id="note-0843339245" dur="8" oct="4" pname="b" accid.ges="f">
+                                            <verse xml:lang="ita" xml:id="verse-1036271525" n="1">
                                                 <syl con="d" wordpos="i">occhi</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001223173068" dots="1" dur="8" oct="4" pname="a" accid.ges="f" />
-                                        <note xml:id="note-0000002119146014" dur="32" oct="4" pname="g" />
+                                        <note xml:id="note-1223173068" dots="1" dur="8" oct="4" pname="a" accid.ges="f" />
+                                        <note xml:id="note-2119146014" dur="32" oct="4" pname="g" />
                                     </beam>
-                                    <note xml:id="note-0000001487000502" dur="32" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001263271552" n="1">
+                                    <note xml:id="note-1487000502" dur="32" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1263271552" n="1">
                                             <syl con="s" wordpos="t">chi</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000308251385" n="2">
-                                <layer xml:id="layer-0000000021079159" n="1">
-                                    <note xml:id="note-0000000610208623" dur="4" oct="3" pname="d">
+                            <staff xml:id="staff-0308251385" n="2">
+                                <layer xml:id="layer-0021079159" n="1">
+                                    <note xml:id="note-0610208623" dur="4" oct="3" pname="d">
                                         <accid accid="n" />
                                     </note>
-                                    <rest xml:id="rest-0000001604989272" dur="8" />
+                                    <rest xml:id="rest-1604989272" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000002110501254" n="89">
-                            <staff xml:id="staff-0000000640337728" n="1">
-                                <layer xml:id="layer-0000000112232078" n="1">
-                                    <note xml:id="note-0000001363639860" dur="8" oct="4" pname="g">
-                                        <verse xml:lang="ita" xml:id="verse-0000001896165266" n="1">
+                        <measure xml:id="measure-2110501254" n="89">
+                            <staff xml:id="staff-0640337728" n="1">
+                                <layer xml:id="layer-0112232078" n="1">
+                                    <note xml:id="note-1363639860" dur="8" oct="4" pname="g">
+                                        <verse xml:lang="ita" xml:id="verse-1896165266" n="1">
                                             <syl con="s">tuoi</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000002027820946" dur="8" oct="4" pname="f">
+                                    <note xml:id="note-2027820946" dur="8" oct="4" pname="f">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000000479962947" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-0479962947" n="1">
                                             <syl con="s">ne</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000916457808" dur="8" oct="4" pname="e" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001740158560" n="1">
+                                    <note xml:id="note-0916457808" dur="8" oct="4" pname="e" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1740158560" n="1">
                                             <syl con="d" wordpos="i">ven</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000000412125" n="2">
-                                <layer xml:id="layer-0000001908442798" n="1">
-                                    <note xml:id="note-0000001971713127" dur="4" oct="3" pname="e" accid.ges="f" />
-                                    <rest xml:id="rest-0000000822059390" dur="8" />
+                            <staff xml:id="staff-0000412125" n="2">
+                                <layer xml:id="layer-1908442798" n="1">
+                                    <note xml:id="note-1971713127" dur="4" oct="3" pname="e" accid.ges="f" />
+                                    <rest xml:id="rest-0822059390" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001651130906" n="90">
-                            <staff xml:id="staff-0000000582175268" n="1">
-                                <layer xml:id="layer-0000002114839993" n="1">
-                                    <note xml:id="note-0000001627111590" dur="8" oct="4" pname="e" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000966120365" n="1">
+                        <measure xml:id="measure-1651130906" n="90">
+                            <staff xml:id="staff-0582175268" n="1">
+                                <layer xml:id="layer-2114839993" n="1">
+                                    <note xml:id="note-1627111590" dur="8" oct="4" pname="e" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0966120365" n="1">
                                             <syl con="b" wordpos="t">ga</syl>
                                             <syl con="s">il</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001164042132" dur="4" oct="4" pname="d">
+                                    <note xml:id="note-1164042132" dur="4" oct="4" pname="d">
                                         <accid accid="f" />
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000354755364" n="2">
-                                <layer xml:id="layer-0000000479267219" n="1">
-                                    <note xml:id="note-0000000450399567" dur="4" oct="3" pname="g" />
-                                    <rest xml:id="rest-0000000615266658" dur="8" />
+                            <staff xml:id="staff-0354755364" n="2">
+                                <layer xml:id="layer-0479267219" n="1">
+                                    <note xml:id="note-0450399567" dur="4" oct="3" pname="g" />
+                                    <rest xml:id="rest-0615266658" dur="8" />
                                 </layer>
                             </staff>
-                            <slur xml:id="slur-0000001943000346" startid="#note-0000001627111590" endid="#note-0000001164042132" />
+                            <slur xml:id="slur-1943000346" startid="#note-1627111590" endid="#note-1164042132" />
                         </measure>
                         <pb source="#secondEdition" n="359" facs="#graphic_01DRXXBW9M0QVTHNDK5X37HXE3" />
-                        <measure xml:id="measure-0000002054233721" n="91">
-                            <staff xml:id="staff-0000001567636525" n="1">
-                                <layer xml:id="layer-0000000137563342" n="1">
-                                    <note xml:id="note-0000001314178645" dur="8" oct="5" pname="d">
+                        <measure xml:id="measure-2054233721" n="91">
+                            <staff xml:id="staff-1567636525" n="1">
+                                <layer xml:id="layer-0137563342" n="1">
+                                    <note xml:id="note-1314178645" dur="8" oct="5" pname="d">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000001654111209" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-1654111209" n="1">
                                             <syl con="d" wordpos="i">dar</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001076809704" dur="8" oct="4" pname="g">
+                                    <note xml:id="note-1076809704" dur="8" oct="4" pname="g">
                                         <accid accid="n" />
-                                        <verse xml:lang="ita" xml:id="verse-0000001774923226" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-1774923226" n="1">
                                             <syl con="s" wordpos="t">do</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000335977565" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001736429544" n="1">
+                                    <note xml:id="note-0335977565" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-1736429544" n="1">
                                             <syl con="s">ne</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000785483324" n="2">
-                                <layer xml:id="layer-0000002121890778" n="1">
-                                    <note xml:id="note-0000000800915366" dur="4" oct="3" pname="e" accid.ges="f" />
-                                    <note xml:id="note-0000001852264993" dur="8" oct="3" pname="c" />
+                            <staff xml:id="staff-0785483324" n="2">
+                                <layer xml:id="layer-2121890778" n="1">
+                                    <note xml:id="note-0800915366" dur="4" oct="3" pname="e" accid.ges="f" />
+                                    <note xml:id="note-1852264993" dur="8" oct="3" pname="c" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001850066416" n="92">
-                            <staff xml:id="staff-0000002055537751" n="1">
-                                <layer xml:id="layer-0000002145891911" n="1">
+                        <measure xml:id="measure-1850066416" n="92">
+                            <staff xml:id="staff-2055537751" n="1">
+                                <layer xml:id="layer-2145891911" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001563699545" dur="8" oct="4" pname="g">
+                                        <note xml:id="note-1563699545" dur="8" oct="4" pname="g">
                                             <accid accid="f" />
-                                            <verse xml:lang="ita" xml:id="verse-0000000656479847" n="1">
+                                            <verse xml:lang="ita" xml:id="verse-0656479847" n="1">
                                                 <syl con="d" wordpos="i">ven</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000197593014" dur="8" oct="4" pname="f" accid.ges="f" />
+                                        <note xml:id="note-0197593014" dur="8" oct="4" pname="f" accid.ges="f" />
                                     </beam>
-                                    <note xml:id="note-0000001929837383" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000441688855" n="1">
+                                    <note xml:id="note-1929837383" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0441688855" n="1">
                                             <syl con="b" wordpos="t">ga</syl>
                                             <syl con="s">il</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000926938390" n="2">
-                                <layer xml:id="layer-0000001177500970" n="1">
-                                    <note xml:id="note-0000001444624833" dur="4" oct="3" pname="d">
+                            <staff xml:id="staff-0926938390" n="2">
+                                <layer xml:id="layer-1177500970" n="1">
+                                    <note xml:id="note-1444624833" dur="4" oct="3" pname="d">
                                         <accid accid="f" />
                                     </note>
-                                    <note xml:id="note-0000002032601817" dur="8" oct="3" pname="c">
+                                    <note xml:id="note-2032601817" dur="8" oct="3" pname="c">
                                         <accid accid="f" />
                                     </note>
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000001218007042" startid="#note-0000001929837383" endid="#note-0000001777042300" />
+                            <tie xml:id="tie-1218007042" startid="#note-1929837383" endid="#note-1777042300" />
                         </measure>
-                        <measure xml:id="measure-0000001331280025" n="93">
-                            <staff xml:id="staff-0000000834338729" n="1">
-                                <layer xml:id="layer-0000000435712998" n="1">
-                                    <note xml:id="note-0000001777042300" dur="8" oct="4" pname="a" accid.ges="f" />
+                        <measure xml:id="measure-1331280025" n="93">
+                            <staff xml:id="staff-0834338729" n="1">
+                                <layer xml:id="layer-0435712998" n="1">
+                                    <note xml:id="note-1777042300" dur="8" oct="4" pname="a" accid.ges="f" />
                                     <beam>
-                                        <note xml:id="note-0000001300947547" dur="8" oct="5" pname="c">
+                                        <note xml:id="note-1300947547" dur="8" oct="5" pname="c">
                                             <accid accid="f" />
-                                            <verse xml:lang="ita" xml:id="verse-0000001510520842" n="1">
+                                            <verse xml:lang="ita" xml:id="verse-1510520842" n="1">
                                                 <syl con="d" wordpos="i">dar</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000000083078322" dur="8" oct="4" pname="b" accid.ges="f" />
+                                        <note xml:id="note-0083078322" dur="8" oct="4" pname="b" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001976010433" n="2">
-                                <layer xml:id="layer-0000001248312674" n="1">
-                                    <note xml:id="note-0000001656398168" dur="4" oct="3" pname="d">
+                            <staff xml:id="staff-1976010433" n="2">
+                                <layer xml:id="layer-1248312674" n="1">
+                                    <note xml:id="note-1656398168" dur="4" oct="3" pname="d">
                                         <accid accid="f" />
                                     </note>
-                                    <note xml:id="note-0000000041324351" dur="8" oct="3" pname="e" accid.ges="f" />
+                                    <note xml:id="note-0041324351" dur="8" oct="3" pname="e" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001487318480" n="94">
-                            <staff xml:id="staff-0000001854415109" n="1">
-                                <layer xml:id="layer-0000001038496674" n="1">
-                                    <note xml:id="note-0000000846998906" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000476824403" n="1">
+                        <measure xml:id="measure-1487318480" n="94">
+                            <staff xml:id="staff-1854415109" n="1">
+                                <layer xml:id="layer-1038496674" n="1">
+                                    <note xml:id="note-0846998906" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0476824403" n="1">
                                             <syl con="s" wordpos="t">do</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000002104219206" dur="4" oct="5" pname="c">
+                                    <note xml:id="note-2104219206" dur="4" oct="5" pname="c">
                                         <accid accid="n" />
-                                        <verse xml:lang="ita" xml:id="verse-0000001033399187" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-1033399187" n="1">
                                             <syl con="s">mà,</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001180245323" n="2">
-                                <layer xml:id="layer-0000002093857986" n="1">
+                            <staff xml:id="staff-1180245323" n="2">
+                                <layer xml:id="layer-2093857986" n="1">
                                     <beam>
-                                        <note xml:id="note-0000001408742039" dur="8" oct="2" pname="a" accid.ges="f" />
-                                        <note xml:id="note-0000000486011433" dur="8" oct="3" pname="a" accid.ges="f" />
-                                        <note xml:id="note-0000001881827674" dur="8" oct="3" pname="g" />
+                                        <note xml:id="note-1408742039" dur="8" oct="2" pname="a" accid.ges="f" />
+                                        <note xml:id="note-0486011433" dur="8" oct="3" pname="a" accid.ges="f" />
+                                        <note xml:id="note-1881827674" dur="8" oct="3" pname="g" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000092367021" n="95">
-                            <staff xml:id="staff-0000001803827472" n="1">
-                                <layer xml:id="layer-0000001107043949" n="1">
-                                    <rest xml:id="rest-0000000056977721" dur="8" />
-                                    <note xml:id="note-0000002064537610" dur="8" oct="5" pname="d">
+                        <measure xml:id="measure-0092367021" n="95">
+                            <staff xml:id="staff-1803827472" n="1">
+                                <layer xml:id="layer-1107043949" n="1">
+                                    <rest xml:id="rest-0056977721" dur="8" />
+                                    <note xml:id="note-2064537610" dur="8" oct="5" pname="d">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000000011531440" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-0011531440" n="1">
                                             <syl con="s">da</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000002000914329" dur="8" oct="5" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000001740178571" n="1">
+                                    <note xml:id="note-2000914329" dur="8" oct="5" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-1740178571" n="1">
                                             <syl con="s">begl'</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001525658173" n="2">
-                                <layer xml:id="layer-0000001101742459" n="1">
-                                    <note xml:id="note-0000001134055243" dur="4" oct="3" pname="f" />
-                                    <rest xml:id="rest-0000001218514801" dur="8" />
+                            <staff xml:id="staff-1525658173" n="2">
+                                <layer xml:id="layer-1101742459" n="1">
+                                    <note xml:id="note-1134055243" dur="4" oct="3" pname="f" />
+                                    <rest xml:id="rest-1218514801" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000002030818134" n="96">
-                            <staff xml:id="staff-0000000077782816" n="1">
-                                <layer xml:id="layer-0000000821346337" n="1">
-                                    <note xml:id="note-0000000349390936" dur="8" oct="4" pname="b" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000405061230" n="1">
+                        <measure xml:id="measure-2030818134" n="96">
+                            <staff xml:id="staff-0077782816" n="1">
+                                <layer xml:id="layer-0821346337" n="1">
+                                    <note xml:id="note-0349390936" dur="8" oct="4" pname="b" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0405061230" n="1">
                                             <syl con="d" wordpos="i">oc</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001449270835" dur="4" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000002139510668" n="1">
+                                    <note xml:id="note-1449270835" dur="4" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-2139510668" n="1">
                                             <syl con="s" wordpos="t">chi</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000330755538" n="2">
-                                <layer xml:id="layer-0000002141659179" n="1">
-                                    <note xml:id="note-0000001257530323" dur="4" oct="3" pname="g">
+                            <staff xml:id="staff-0330755538" n="2">
+                                <layer xml:id="layer-2141659179" n="1">
+                                    <note xml:id="note-1257530323" dur="4" oct="3" pname="g">
                                         <accid accid="n" />
                                     </note>
-                                    <note xml:id="note-0000001303125723" dur="8" oct="3" pname="f" />
+                                    <note xml:id="note-1303125723" dur="8" oct="3" pname="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001527498968" n="97">
-                            <staff xml:id="staff-0000001038691434" n="1">
-                                <layer xml:id="layer-0000001265698681" n="1">
-                                    <note xml:id="note-0000000828072913" dur="4" oct="4" pname="g">
+                        <measure xml:id="measure-1527498968" n="97">
+                            <staff xml:id="staff-1038691434" n="1">
+                                <layer xml:id="layer-1265698681" n="1">
+                                    <note xml:id="note-0828072913" dur="4" oct="4" pname="g">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000002076354844" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-2076354844" n="1">
                                             <syl con="s">tuoi</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000243330666" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000893940328" n="1">
+                                    <note xml:id="note-0243330666" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-0893940328" n="1">
                                             <syl con="s">ne</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000931645173" n="2">
-                                <layer xml:id="layer-0000000841531678" n="1">
-                                    <note xml:id="note-0000000054947774" dur="4" oct="3" pname="b" accid.ges="f" />
-                                    <note xml:id="note-0000000060599810" dur="8" oct="3" pname="a" accid.ges="f" />
+                            <staff xml:id="staff-0931645173" n="2">
+                                <layer xml:id="layer-0841531678" n="1">
+                                    <note xml:id="note-0054947774" dur="4" oct="3" pname="b" accid.ges="f" />
+                                    <note xml:id="note-0060599810" dur="8" oct="3" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000000334006722" startid="#note-0000000243330666" endid="#note-0000001951941007" />
+                            <tie xml:id="tie-0334006722" startid="#note-0243330666" endid="#note-1951941007" />
                         </measure>
                         <sb source="#secondEdition" />
-                        <measure xml:id="measure-0000001933569208" n="98">
-                            <staff xml:id="staff-0000001991931329" n="1">
-                                <layer xml:id="layer-0000001563361356" n="1">
-                                    <note xml:id="note-0000001951941007" dur="8" oct="4" pname="f" />
-                                    <note xml:id="note-0000000461818871" dur="8" oct="4" pname="e">
+                        <measure xml:id="measure-1933569208" n="98">
+                            <staff xml:id="staff-1991931329" n="1">
+                                <layer xml:id="layer-1563361356" n="1">
+                                    <note xml:id="note-1951941007" dur="8" oct="4" pname="f" />
+                                    <note xml:id="note-0461818871" dur="8" oct="4" pname="e">
                                         <accid accid="n" />
-                                        <verse xml:lang="ita" xml:id="verse-0000001787001746" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-1787001746" n="1">
                                             <syl con="d" wordpos="i">ven</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000002046249161" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000001340531766" n="1">
+                                    <note xml:id="note-2046249161" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-1340531766" n="1">
                                             <syl con="b" wordpos="t">ga</syl>
                                             <syl con="s">il</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000269477750" n="2">
-                                <layer xml:id="layer-0000001381939979" n="1">
-                                    <note xml:id="note-0000000832152037" dots="1" dur="4" oct="4" pname="d">
+                            <staff xml:id="staff-0269477750" n="2">
+                                <layer xml:id="layer-1381939979" n="1">
+                                    <note xml:id="note-0832152037" dots="1" dur="4" oct="4" pname="d">
                                         <accid accid="f" />
                                     </note>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000011128658" n="99">
-                            <staff xml:id="staff-0000001252796951" n="1">
-                                <layer xml:id="layer-0000001576590668" n="1">
-                                    <note xml:id="note-0000001162668051" dur="8" oct="4" pname="g">
-                                        <verse xml:lang="ita" xml:id="verse-0000000137366035" n="1">
+                        <measure xml:id="measure-0011128658" n="99">
+                            <staff xml:id="staff-1252796951" n="1">
+                                <layer xml:id="layer-1576590668" n="1">
+                                    <note xml:id="note-1162668051" dur="8" oct="4" pname="g">
+                                        <verse xml:lang="ita" xml:id="verse-0137366035" n="1">
                                             <syl con="d" wordpos="i">dar</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000002122970968" dur="8" oct="4" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000000047254317" n="1">
+                                    <note xml:id="note-2122970968" dur="8" oct="4" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-0047254317" n="1">
                                             <syl con="s" wordpos="t">do</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000378206289" dur="8" oct="5" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000000330330828" n="1">
+                                    <note xml:id="note-0378206289" dur="8" oct="5" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-0330330828" n="1">
                                             <syl con="s">mà</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000174726931" n="2">
-                                <layer xml:id="layer-0000000654756524" n="1">
-                                    <note xml:id="note-0000000022598270" dur="4" oct="4" pname="c" />
-                                    <rest xml:id="rest-0000000102303715" dur="8" />
+                            <staff xml:id="staff-0174726931" n="2">
+                                <layer xml:id="layer-0654756524" n="1">
+                                    <note xml:id="note-0022598270" dur="4" oct="4" pname="c" />
+                                    <rest xml:id="rest-0102303715" dur="8" />
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000000010176465" startid="#note-0000000378206289" endid="#note-0000001006552695" />
+                            <tie xml:id="tie-0010176465" startid="#note-0378206289" endid="#note-1006552695" />
                         </measure>
-                        <measure xml:id="measure-0000001204084840" n="100">
-                            <staff xml:id="staff-0000000193589534" n="1">
-                                <layer xml:id="layer-0000000091136431" n="1">
-                                    <note xml:id="note-0000001006552695" dur="8" oct="5" pname="c" />
-                                    <note xml:id="note-0000001707737285" dur="8" oct="4" pname="a" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000555985411" n="1">
+                        <measure xml:id="measure-1204084840" n="100">
+                            <staff xml:id="staff-0193589534" n="1">
+                                <layer xml:id="layer-0091136431" n="1">
+                                    <note xml:id="note-1006552695" dur="8" oct="5" pname="c" />
+                                    <note xml:id="note-1707737285" dur="8" oct="4" pname="a" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0555985411" n="1">
                                             <syl con="s">da</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000000959348879" dur="8" oct="4" pname="g">
-                                        <verse xml:lang="ita" xml:id="verse-0000000421634421" n="1">
+                                    <note xml:id="note-0959348879" dur="8" oct="4" pname="g">
+                                        <verse xml:lang="ita" xml:id="verse-0421634421" n="1">
                                             <syl con="s">begl'</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001758319173" n="2">
-                                <layer xml:id="layer-0000001337107278" n="1">
-                                    <note xml:id="note-0000001274848284" dur="4" oct="3" pname="c" />
-                                    <rest xml:id="rest-0000000731670818" dur="8" />
+                            <staff xml:id="staff-1758319173" n="2">
+                                <layer xml:id="layer-1337107278" n="1">
+                                    <note xml:id="note-1274848284" dur="4" oct="3" pname="c" />
+                                    <rest xml:id="rest-0731670818" dur="8" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001565257221" n="101">
-                            <staff xml:id="staff-0000001432561474" n="1">
-                                <layer xml:id="layer-0000001440131390" n="1">
-                                    <note xml:id="note-0000001155129557" dur="8" oct="4" pname="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000858422390" n="1">
+                        <measure xml:id="measure-1565257221" n="101">
+                            <staff xml:id="staff-1432561474" n="1">
+                                <layer xml:id="layer-1440131390" n="1">
+                                    <note xml:id="note-1155129557" dur="8" oct="4" pname="f">
+                                        <verse xml:lang="ita" xml:id="verse-0858422390" n="1">
                                             <syl con="d" wordpos="i">oc</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001611959173" dur="4" oct="4" pname="e" accid.ges="f">
-                                        <verse xml:lang="ita" xml:id="verse-0000000728323314" n="1">
+                                    <note xml:id="note-1611959173" dur="4" oct="4" pname="e" accid.ges="f">
+                                        <verse xml:lang="ita" xml:id="verse-0728323314" n="1">
                                             <syl con="s" wordpos="t">chi</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001036850386" n="2">
-                                <layer xml:id="layer-0000000666236667" n="1">
-                                    <note xml:id="note-0000001829483449" dur="8" oct="3" pname="a" accid.ges="f" />
-                                    <note xml:id="note-0000000731085416" dur="4" oct="3" pname="g" />
+                            <staff xml:id="staff-1036850386" n="2">
+                                <layer xml:id="layer-0666236667" n="1">
+                                    <note xml:id="note-1829483449" dur="8" oct="3" pname="a" accid.ges="f" />
+                                    <note xml:id="note-0731085416" dur="4" oct="3" pname="g" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001474151330" n="102">
-                            <staff xml:id="staff-0000002086258764" n="1">
-                                <layer xml:id="layer-0000000910763814" n="1">
-                                    <note xml:id="note-0000000711648818" dur="4" oct="4" pname="d">
+                        <measure xml:id="measure-1474151330" n="102">
+                            <staff xml:id="staff-2086258764" n="1">
+                                <layer xml:id="layer-0910763814" n="1">
+                                    <note xml:id="note-0711648818" dur="4" oct="4" pname="d">
                                         <accid accid="f" />
-                                        <verse xml:lang="ita" xml:id="verse-0000001873079289" n="1">
+                                        <verse xml:lang="ita" xml:id="verse-1873079289" n="1">
                                             <syl con="s">tuoi</syl>
                                         </verse>
                                     </note>
-                                    <note xml:id="note-0000001468568957" dur="8" oct="4" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000002086015442" n="1">
+                                    <note xml:id="note-1468568957" dur="8" oct="4" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-2086015442" n="1">
                                             <syl con="s">ne</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001635685963" n="2">
-                                <layer xml:id="layer-0000000795078946" n="1">
-                                    <note xml:id="note-0000000631721950" dur="4" oct="3" pname="f" />
-                                    <note xml:id="note-0000002018104331" dur="8" oct="3" pname="e" accid.ges="f" />
+                            <staff xml:id="staff-1635685963" n="2">
+                                <layer xml:id="layer-0795078946" n="1">
+                                    <note xml:id="note-0631721950" dur="4" oct="3" pname="f" />
+                                    <note xml:id="note-2018104331" dur="8" oct="3" pname="e" accid.ges="f" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000950783172" n="103">
-                            <staff xml:id="staff-0000001357770427" n="1">
-                                <layer xml:id="layer-0000001984920144" n="1">
+                        <measure xml:id="measure-0950783172" n="103">
+                            <staff xml:id="staff-1357770427" n="1">
+                                <layer xml:id="layer-1984920144" n="1">
                                     <beam>
-                                        <note xml:id="note-0000000353203471" dur="8" oct="4" pname="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000000297664414" n="1">
+                                        <note xml:id="note-0353203471" dur="8" oct="4" pname="f">
+                                            <verse xml:lang="ita" xml:id="verse-0297664414" n="1">
                                                 <syl con="d" wordpos="i">ven</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000002053022836" dur="8" oct="4" pname="b" />
+                                        <note xml:id="note-2053022836" dur="8" oct="4" pname="b" />
                                     </beam>
-                                    <note xml:id="note-0000001038504155" dur="8" oct="5" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000001081654634" n="1">
+                                    <note xml:id="note-1038504155" dur="8" oct="5" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-1081654634" n="1">
                                             <syl con="b" wordpos="t">ga</syl>
                                             <syl con="s">il</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000001562046506" n="2">
-                                <layer xml:id="layer-0000002032462787" n="1">
-                                    <note xml:id="note-0000000228695196" dur="4" oct="3" pname="d" />
-                                    <note xml:id="note-0000000213016277" dur="8" oct="3" pname="c" />
+                            <staff xml:id="staff-1562046506" n="2">
+                                <layer xml:id="layer-2032462787" n="1">
+                                    <note xml:id="note-0228695196" dur="4" oct="3" pname="d" />
+                                    <note xml:id="note-0213016277" dur="8" oct="3" pname="c" />
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000001981881068" startid="#note-0000001038504155" endid="#note-0000000148492032" />
+                            <tie xml:id="tie-1981881068" startid="#note-1038504155" endid="#note-0148492032" />
                         </measure>
-                        <measure xml:id="measure-0000000684738928" n="104">
-                            <staff xml:id="staff-0000000539973028" n="1">
-                                <layer xml:id="layer-0000001208801023" n="1">
-                                    <note xml:id="note-0000000148492032" dur="8" oct="5" pname="c" />
+                        <measure xml:id="measure-0684738928" n="104">
+                            <staff xml:id="staff-0539973028" n="1">
+                                <layer xml:id="layer-1208801023" n="1">
+                                    <note xml:id="note-0148492032" dur="8" oct="5" pname="c" />
                                     <beam>
-                                        <note xml:id="note-0000001592069111" dur="8" oct="4" pname="e" accid.ges="f">
-                                            <verse xml:lang="ita" xml:id="verse-0000000748513470" n="1">
+                                        <note xml:id="note-1592069111" dur="8" oct="4" pname="e" accid.ges="f">
+                                            <verse xml:lang="ita" xml:id="verse-0748513470" n="1">
                                                 <syl con="d" wordpos="i">dar</syl>
                                             </verse>
                                         </note>
-                                        <note xml:id="note-0000001506146749" dur="8" oct="4" pname="d" />
+                                        <note xml:id="note-1506146749" dur="8" oct="4" pname="d" />
                                     </beam>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000050385755" n="2">
-                                <layer xml:id="layer-0000001405327551" n="1">
-                                    <note xml:id="note-0000001190335403" dur="8" oct="3" pname="f" />
-                                    <note xml:id="note-0000001155959994" dur="4" oct="3" pname="g" />
+                            <staff xml:id="staff-0050385755" n="2">
+                                <layer xml:id="layer-1405327551" n="1">
+                                    <note xml:id="note-1190335403" dur="8" oct="3" pname="f" />
+                                    <note xml:id="note-1155959994" dur="4" oct="3" pname="g" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001863225755" right="end" n="105" metcon="false">
-                            <staff xml:id="staff-0000000522257882" n="1">
-                                <layer xml:id="layer-0000001012976073" n="1">
-                                    <note xml:id="note-0000000058480097" dur="4" oct="4" pname="c">
-                                        <verse xml:lang="ita" xml:id="verse-0000001680664842" n="1">
+                        <measure xml:id="measure-1863225755" right="end" n="105" metcon="false">
+                            <staff xml:id="staff-0522257882" n="1">
+                                <layer xml:id="layer-1012976073" n="1">
+                                    <note xml:id="note-0058480097" dur="4" oct="4" pname="c">
+                                        <verse xml:lang="ita" xml:id="verse-1680664842" n="1">
                                             <syl con="s" wordpos="t">do.</syl>
                                         </verse>
                                     </note>
                                 </layer>
                             </staff>
-                            <staff xml:id="staff-0000000218165588" n="2">
-                                <layer xml:id="layer-0000000675923169" n="1">
-                                    <note xml:id="note-0000000326947604" dur="4" oct="3" pname="c" />
+                            <staff xml:id="staff-0218165588" n="2">
+                                <layer xml:id="layer-0675923169" n="1">
+                                    <note xml:id="note-0326947604" dur="4" oct="3" pname="c" />
                                 </layer>
                             </staff>
                             <dir staff="1" tstamp="2.5" place="within">

--- a/encodings/10/mattheson/comments_1st.xml
+++ b/encodings/10/mattheson/comments_1st.xml
@@ -267,8 +267,8 @@
           <lb/>wegen ſonderlich <hi rendition="#aq">charm</hi>iren ſolte,
           zumahl, wann ich die <hi rendition="#aq">Repriſe</hi> betrachte, kan ich
           <lb/>eben nicht sagen: doch jeder hat seinen <hi rendition="#aq">Gout</hi>.
-          <abbr>Vid.</abbr> <persName ref="#ed_mzk_n5x_qlb">Giacomo Sherard</persName>, <name type="musicalWork" ref="#ed_fp3_txc_tlb">Opera II.
-          <lb/>Sonata VIII</name>. <abbr>it.</abbr> <persName ref="#ed_khq_sfy_qlb">Giovanni Moſſi</persName>,
+          <abbr>Vid.</abbr> <persName corresp="#ed_mzk_n5x_qlb">Giacomo Sherard</persName>, <name type="musicalWork" ref="#ed_fp3_txc_tlb">Opera II.
+          <lb/>Sonata VIII</name>. <abbr>it.</abbr> <persName corresp="#ed_khq_sfy_qlb">Giovanni Moſſi</persName>,
           <name type="musicalWork" ref="#ed_llx_3gc_tlb">Sonata VI.</name>, beyde in <placeName>Holland</placeName>
           <hi rendition="#aq">gravirt</hi>.
         </p>

--- a/encodings/10/mattheson/comments_1st.xml
+++ b/encodings/10/mattheson/comments_1st.xml
@@ -236,16 +236,16 @@
               <lb/>ſen Meister erfordert, diese Aria ohne Bezieferung
               <hi rendition="#aq">accurat</hi> zu <hi rendition="#aq">accompagni</hi>ren:
               <lb/>maſſen dem
-              <ref target="#measure-0000001827916444">ſiebendem</ref>,
-              <ref target="#measure-0000001219466359">achten</ref>,
-              <ref target="#measure-0000001708734092">neunten</ref>
-              und <ref target="#measure-0000000917306217">zehnten Tact</ref>
+              <ref target="#measure-1827916444">ſiebendem</ref>,
+              <ref target="#measure-1219466359">achten</ref>,
+              <ref target="#measure-1708734092">neunten</ref>
+              und <ref target="#measure-0917306217">zehnten Tact</ref>
               keiner ihr Recht thun
               <lb/>wird, der nicht aus dem
-              <ref target="#measure-0000000173914305">drey ſechtzigſten</ref>
+              <ref target="#measure-0173914305">drey ſechtzigſten</ref>
               und folgenden ersehe, wie jene muͤſſen
               <lb/><hi rendition="#aq">tracti</hi>ret werden; und</item>
-            <item>(5) weil <ref target="#staff-0000000093433268"><hi rendition="#aq">pag.
+            <item>(5) weil <ref target="#staff-0093433268"><hi rendition="#aq">pag.
               156. lin. 2. Tactu ſecondo</hi> in der Sing-
               <lb/>Stimme</ref>, und denn im neundten und zwölfften Tact des
               letzten Theils, <hi rendition="#aq">Tactu ante-
@@ -260,8 +260,8 @@
               <lb/>auch <hi rendition="#aq">practicable</hi> geglaubet habe.</item>
           </list>
 
-          So ist auch die <ref target="#measure-0000001424025321">Cadentz des ersten Theils</ref> in
-          <lb/>in <ref target="#note-0000000527129810"><hi rendition="#aq">Septimam</hi></ref>
+          So ist auch die <ref target="#measure-1424025321">Cadentz des ersten Theils</ref> in
+          <lb/>in <ref target="#note-0527129810"><hi rendition="#aq">Septimam</hi></ref>
           etwas merckwuͤrdiges und nichts <hi rendition="#aq">quotidia</hi>nes.
           Daß ſie mich aber deß-
           <lb/>wegen ſonderlich <hi rendition="#aq">charm</hi>iren ſolte,

--- a/encodings/10/mattheson/comments_1st.xml
+++ b/encodings/10/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Zehntes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/10/mattheson/comments_de.xml
+++ b/encodings/10/mattheson/comments_de.xml
@@ -189,27 +189,27 @@
           und <hi rendition="#aq">Gis mol</hi> theils moduliert, theils absetzet; (4) weil
           es einen grossen Meister erfordert, diese Arie, ohne Bezieferung, richtig
           zu accompagniren: massen dem
-          <ref target="#measure-0000001827916444">siebendem</ref>,
-          <ref target="#measure-0000001219466359">achten</ref>,
-          <ref target="#measure-0000001708734092">neunten</ref>
-          und <ref target="#measure-0000000917306217">zehnten Tact</ref>
+          <ref target="#measure-1827916444">siebendem</ref>,
+          <ref target="#measure-1219466359">achten</ref>,
+          <ref target="#measure-1708734092">neunten</ref>
+          und <ref target="#measure-0917306217">zehnten Tact</ref>
           keiner ihr Recht thun wird, der nicht aus dem
-          <ref target="#measure-0000000173914305">drey sechtzigsten</ref>
+          <ref target="#measure-0173914305">drey sechtzigsten</ref>
           und folgenden ersehe, wie jene muͤssen behandelt werden; und (5) weil
-          <ref target="#staff-0000000093433268">auf der
+          <ref target="#staff-0093433268">auf der
           vorhergehenden Seite, im andern Tact der zweiten Zeile, in der Sing-Stimme</ref>
           und denn im zehnten und dreizehnten Tact des letzten Theils, das erstemahl
-          <ref target="#measure-0000002110501254"><hi rendition="#aq">pag. 358 tact. penult.</hi></ref> uͤber
-          <ref target="#verse-0000000479962947">der Sylbe <hi rendition="#aq">ne</hi></ref>, das andermahl
-          <ref target="#measure-0000001850066416"><hi rendition="#aq">pag. 359 tact.</hi> 2.</ref>
-          uͤber <ref target="#verse-0000000656479847">der Sylbe <hi rendition="#aq">ven</hi></ref>
+          <ref target="#measure-2110501254"><hi rendition="#aq">pag. 358 tact. penult.</hi></ref> uͤber
+          <ref target="#verse-0479962947">der Sylbe <hi rendition="#aq">ne</hi></ref>, das andermahl
+          <ref target="#measure-1850066416"><hi rendition="#aq">pag. 359 tact.</hi> 2.</ref>
+          uͤber <ref target="#verse-0656479847">der Sylbe <hi rendition="#aq">ven</hi></ref>
           ein <hi rendition="#aq"><foreign xml:lang="lat">Intervallum</foreign></hi> vorkoͤmmt, das unter die sogenannte
           gebraͤuchliche wol eben nicht zu zehlen ist, und dennoch weiset, wie sich
           ein geschickter Meister dessen wol bedienen koͤnne. Es ist eine kleine None
           in Ansehung der Grund-Stimme, und ich gestehe es gerne, die erste, die ich
           damahls, in einer Melodie, auf solche Art, gefunden oder auch brauchbar
-          geglaubet habe. So ist auch der <ref target="#measure-0000001424025321">Schluß des ersten Absatzes</ref>
-          in die <ref target="#note-0000000527129810">Septime</ref> etwas merckwuͤrdiges, und nichts alltaͤgliches;
+          geglaubet habe. So ist auch der <ref target="#measure-1424025321">Schluß des ersten Absatzes</ref>
+          in die <ref target="#note-0527129810">Septime</ref> etwas merckwuͤrdiges, und nichts alltaͤgliches;
           dass sie mich aber deswegen sonderlich entzuͤcken sollte,
           zumahl, wann ich die Wiederholung betrachte,
           kann ich eben nicht sagen: doch jeder hat seinen Geschmack.

--- a/encodings/10/mattheson/comments_de.xml
+++ b/encodings/10/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Zehntes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/10/mattheson/comments_en.xml
+++ b/encodings/10/mattheson/comments_en.xml
@@ -15,8 +15,8 @@
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/10/mattheson/comments_en.xml
+++ b/encodings/10/mattheson/comments_en.xml
@@ -124,28 +124,28 @@
           D-sharp minor and G-sharp minor. (4) since in demands a great master
           to accompany this aria well without figures:
           for nobody will do justice to the
-          <ref target="#measure-0000001827916444">seventh</ref>,
-          <ref target="#measure-0000001219466359">eighth</ref>,
-          <ref target="#measure-0000001708734092">ninth</ref>
-          and <ref target="#measure-0000000917306217">tenth measure</ref>,
+          <ref target="#measure-1827916444">seventh</ref>,
+          <ref target="#measure-1219466359">eighth</ref>,
+          <ref target="#measure-1708734092">ninth</ref>
+          and <ref target="#measure-0917306217">tenth measure</ref>,
           who does not see from the
-          <ref target="#measure-0000000173914305">63th</ref> measure and following
+          <ref target="#measure-0173914305">63th</ref> measure and following
           how to treat them correctly; and (5) because in
-          <ref target="#staff-0000000093433268">the second measure in the second line
+          <ref target="#staff-0093433268">the second measure in the second line
             of the previous page in the singing voice</ref>
           and also in the 13th measure of the last part, for the first time on
-          <ref target="#measure-0000002110501254">page 358 in the penultimate measure</ref> on the
-          <ref target="#verse-0000000479962947">syllable -ne</ref> and for the second time on
-          <ref target="#measure-0000001850066416">page 359 in the second measure</ref>
-          on <ref target="#verse-0000000656479847">the syllable -ven</ref>,
+          <ref target="#measure-2110501254">page 358 in the penultimate measure</ref> on the
+          <ref target="#verse-0479962947">syllable -ne</ref> and for the second time on
+          <ref target="#measure-1850066416">page 359 in the second measure</ref>
+          on <ref target="#verse-0656479847">the syllable -ven</ref>,
           appears in interval that cannot be counted among the so-called common ones
           but still indicated how a skilled master might make use of it. It is
           a minor ninth in relation to the fundamental voice, and I do not hesitate
           to admit that it is the first which then I found in a melody in that way
           and considered useful.
           Likewise, the
-          <ref target="#measure-0000001424025321">cadence of the first section</ref>
-          on the <ref target="#note-0000000527129810">seventh</ref> scale degree is
+          <ref target="#measure-1424025321">cadence of the first section</ref>
+          on the <ref target="#note-0527129810">seventh</ref> scale degree is
           something strange and nothing ordinary.
           But I cannot really say that it delights may, especially considering
           the repetition: but everybody has his own taste.

--- a/encodings/10/mattheson/music-example1.xml
+++ b/encodings/10/mattheson/music-example1.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 10, Example 1</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -15,20 +15,23 @@
                 </respStmt>
             </titleStmt>
             <editionStmt>
-                <edition>First draft, <date>2019</date></edition>
+                <edition>
+                    First draft,
+                    <date>2019</date>
+                </edition>
             </editionStmt>
             <pubStmt>
                 <respStmt>
-                  <persName role="publisher">Niels Pfeffer</persName>
+                    <persName role="publisher">Niels Pfeffer</persName>
                 </respStmt>
                 <date>2019</date>
                 <availability>
-                  <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
-                    <p>Creative Commons Attribution 4.0 International License</p>
-                  </useRestrict>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
                 </availability>
-              </pubStmt>
-          </fileDesc>
+            </pubStmt>
+        </fileDesc>
     </meiHead>
     <music>
         <body>
@@ -36,27 +39,31 @@
                 <score>
                     <scoreDef key.pname="f" key.accid="n" key.mode="minor" meter.unit="8" midi.bpm="100" mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" key.sig="3f" n="1" lines="5" />
-                            <staffDef clef.shape="F" clef.line="4" key.sig="3f" n="2" lines="5" />
+                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5">
+                                <keySig sig="3f" />
+                            </staffDef>
+                            <staffDef clef.shape="F" clef.line="4" n="2" lines="5">
+                                <keySig sig="3f" />
+                            </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure xml:id="ex-1131" n="46" corresp="#m-1131">
+                        <measure corresp="#m-1131">
                             <staff n="1">
                                 <layer n="1">
                                     <chord xml:id="ex-1134" dots="1" dur="4">
-                                        <note xml:id="ex-1135" oct="4" pname="f" />
-                                        <note xml:id="ex-1136" oct="4" pname="a" />
-                                        <note xml:id="ex-1138" oct="5" pname="c" />
                                         <note xml:id="ex-1139" oct="5" pname="f" />
+                                        <note xml:id="ex-1138" oct="5" pname="c" dots="0" />
+                                        <note xml:id="ex-1136" oct="4" pname="a" accid.ges="f" dots="0" />
+                                        <note xml:id="ex-1135" oct="4" pname="f" dots="0" />
                                     </chord>
                                     <beam>
                                         <note xml:id="ex-1141" dur="16" oct="5" pname="f" />
                                         <note xml:id="ex-1143" dur="16" oct="5" pname="f" />
-                                        <note xml:id="ex-1144" dur="16" oct="5" pname="e" />
-                                        <note xml:id="ex-1146" dur="16" oct="5" pname="e" />
-                                        <note xml:id="ex-1148" dur="16" oct="4" pname="b" />
-                                        <note xml:id="ex-1150" dur="16" oct="4" pname="b" />
+                                        <note xml:id="ex-1144" dur="16" oct="5" pname="e" accid.ges="f" />
+                                        <note xml:id="ex-1146" dur="16" oct="5" pname="e" accid.ges="f" />
+                                        <note xml:id="ex-1148" dur="16" oct="4" pname="b" accid.ges="f" />
+                                        <note xml:id="ex-1150" dur="16" oct="4" pname="b" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
@@ -67,11 +74,11 @@
                                         <note xml:id="ex-1156" dur="16" oct="3" pname="f" />
                                         <note xml:id="ex-1157" dur="16" oct="3" pname="c" />
                                         <note xml:id="ex-1158" dur="16" oct="3" pname="c" />
-                                        <note xml:id="ex-1159" dur="16" oct="2" pname="a" />
-                                        <note xml:id="ex-1161" dur="16" oct="2" pname="a" />
+                                        <note xml:id="ex-1159" dur="16" oct="2" pname="a" accid.ges="f" />
+                                        <note xml:id="ex-1161" dur="16" oct="2" pname="a" accid.ges="f" />
                                     </beam>
                                     <note xml:id="ex-1163" dur="4" oct="2" pname="g" />
-                                    <rest xml:id="ex-1164" dur="8" />
+                                    <rest xml:id="ex-1164" dur="8" oloc="2" ploc="g" />
                                 </layer>
                             </staff>
                             <tie startid="#ex-1139" endid="#ex-1141" />
@@ -88,39 +95,39 @@
                                 </harm>
                             </supplied>
                         </measure>
-                        <measure xml:id="ex-1165" n="47" corresp="#m-1165">
+                        <measure corresp="#m-1165">
                             <staff n="1">
                                 <layer n="1">
                                     <chord xml:id="ex-1169" dots="1" dur="4">
-                                        <note xml:id="ex-1170" oct="4" pname="e" />
-                                        <note xml:id="ex-1172" oct="4" pname="g" />
-                                        <note xml:id="ex-1173" oct="4" pname="b" />
-                                        <note xml:id="ex-1175" oct="5" pname="e" />
+                                        <note xml:id="ex-1175" oct="5" pname="e" accid.ges="f" />
+                                        <note xml:id="ex-1173" oct="4" pname="b" accid.ges="f" dots="0" />
+                                        <note xml:id="ex-1172" oct="4" pname="g" dots="0" />
+                                        <note xml:id="ex-1170" oct="4" pname="e" accid.ges="f" dots="0" />
                                     </chord>
                                     <beam>
-                                        <note xml:id="ex-1178" dur="16" oct="5" pname="e" />
-                                        <note xml:id="ex-1181" dur="16" oct="5" pname="e" />
+                                        <note xml:id="ex-1178" dur="16" oct="5" pname="e" accid.ges="f" />
+                                        <note xml:id="ex-1181" dur="16" oct="5" pname="e" accid.ges="f" />
                                         <note xml:id="ex-1183" dur="16" oct="5" pname="d">
                                             <accid xml:id="ex-1184" accid="f" />
                                         </note>
-                                        <note xml:id="ex-1185" dur="16" oct="5" pname="d" />
-                                        <note xml:id="ex-1187" dur="16" oct="4" pname="a" />
-                                        <note xml:id="ex-1189" dur="16" oct="4" pname="a" />
+                                        <note xml:id="ex-1185" dur="16" oct="5" pname="d" accid.ges="f" />
+                                        <note xml:id="ex-1187" dur="16" oct="4" pname="a" accid.ges="f" />
+                                        <note xml:id="ex-1189" dur="16" oct="4" pname="a" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
                                     <beam>
-                                        <note xml:id="ex-1193" dur="16" oct="3" pname="e" />
-                                        <note xml:id="ex-1196" dur="16" oct="3" pname="e" />
-                                        <note xml:id="ex-1198" dur="16" oct="2" pname="b" />
-                                        <note xml:id="ex-1200" dur="16" oct="2" pname="b" />
+                                        <note xml:id="ex-1193" dur="16" oct="3" pname="e" accid.ges="f" />
+                                        <note xml:id="ex-1196" dur="16" oct="3" pname="e" accid.ges="f" />
+                                        <note xml:id="ex-1198" dur="16" oct="2" pname="b" accid.ges="f" />
+                                        <note xml:id="ex-1200" dur="16" oct="2" pname="b" accid.ges="f" />
                                         <note xml:id="ex-1202" dur="16" oct="2" pname="g" />
                                         <note xml:id="ex-1203" dur="16" oct="2" pname="g" />
                                     </beam>
                                     <note xml:id="ex-1204" dur="4" oct="2" pname="f" />
-                                    <rest xml:id="ex-1205" dur="8" />
+                                    <rest xml:id="ex-1205" dur="8" oloc="2" ploc="g" />
                                 </layer>
                             </staff>
                             <tie startid="#ex-1175" endid="#ex-1178" />
@@ -141,18 +148,18 @@
                             <staff n="1">
                                 <layer n="1">
                                     <chord xml:id="ex-1209" dots="1" dur="4">
-                                        <note xml:id="ex-1210" oct="4" pname="d">
-                                            <accid xml:id="ex-1211" accid="f" />
-                                        </note>
-                                        <note xml:id="ex-1212" oct="4" pname="f" />
-                                        <note xml:id="ex-1213" oct="4" pname="a" />
                                         <note xml:id="ex-1215" oct="5" pname="d">
                                             <accid xml:id="ex-1216" accid="f" />
                                         </note>
+                                        <note xml:id="ex-1213" oct="4" pname="a" dots="0" />
+                                        <note xml:id="ex-1212" oct="4" pname="f" dots="0" />
+                                        <note xml:id="ex-1210" oct="4" pname="d" dots="0">
+                                            <accid xml:id="ex-1211" accid="f" />
+                                        </note>
                                     </chord>
                                     <beam>
-                                        <note xml:id="ex-1218" dur="16" oct="5" pname="d" />
-                                        <note xml:id="ex-1221" dur="16" oct="5" pname="d" />
+                                        <note xml:id="ex-1218" dur="16" oct="5" pname="d" accid.ges="f" />
+                                        <note xml:id="ex-1221" dur="16" oct="5" pname="d" accid.ges="f" />
                                         <note xml:id="ex-1223" dur="16" oct="5" pname="c" />
                                         <note xml:id="ex-1224" dur="16" oct="5" pname="c" />
                                         <note xml:id="ex-1225" dur="16" oct="4" pname="g" />
@@ -166,14 +173,14 @@
                                         <note xml:id="ex-1229" dur="16" oct="3" pname="d">
                                             <accid xml:id="ex-1230" accid="f" />
                                         </note>
-                                        <note xml:id="ex-1232" dur="16" oct="3" pname="d" />
-                                        <note xml:id="ex-1234" dur="16" oct="2" pname="a" />
-                                        <note xml:id="ex-1236" dur="16" oct="2" pname="a" />
+                                        <note xml:id="ex-1232" dur="16" oct="3" pname="d" accid.ges="f" />
+                                        <note xml:id="ex-1234" dur="16" oct="2" pname="a" accid.ges="f" />
+                                        <note xml:id="ex-1236" dur="16" oct="2" pname="a" accid.ges="f" />
                                         <note xml:id="ex-1238" dur="16" oct="2" pname="f" />
                                         <note xml:id="ex-1239" dur="16" oct="2" pname="f" />
                                     </beam>
-                                    <note xml:id="ex-1240" dur="4" oct="2" pname="e" />
-                                    <rest xml:id="ex-1242" dur="8" />
+                                    <note xml:id="ex-1240" dur="4" oct="2" pname="e" accid.ges="f" />
+                                    <rest xml:id="ex-1242" dur="8" oloc="2" ploc="e" />
                                 </layer>
                             </staff>
                             <tie startid="#ex-1215" endid="#ex-1218" />

--- a/encodings/10/pfeffer/comments_de.xml
+++ b/encodings/10/pfeffer/comments_de.xml
@@ -6,16 +6,16 @@
         <title type="part">Description of Realization</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/11/mattheson/comments_1st.xml
+++ b/encodings/11/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Elftes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/11/mattheson/comments_1st.xml
+++ b/encodings/11/mattheson/comments_1st.xml
@@ -90,13 +90,13 @@
         <p>
           <hi rendition="#aq">
             <abbr>Vid.</abbr>
-            <persName ref="#ed_whl_5gy_qlb">Guiſeppe Valentini</persName>
+            <persName corresp="#ed_whl_5gy_qlb">Guiſeppe Valentini</persName>
             <name type="musicalWork" ref="#ed_xz2_khc_tlb">Opera V. Sonata VII. chiamata: la <hi rendition="#i">Corelli</hi></name>.
 
-            <persName ref="#ed_fy5_r5x_qlb">Keiſers</persName>
+            <persName corresp="#ed_fy5_r5x_qlb">Keiſers</persName>
             <name type="musicalWork" ref="#ed_zqv_vrx_slb">Soliloquia</name> pag. 5. 6. 7. 8. 9.
 
-            <persName ref="#ed_jdg_wsx_qlb">Elias <hi rendition="#i">Brunmüller</hi></persName>
+            <persName corresp="#ed_jdg_wsx_qlb">Elias <hi rendition="#i">Brunmüller</hi></persName>
             <name type="musicalWork" ref="#ed_xbz_fjc_tlb">Sonata III.</name> in
             <placeName ref="https://www.geonames.org/2759794">Amſterdam</placeName> gravirt.
           </hi>
@@ -118,7 +118,7 @@
           <fw place="bottom" type="catch">ge</fw>
           <pb n="162"/>
           gedruckten Noten; es iſt wahr, man iſt es nicht gewohnt. Das Papier ſcheinet auch
-          <lb/>etwas durchzuſchlagen; er nehme es mit nach Hauſe und laſſe es rein, in <hi rendition="#b"><persName ref="#ed_mj2_qx2_5lb">Möhl-
+          <lb/>etwas durchzuſchlagen; er nehme es mit nach Hauſe und laſſe es rein, in <hi rendition="#b"><persName corresp="#ed_mj2_qx2_5lb">Möhl-
           <lb/>manns</persName></hi>
           <note place="foot" n="✚">
             Es war ein Organiſte an der <placeName>Nicolai-Kirchen</placeName> alhier, dem man einige Tage zuvor die Partie oder den Baß zur

--- a/encodings/11/mattheson/comments_de.xml
+++ b/encodings/11/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Elftes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/11/mattheson/music-example1.xml
+++ b/encodings/11/mattheson/music-example1.xml
@@ -28,25 +28,29 @@
                 <score>
                     <scoreDef key.pname="e" key.accid="f" key.mode="major" meter.unit="4" midi.bpm="90" mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="G" clef.line="1" key.sig="3f" n="1" lines="5" />
-                            <staffDef clef.shape="C" clef.line="3" key.sig="3f" n="2" lines="5" />
+                            <staffDef clef.shape="G" clef.line="1" n="1" lines="5">
+                                <keySig sig="3f" />
+                            </staffDef>
+                            <staffDef clef.shape="C" clef.line="3" n="2" lines="5">
+                                <keySig sig="3f" />
+                            </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure n="4" corresp="#measure-0000000448770319">
+                        <measure corresp="#measure-0000000448770319">
                             <staff n="1">
                                 <layer n="1">
-                                    <rest dur="4" />
-                                    <rest dur="16" />
+                                    <rest dur="4" oloc="5" ploc="a" />
+                                    <rest dur="16" oloc="5" ploc="a" />
                                     <beam>
-                                        <note dur="16" oct="5" pname="a" stem.dir="down" />
-                                        <note dur="16" oct="5" pname="b" stem.dir="down" />
-                                        <note dur="16" oct="5" pname="a" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="a" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="b" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="a" stem.dir="down" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <note dur="8" oct="5" pname="g" stem.dir="down" accid.ges="f" />
+                                        <note dur="8" oct="5" pname="g" stem.dir="down" />
                                         <note dur="16" oct="5" pname="f" stem.dir="down" />
-                                        <note dur="16" oct="5" pname="e" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
@@ -111,20 +115,20 @@
                                 </harm>
                             </supplied>
                         </measure>
-                        <measure n="5" corresp="#measure-0000001465389423">
+                        <measure corresp="#measure-0000001465389423">
                             <staff n="1">
                                 <layer n="1">
                                     <note dur="4" oct="5" pname="f" stem.dir="down" xml:id="ex-1769775861" />
                                     <beam>
                                         <note dur="16" oct="5" pname="f" stem.dir="down" xml:id="ex-1881082125" />
-                                        <note dur="16" oct="5" pname="g" stem.dir="down" accid.ges="f" />
-                                        <note dur="16" oct="5" pname="a" stem.dir="down" />
-                                        <note dur="16" oct="5" pname="g" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="g" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="a" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="g" stem.dir="down" />
                                     </beam>
                                     <beam>
                                         <note dur="8" oct="5" pname="f" stem.dir="down" />
-                                        <note dur="16" oct="5" pname="e" stem.dir="down" />
-                                        <note dur="16" oct="5" pname="d" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="d" stem.dir="down" />
                                     </beam>
                                 </layer>
                             </staff>
@@ -190,19 +194,19 @@
                                 </harm>
                             </supplied>
                         </measure>
-                        <measure n="6" corresp="#measure-0000001029700479">
+                        <measure corresp="#measure-0000001029700479">
                             <staff n="1">
                                 <layer n="1">
-                                    <note dur="4" oct="5" pname="e" stem.dir="down" xml:id="ex-1193092165" />
+                                    <note dur="4" oct="5" pname="e" stem.dir="down" accid.ges="f" xml:id="ex-1193092165" />
                                     <beam>
-                                        <note dur="16" oct="5" pname="e" stem.dir="down" xml:id="ex-0802666718" />
+                                        <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" xml:id="ex-0802666718" />
                                         <note dur="16" oct="5" pname="f" stem.dir="down" />
-                                        <note dur="16" oct="5" pname="g" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="g" stem.dir="down" />
                                         <note dur="16" oct="5" pname="f" stem.dir="down" />
                                     </beam>
                                     <beam>
-                                        <note dur="8" oct="5" pname="e" stem.dir="down" />
-                                        <note dur="16" oct="5" pname="d" stem.dir="down" accid.ges="f" />
+                                        <note dur="8" oct="5" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="d" stem.dir="down" />
                                         <note dur="16" oct="5" pname="c" stem.dir="up"/>
                                     </beam>
                                 </layer>
@@ -228,17 +232,17 @@
                                         </chord>
                                         <chord dur="8" stem.dir="up">
                                             <note oct="4" pname="e" accid.ges="f" />
-                                            <note oct="4" pname="a" />
+                                            <note oct="4" pname="a" accid.ges="n" />
                                         </chord>
                                     </beam>
                                     <beam>
                                         <chord dur="8" stem.dir="up">
                                             <note oct="4" pname="e" accid.ges="f" />
-                                            <note oct="4" pname="a" />
+                                            <note oct="4" pname="a" accid.ges="n" />
                                         </chord>
                                         <chord dur="8" stem.dir="up">
                                             <note oct="4" pname="e" accid.ges="f" />
-                                            <note oct="4" pname="a" />
+                                            <note oct="4" pname="a" accid.ges="n" />
                                         </chord>
                                     </beam>
                                 </layer>
@@ -274,7 +278,7 @@
                         <measure n="7" right="invis">
                             <staff n="1">
                                 <layer n="1">
-                                    <custos oct="4" pname="b" />
+                                    <custos oct="5" pname="d" />
                                 </layer>
                             </staff>
                             <staff n="2">

--- a/encodings/11/mattheson/music-example2.xml
+++ b/encodings/11/mattheson/music-example2.xml
@@ -28,12 +28,16 @@
                 <score>
                     <scoreDef key.pname="e" key.accid="f" key.mode="major" meter.unit="4" midi.bpm="90" mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" key.sig="3f" n="1" lines="5" />
-                            <staffDef clef.shape="F" clef.line="4" key.sig="3f" n="2" lines="5" />
+                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5">
+                                <keySig sig="3f" />
+                            </staffDef>
+                            <staffDef clef.shape="F" clef.line="4" n="2" lines="5">
+                                <keySig sig="3f" />
+                            </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure n="23" corresp="#measure-0000002078803044">
+                        <measure corresp="#measure-0000002078803044">
                             <staff n="1">
                                 <layer n="1">
                                     <rest dur="16" staff="2" loc="6" />
@@ -103,7 +107,7 @@
                                 </harm>
                             </supplied>
                         </measure>
-                        <measure n="24" corresp="#measure-0000001071915657">
+                        <measure corresp="#measure-0000001071915657">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
@@ -170,7 +174,7 @@
                             </staff>
                             <staff n="2">
                                 <layer n="2">
-                                    <custos oct="5" pname="c" />
+                                    <custos oct="4" pname="c" />
                                 </layer>
                             </staff>
                             <!-- dir should be placed between staves -->

--- a/encodings/11/mattheson/music-example3.xml
+++ b/encodings/11/mattheson/music-example3.xml
@@ -28,11 +28,13 @@
                 <score>
                     <scoreDef key.pname="e" key.accid="f" key.mode="major" meter.unit="4" midi.bpm="90" mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" key.sig="3f" n="1" lines="5" />
+                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5">
+                                <keySig sig="3f" />
+                            </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure n="33" corresp="#measure-0000000874590211">
+                        <measure corresp="#measure-0000000874590211">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
@@ -70,8 +72,10 @@
                                     <beam>
                                         <note dur="32" oct="4" pname="g" />
                                         <note dur="32" oct="4" pname="b" accid.ges="f" />
-                                        <note dur="32" oct="5" pname="e">
-                                            <accid accid="n" />
+                                        <note dur="32" oct="5" pname="e" accid.ges="n">
+                                            <orig>
+                                                <accid accid="n" />
+                                            </orig>
                                         </note>
                                         <note dur="32" oct="4" pname="b" accid.ges="f" />
                                     </beam>

--- a/encodings/11/mattheson/music-example4.xml
+++ b/encodings/11/mattheson/music-example4.xml
@@ -28,8 +28,12 @@
                 <score>
                     <scoreDef key.pname="e" key.accid="f" key.mode="major" meter.unit="4" midi.bpm="90" mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" key.sig="3f" n="1" lines="5" />
-                            <staffDef clef.shape="F" clef.line="4" key.sig="3f" n="2" lines="5" />
+                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5">
+                                <keySig sig="3f" />
+                            </staffDef>
+                            <staffDef clef.shape="F" clef.line="4" n="2" lines="5">
+                                <keySig sig="3f" />
+                            </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
@@ -39,7 +43,7 @@
                                     <supplied resp="#pfeffer">
                                         <space dur="4" />
                                     </supplied>
-                                    <rest dur="8" />
+                                    <rest dur="8" oloc="5" ploc="d" />
                                     <note dur="8" oct="5" pname="f" />
                                     <beam>
                                         <note dur="16" oct="5" pname="f" />
@@ -88,9 +92,14 @@
                                         <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="4" pname="a">
-                                            <supplied resp="#rettinghaus">
-                                                <accid accid="n" />
-                                            </supplied>
+                                            <app>
+                                                <lem source="#secondEdition">
+                                                    <accid accid="n" />
+                                                </lem>
+                                                <rdg source="#firstEdition">
+                                                    <accid accid.ges="f" />
+                                                </rdg>
+                                            </app>
                                         </note>
                                     </beam>
                                 </layer>
@@ -99,9 +108,11 @@
                                 <layer n="1">
                                     <beam>
                                         <note dur="8" oct="3" pname="a">
-                                            <reg resp="#rettinghaus">
-                                                <accid accid="n" enclose="brack" />
-                                            </reg>
+                                            <supplied resp="#rettinghaus">
+                                                <reg>
+                                                    <accid accid="n" />
+                                                </reg>
+                                            </supplied>
                                         </note>
                                         <note dur="8" oct="3" pname="g" />
                                         <note dur="8" oct="3" pname="g" />
@@ -127,7 +138,9 @@
                                 <layer n="1">
                                     <note dur="8" oct="4" pname="a">
                                         <supplied resp="#rettinghaus">
-                                            <accid accid="n" />
+                                            <reg>
+                                                <accid accid="n" />
+                                            </reg>
                                         </supplied>
                                     </note>
                                     <note dur="4" oct="5" pname="d" />

--- a/encodings/12/mattheson/comments_1st.xml
+++ b/encodings/12/mattheson/comments_1st.xml
@@ -214,7 +214,7 @@
           weichet gar offt ins <hi rendition="#b">bA</hi>, als ſeine <hi rendition="#aq">Sex-
           <lb />tam</hi>, aus. Zum Beweiß deſſen kan eine
           <hi rendition="#aq">Cantate</hi> von dem
-          <persName ref="#ed_lhv_3sx_qlb">Mſr. <hi rendition="#b">Ha&#x0364;ndeln</hi></persName>,
+          <persName corresp="#ed_lhv_3sx_qlb">Mſr. <hi rendition="#b">Ha&#x0364;ndeln</hi></persName>,
           die mir eben zur Hand lieget,
           <lb />dienen. Sie iſt zwar nicht gedruckt, (wie ich denn nicht weiß,
           daß von dieſem ſo beru&#x0364;hmten <hi rendition="#aq">Autore</hi> was

--- a/encodings/12/mattheson/comments_1st.xml
+++ b/encodings/12/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Zwölftes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/12/mattheson/comments_de.xml
+++ b/encodings/12/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Zwölftes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/12/mattheson/comments_de.xml
+++ b/encodings/12/mattheson/comments_de.xml
@@ -239,7 +239,7 @@
           derowegen denn ein General-Bassist nothwendig auch in dieser Ton-Art, wenn
           sie gleich nicht zum Grunde stehen, sondern nur, als eine Anverwandtinn,
           herbeigefuͤhret werden sollte, wol beschlagen seyn muß. Man besehe und untersuche
-          nur noch einmahl die vorhin, auf der 356sten Seite, angefuͤhrte <persName ref="#ed_tj3_cwx_qlb">Marcellische</persName>
+          nur noch einmahl die vorhin, auf der 356sten Seite, angefuͤhrte <persName corresp="#ed_tj3_cwx_qlb">Marcellische</persName>
           Arie, so wird sich die Wahrheit des gesagten von selbst erweisen.
         </p>
       </div>
@@ -290,7 +290,7 @@
           Schule; alleine die Legalitaͤt des Emerepes gilt lange so viel nicht, als des
           Justitiani seine: welche doch auch ihre Abfaͤlle und Zusaͤtze leidet. Jn
           dem Punct der Sext und Quart bin ich also bey nahe der
-          <persName ref="#ed_rc3_fgy_qlb">Aristoxenischen</persName> Meynung
+          <persName corresp="#ed_rc3_fgy_qlb">Aristoxenischen</persName> Meynung
           zugethan, die noch diesen Tag bey allen Griechen so wol angenommen als auch
           ausgeuͤbet wird, und habe, wegen der Gesellschaft der Sext, eine besondre
           Hochachtung fuͤr die arme Quart, daß ich sie, in solchem Fall, den uͤbrigen

--- a/encodings/12/mattheson/comments_en.xml
+++ b/encodings/12/mattheson/comments_en.xml
@@ -128,7 +128,7 @@
           pieces in F minor modulate often into their third scale degree, bA:
           That is, why a thorough-bass player necessarily has to be well-versed in this
           key as well, even if it is not the piece's tonality but only a related key.
-          One shall study and look once more at the aria of <persName ref="#ed_tj3_cwx_qlb">Marcello</persName> on p. 356, which will
+          One shall study and look once more at the aria of <persName corresp="#ed_tj3_cwx_qlb">Marcello</persName> on p. 356, which will
           prove the correctness of the said.
         </p>
       </div>
@@ -138,7 +138,7 @@
         <p xml:id="p9-1">
           Yet what do talk so much of F minor? The daily and common <hi rendition="#b">C minor</hi>
           modulates often into <hi rendition="#b">bA</hi>, its natural sixth. To prove that can serve,
-          among thousands of other things, a particular cantata of the <persName ref="#ed_lhv_3sx_qlb">Capell-Meister
+          among thousands of other things, a particular cantata of the <persName corresp="#ed_lhv_3sx_qlb">Capell-Meister
           <hi rendition="#b">Ha&#x0364;ndel</hi></persName>, which is not printed but in many people's hands and which
           is well-known. It is called <name type="musicalWork" ref="#ed_sry_1sx_slb"><hi rendition="#b">Lucretia</hi></name> and its first words
           <hi rendition="#aq">O Numi eterni &amp;c.</hi>, from which will likely know it. The second aria of
@@ -175,7 +175,7 @@
           spartanic school. yet the legality of Emerepes counts by far not as much as the
           one of Iustitian: which also tolerates things falling away or being added.
           Regarding the sixth and the fourth I am almost devoted to the opinion of
-          <persName ref="#ed_rc3_fgy_qlb">Aristoxenes</persName> which is still
+          <persName corresp="#ed_rc3_fgy_qlb">Aristoxenes</persName> which is still
           accepted and exercised among the greeks and I have
           because of the combination with the sixth a special esteem for the poor fourth
           so that I do not completly estimate it equal to all the other dissonances

--- a/encodings/13/mattheson/comments_de.xml
+++ b/encodings/13/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Dreizehntes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/13/mattheson/comments_de.xml
+++ b/encodings/13/mattheson/comments_de.xml
@@ -137,7 +137,7 @@
           haben: <hi rendition="#b">Es sey eine grosse Thorheit, diejenige Melodie, welche mit
           schlechten, deutlichen Noten geschrieben werden kann, durch dunckle
           Zeichen zweifelhafft zu machen</hi>; wie solches Schwaͤbisch-Hallische
-          <hi rendition="#aq"><foreign xml:lang="ita">Cantor</foreign></hi>, <persName ref="#ed_esw_kxx_qlb">Herr <hi rendition="#i">Majer</hi></persName>,
+          <hi rendition="#aq"><foreign xml:lang="ita">Cantor</foreign></hi>, <persName corresp="#ed_esw_kxx_qlb">Herr <hi rendition="#i">Majer</hi></persName>,
           in seinem <hi rendition="#aq"><bibl ref="#ed_tyg_hdl_tlb">Hodego Musico, p. 28.</bibl></hi>
           kluͤglich anfuͤhret. Allein, erstlich muß man, um geschwinde Sachen recht auszudruͤcken,
           auch geschwinde Taͤcte und geschwinde Noten gebrauchen, damit Zeichen und Sachen

--- a/encodings/13/mattheson/comments_en.xml
+++ b/encodings/13/mattheson/comments_en.xml
@@ -143,7 +143,7 @@
           That old and honourable musician did not say wrongly that <hi rendition="#b">it is a
           great folly to turn a melody that can be written in simple and plain notes
           dubious by using obscure signatures.</hi>, as the <hi rendition="#aq"><foreign xml:lang="ita">Cantor</foreign></hi> of
-          Schwa&#x0364;bisch Hall, <persName ref="#ed_esw_kxx_qlb">mister Majer</persName> wisely says in his
+          Schwa&#x0364;bisch Hall, <persName corresp="#ed_esw_kxx_qlb">mister Majer</persName> wisely says in his
           <hi rendition="#aq"><bibl ref="#ed_tyg_hdl_tlb">Hodego Musico, p. 28</bibl></hi>. Yet one has to use quick signatures and
           quick notes in order to correctly express quick music, so that signature and
           music do match. Secondly one must not reject the fashion in certain pieces,

--- a/encodings/14/mattheson/comments_1st.xml
+++ b/encodings/14/mattheson/comments_1st.xml
@@ -131,7 +131,7 @@
           <lb />Wir betrachten offtmahls eine unanſehnliche <hi rendition="#aq">Aria</hi>, als etwas nichtswürdiges, bis wir einſt hören,
           <lb />mit welcher Art dieſelbe müſſe oder könne <hi rendition="#aq">executi</hi>rt werden, alsdann ist ſie unsere <hi rendition="#aq">Favorite</hi>. Die
           <lb /><hi rendition="#aq">Arietta: <name type="musicalWork" ref="#ed_j3j_3kc_tlb">Navicella, che s'inoltra</name> &amp;c.</hi> war hier lange bekandt,
-          ehe <hi rendition="#aq"><abbr>Monſr.</abbr></hi> <hi rendition="#b"><persName ref="#ed_a2l_3hy_qlb">Grünewald</persName></hi>, der
+          ehe <hi rendition="#aq"><abbr>Monſr.</abbr></hi> <hi rendition="#b"><persName corresp="#ed_a2l_3hy_qlb">Grünewald</persName></hi>, der
           <fw place="bottom" type="catch">groſſe</fw>
           <pb n="177" />
           groſſe <hi rendition="#aq">Virtuoſe</hi> und nunmehrige <placeName>Darmſtädtiſcher</placeName>
@@ -139,7 +139,7 @@
           <lb />kam. Niemand wuſte was an dem Dinge war, es wurde fein gerade weggeſungen, daß man über
           <lb />des <hi rendition="#aq">Componiſten</hi> vermeynte Einfalt lachen muſte, da er doch unſchuldig war. Wie aber
           <hi rendition="#aq"><abbr>Monſr.</abbr></hi>
-          <lb /><hi rendition="#b"><persName ref="#ed_a2l_3hy_qlb">Grünewald</persName></hi> ſich damit hören ließ, kannte es faſt niemand, ſo fremd klang es, und jeder wolte ſich
+          <lb /><hi rendition="#b"><persName corresp="#ed_a2l_3hy_qlb">Grünewald</persName></hi> ſich damit hören ließ, kannte es faſt niemand, ſo fremd klang es, und jeder wolte ſich
           <lb />hernach an der Sache zu Tode künſteln. O! es hatte ſeines gleichen nicht. Seht! ſo viel liegt an der
           <lb /><hi rendition="#aq">Execution</hi>, ſie macht in der <hi rendition="#aq">Muſic</hi> juſt den Unterſcheid, welchen Licht und Schatten haben, das ſind
           <lb />aber <hi rendition="#aq">Extremität</hi>en. Alſo wolte ich denn auch inſonderheit diese <hi rendition="#aq">Pieçe</hi>, mit einem gewissen <hi rendition="#aq">Mouve-
@@ -170,7 +170,7 @@
           <lb />gleich alle gar wohl bekandt machen darff, weil ſie alle <hi rendition="#aq">affinaliter</hi> häuffig genug vorkommen. Fol-
           <lb />gende zwey aber ſcheinen mir dieſen Falls nothwendiger zu ſeyn, als die andern ſieben, nemlich:
           <lb /><hi rendition="#aq">♯D</hi> in Gegenhaltung <hi rendition="#aq">♭E</hi>, und <hi rendition="#aq">♯G</hi> in Gegenhaltung <hi rendition="#aq">♭A</hi>. Die übrigen: <hi rendition="#aq">♯H, ♭C, ♭D,
-          <lb />♯E, ♭F, ♭G</hi>, und <hi rendition="#aq">♯A</hi>, die doch <hi rendition="#aq"><persName ref="#ed_dwf_j5x_qlb">Monſr. de St. Lambert</persName></hi>, und ſonſt noch kein <hi rendition="#aq">Autor</hi> zu
+          <lb />♯E, ♭F, ♭G</hi>, und <hi rendition="#aq">♯A</hi>, die doch <hi rendition="#aq"><persName corresp="#ed_dwf_j5x_qlb">Monſr. de St. Lambert</persName></hi>, und ſonſt noch kein <hi rendition="#aq">Autor</hi> zu
           <lb /><hi rendition="#aq">ſpecifici</hi>ren die <hi rendition="#aq">Curioſitè</hi> gehabt hat, würden mit ihrer <hi rendition="#aq">Transpoſition</hi> gar zu weitläuffig fallen,
           <lb />und doch wenig Nutzen ſchaffen, weil man ſie alle mit einander viel näher haben kan. Denn ♯H iſt <hi rendition="#aq">C mol</hi>,
           <lb /><hi rendition="#aq">bC</hi> iſt <hi rendition="#aq">H dur</hi>, <hi rendition="#aq">♭D</hi> iſt <hi rendition="#aq">Cis dur</hi>, <hi rendition="#aq">#E</hi> iſt <hi rendition="#aq">F mol</hi>,

--- a/encodings/14/mattheson/comments_1st.xml
+++ b/encodings/14/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Vierzehntes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/14/mattheson/comments_de.xml
+++ b/encodings/14/mattheson/comments_de.xml
@@ -165,7 +165,7 @@
             also versetzen, solches muß niemand hieraus schliessen; ob man sie sich gleich alle neun
             wol bekannt machen darff, indem sie, als Verwandte, haͤuffig genug vorkommen. Das <hi rendition="#b">♯D</hi>, in Gegenhaltung mit dem <hi rendition="#b">♭E</hi> und denn
             das <hi rendition="#b">♯G</hi>, in Betracht des <hi rendition="#b">♭A</hi>, scheinen mir
-            hierzu nothwendiger zu seyn, als die uͤbrigen sieben: welche dennoch der <persName ref="#ed_dwf_j5x_qlb">Herr von St. Lambert</persName>, und sonst noch
+            hierzu nothwendiger zu seyn, als die uͤbrigen sieben: welche dennoch der <persName corresp="#ed_dwf_j5x_qlb">Herr von St. Lambert</persName>, und sonst noch
             keiner, verzeichnet hat. Mit den beiden erwehnten Tonen hat es einegantz andere
             Bewandtniß, als mit den uͤbrigen: denn <hi rendition="#b">♯D</hi> ist eben so gewoͤhnlich,
             als <hi rendition="#b">♭E</hi>, und <hi rendition="#b">♯G</hi> koͤmt eben so offt vor,

--- a/encodings/14/mattheson/comments_de.xml
+++ b/encodings/14/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Vierzehntes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/14/mattheson/comments_en.xml
+++ b/encodings/14/mattheson/comments_en.xml
@@ -15,8 +15,8 @@
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/14/mattheson/comments_en.xml
+++ b/encodings/14/mattheson/comments_en.xml
@@ -114,7 +114,7 @@
           one may get acquainted with all the nine, for they appear
           often enough as relative keys. The <hi rendition="#b">♯D</hi> as an enharmonic equivalent of the
           <hi rendition="#b">♭E</hi> and the <hi rendition="#b">♯G</hi> of the <hi rendition="#b">♭A</hi> seem to be more
-          necessary than the other seven: although <persName ref="#ed_dwf_j5x_qlb">St. Lambert</persName>
+          necessary than the other seven: although <persName corresp="#ed_dwf_j5x_qlb">St. Lambert</persName>
           and nobody else yet has recorded
           them. But those two keys are very different matter than all the other ones, since
           <hi rendition="#b">♯D</hi> is as common as <hi rendition="#b">♭E</hi> and <hi rendition="#b">♯G</hi> as common as

--- a/encodings/15/mattheson/comments_de.xml
+++ b/encodings/15/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Fünfzehntes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/15/mattheson/comments_de.xml
+++ b/encodings/15/mattheson/comments_de.xml
@@ -163,7 +163,7 @@
           Weise, mit unserm <hi rendition="#b">Nohthelffer</hi> (dem <hi rendition="#b">Tact-schlagen</hi>) bruͤsten? da es ja weiter
           zu nichts dienet, als denjenigen, die unter dem Hauffen etwa hincken, eine
           Stuͤtze abzugeben, bey welcher sie sich wieder auffrichten, und in guter
-          Einigkeit mitfortschreiten koͤnnen. <persName ref="#ed_ghv_kvx_qlb">Donius</persName> schreibet<note place="foot" n="*)"><hi rendition="#aq"><foreign xml:lang="lat">De
+          Einigkeit mitfortschreiten koͤnnen. <persName corresp="#ed_ghv_kvx_qlb">Donius</persName> schreibet<note place="foot" n="*)"><hi rendition="#aq"><foreign xml:lang="lat">De
           tibicinum romanorum sui temporis imperitia sic loquitur: <hi rendition="#i">Demiratus
           sum minus, iis in usu esse rhythmum pedibus moderari: sine quo vix numeros
           exacte sequi unquam possunt.</hi></foreign> <bibl ref="#ed_i1b_lfl_tlb">Don. de Præst. Vet. Music, pag. III.</bibl></hi></note>
@@ -218,7 +218,7 @@
       <div n="6">
         <head>§. 6.</head>
         <p xml:id="p6-1">
-          Bißher haben wir wieder die uͤbermaͤssige Tactirungs-Lust <note place="foot" n="(*)"><persName ref="#ed_jtb_pfy_qlb">Lully</persName>
+          Bißher haben wir wieder die uͤbermaͤssige Tactirungs-Lust <note place="foot" n="(*)"><persName corresp="#ed_jtb_pfy_qlb">Lully</persName>
           hatte die Gewohnheit, mittelst hefftiger Stossung seines Spanischen Rohrs wieder den
           Fuß-Boden, den Tact zu geben; nahm aber den Tod davon, wie seine Lebens-Beschreibung
           berichtet. <hi rendition="#i"><hi rendition="#aq">
@@ -233,7 +233,7 @@
             </choice> T. I. pag. 183.</bibl></hi></hi></note> und den dabey
           vermachten gottlosen Ehr-Geitz geredet. Wie waͤre es aber, wenn man
           Directores finde, die gar nicht einmahl den Tact selber fuͤhren koͤnnten? sondern einen
-          andern dazu brauchen muͤssten? Ein gelehrter Breslauer, <persName ref="#ed_bxd_xvx_qlb" full="abb">G.E.S.</persName>, schrieb den <date>28. Julii
+          andern dazu brauchen muͤssten? Ein gelehrter Breslauer, <persName corresp="#ed_bxd_xvx_qlb" full="abb">G.E.S.</persName>, schrieb den <date>28. Julii
           1728</date> davon also:
           <pb n="387" facs="#facs-p469"/>
           <quote>
@@ -268,8 +268,8 @@
           Jrrthum entspringe; nehmlich aus lauter grober Unwissenheit in dieser Sache, und
           aus dem damit genau verknuͤpfften geistlichen Uebermuth und Kragen-Stoltz. Wuͤsten diese
           Sammler, welche doch so blindlings auff die Deutlichkeit, Ernsthafftigkeit und Erbaulichkeit
-          ihrer alten Choral-Goͤtzen pochen, wie undeutlich, naͤrrisch und aͤrgerlich z.B. <hi rendition="#aq"><persName ref="#ed_xrr_lfy_qlb">Lasso</persName></hi>,
-          <persName ref="#ed_svf_qhy_qlb">Hammerschmidt</persName> und andere dergleichen in ihren Compositionen verfahren haben, allwo
+          ihrer alten Choral-Goͤtzen pochen, wie undeutlich, naͤrrisch und aͤrgerlich z.B. <hi rendition="#aq"><persName corresp="#ed_xrr_lfy_qlb">Lasso</persName></hi>,
+          <persName corresp="#ed_svf_qhy_qlb">Hammerschmidt</persName> und andere dergleichen in ihren Compositionen verfahren haben, allwo
           <hi rendition="#aq"><foreign xml:lang="lat">
           <choice>
             <sic>Hamonia</sic>
@@ -326,7 +326,7 @@
           wenn, im Beyseyn einiger Kenner, ein Pflaster-Treter und eingebildeter Meister
           sich damit bloß gaͤbe. Jch will die Stelle nicht nennen, sie wird sich schon weisen,
           und die Algebraisten werden sie von ferne riechen: insodernheit der Quedlinburger
-          Hof-Organist<note type="editorial" resp="#pfeffer"><persName ref="#ed_u1q_mlx_qlb">Andreas Werckmeister.</persName></note>,
+          Hof-Organist<note type="editorial" resp="#pfeffer"><persName corresp="#ed_u1q_mlx_qlb">Andreas Werckmeister.</persName></note>,
           der die Leute fuͤr Katzen haͤlt.
         </p>
         <notatedMusic xml:id="aria-bottari">

--- a/encodings/15/mattheson/comments_en.xml
+++ b/encodings/15/mattheson/comments_en.xml
@@ -15,8 +15,8 @@
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/15/mattheson/comments_en.xml
+++ b/encodings/15/mattheson/comments_en.xml
@@ -97,7 +97,7 @@
           try to hide it as much as possible. So why should we so unnecessarily and
           needlessly boast about our auxiliary, the time-beating? Since it only
           serves to give those a support who limp in mob, so they can catch up and
-          go along in good unity. <persName ref="#ed_ghv_kvx_qlb">Donius</persName> writes<note type="footnote"><hi rendition="#aq">De
+          go along in good unity. <persName corresp="#ed_ghv_kvx_qlb">Donius</persName> writes<note type="footnote"><hi rendition="#aq">De
           tibicinum romanorum sui temporis imperitia sic loquitur: <hi rendition="#i">Demiratus
           sum minus, iis in usu esse rhythmum pedibus moderari: sine quo vix numeros
           exacte sequi unquam possunt.</hi> <bibl ref="#ed_i1b_lfl_tlb">Don. de Præst. Vet. Music, pag. III.</bibl></hi></note>
@@ -148,14 +148,14 @@
         <head>§. 6.</head>
         <p xml:id="p6-1">
           Up to here we were talking against the exceeding conducting-desire <note place="foot" n="(*)" type="footnote">
-          <persName ref="#ed_jtb_pfy_qlb">Lully</persName> has had the habit of beating the time by strongly knocking his Spanish pipe
+          <persName corresp="#ed_jtb_pfy_qlb">Lully</persName> has had the habit of beating the time by strongly knocking his Spanish pipe
           against the floor; but he died because of it, as his biography
           tells.<hi rendition="#i">Vid Crit. Mus. T. I. pag. 183.</hi></note>
           and against the ungodly ambition in which it results.
           But how would it be if we found directors that do not even know how to conduct
           themselves? but need someone to do it?
           A scholar from <placeName>Breslau</placeName>,
-          <persName ref="#ed_bxd_xvx_qlb">G.E.S.</persName><note type="gloss" resp="#pfeffer">probably Gottfried
+          <persName corresp="#ed_bxd_xvx_qlb">G.E.S.</persName><note type="gloss" resp="#pfeffer">probably Gottfried
           Ephraim Scheibel.</note>, wrote about it on the 28th of July 1728:
           <quote>
             I have been talking to a good friend here, who knows quite well the sly old
@@ -182,8 +182,8 @@
           this matter and, associated with just that, a clerical presumption and collar-pride.
           If only those gatherers, who insist so much on the clarity, graveness and
           edifying nature of their old chorale idols, knew, how unclear, silly and irritating
-          <abbr>e.g.</abbr> <hi rendition="#aq"><persName ref="#ed_xrr_lfy_qlb">Lasso</persName></hi>,
-          <persName ref="#ed_svf_qhy_qlb">Hammerschmidt</persName> etc. were proceeding in their
+          <abbr>e.g.</abbr> <hi rendition="#aq"><persName corresp="#ed_xrr_lfy_qlb">Lasso</persName></hi>,
+          <persName corresp="#ed_svf_qhy_qlb">Hammerschmidt</persName> etc. were proceeding in their
           compositions, in which the <foreign xml:lang="lat">Harmonia</foreign> was the <foreign xml:lang="lat">domina</foreign>,
           they would not embarass themselves, but rather change the tune. Yes, if those folks knew
           that this way of making music, which they condemn because of some performing

--- a/encodings/16/hill/comments_de.xml
+++ b/encodings/16/hill/comments_de.xml
@@ -6,16 +6,16 @@
         <title type="part">Lesson by R. Hill on Probstück 16</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/16/hill/comments_de.xml
+++ b/encodings/16/hill/comments_de.xml
@@ -86,7 +86,7 @@
         a-Moll, transponierst und dir die ganze Ausarbeitung in a-Moll ausdenkst
         und das wieder nach as-Moll transponierst?
 
-        Die Wahrscheinlichkeit ist sehr hoch, dass bei <persName ref="#ed_ngx_5lx_qlb">Bach</persName>
+        Die Wahrscheinlichkeit ist sehr hoch, dass bei <persName corresp="#ed_ngx_5lx_qlb">Bach</persName>
         zumindest sehr viel von
         seinen Präludien und Fugen, die in abgelegenen Tonarten sind, ursprünglich
         einen halben Ton höher oder tiefer komponiert wurden.

--- a/encodings/16/mattheson/comments_de.xml
+++ b/encodings/16/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Sechzehntes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/16/mattheson/comments_de.xml
+++ b/encodings/16/mattheson/comments_de.xml
@@ -158,8 +158,8 @@
           u. vermeynet haben, daß dem Clavier bey den halben Stuffen noch sieben Tangenten
           in jeder Octave fehlten, sind wol schwerlich auf die Gedancken gerathen, daß
           man nach ihrer Zeit aus solchen halben Stuffen, (geschweige aus ihren Bruͤchen)
-          jemahls ein Stuͤck setzen wuͤrde, zumahl da <persName ref="#ed_dvy_pvy_qlb">Capricornus</persName>
-          und <persName ref="#ed_jlh_wvy_qlb">Bernhardi</persName> sich in diesem Werck schon wacker
+          jemahls ein Stuͤck setzen wuͤrde, zumahl da <persName corresp="#ed_dvy_pvy_qlb">Capricornus</persName>
+          und <persName corresp="#ed_jlh_wvy_qlb">Bernhardi</persName> sich in diesem Werck schon wacker
           umgesehen, und fast fuͤr unmoͤglich gehalten haben, daß es weiter koͤnne
           getrieben werden; wie doch zu Tage lieget: sie haben nur die Folgen
           oder Ausweichungen der andern gewoͤhnlichen Tone betrachtet, und nach
@@ -230,14 +230,14 @@
           Tertz wesentlich, das andere nur zufaͤlliger Weise fuͤhret; allein, es ist doch
           einerley im Spielen, nur laͤsset sich das letztere reiner auffschreiben, darum
           hat mans hier im Prob-Stuͤcke gewehlet. Einen schoͤnen Satz aber, aus dem
-          <hi rendition="#aq">b</hi><hi rendition="#b">A dur</hi>, finde ich in <hi rendition="#aq"><persName ref="#ed_khq_sfy_qlb">Mossi</persName></hi> seinem
+          <hi rendition="#aq">b</hi><hi rendition="#b">A dur</hi>, finde ich in <hi rendition="#aq"><persName corresp="#ed_khq_sfy_qlb">Mossi</persName></hi> seinem
           Wercke, <hi rendition="#aq">pag. 34</hi>, welches zu mercken bitte, weil es mir bey dem Zwoͤlfften
           Prob-Stuͤcke dieser Classe nicht beigefallen ist. Einen andern Satz aber, aus
           dem <hi rendition="#b">♯G dur</hi> trifft man bey eben selbigem Componisten <hi rendition="#aq">pag. 59</hi> an,
           wodurch meine obige Anmerckungen bewiesen sind. Besagtes Werck, das hier
           angefuͤhret, und als ein Exempel vorgestellet wird, bestehet in zwoͤlff Sonaten mit
           einer Violin und dem Basse, zu <placeName ref="https://www.geonames.org/2759794">Amsterdam</placeName> in Kupffer gestochen, und der Verfasser
-          heisset: <hi rendition="#aq"><persName ref="#ed_khq_sfy_qlb">Giovanni Mossi</persName></hi>.
+          heisset: <hi rendition="#aq"><persName corresp="#ed_khq_sfy_qlb">Giovanni Mossi</persName></hi>.
         </p>
       </div>
 

--- a/encodings/16/mattheson/comments_en.xml
+++ b/encodings/16/mattheson/comments_en.xml
@@ -8,8 +8,8 @@
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/16/mattheson/comments_en.xml
+++ b/encodings/16/mattheson/comments_en.xml
@@ -159,7 +159,7 @@
           Tertz wesentlich, das andere nur zufa&#x0364;lliger Weise fu&#x0364;hret; allein, es ist doch
           einerley im Spielen, nur la&#x0364;sset sich das letztere reiner auffschreiben, darum
           hat mans hier im Prob-Stu&#x0364;cke gewehlet. Einen scho&#x0364;nen Satz aber, aus dem
-          <emph>♭A major</emph>, finde ich in <persName ref="#ed_khq_sfy_qlb">Mossi</persName> seinem
+          <emph>♭A major</emph>, finde ich in <persName corresp="#ed_khq_sfy_qlb">Mossi</persName> seinem
           Wercke, pag. 34, welches zu mercken bitte, weil es mir bey dem
           <ref target="/view/12/mattheson/english">Zwo&#x0364;lfften
           Prob-Stu&#x0364;cke dieser Classe</ref> nicht beigefallen ist. Einen andern Satz aber, aus
@@ -167,7 +167,7 @@
           wodurch meine obige Anmerckungen bewiesen sind. Besagtes Werck, das hier
           angefu&#x0364;hret, und als ein Exempel vorgestellet wird, bestehet in zwo&#x0364;lff Sonaten mit
           einer Violin und dem Basse, zu <placeName ref="https://www.geonames.org/2759794">Amsterdam</placeName> in Kupffer gestochen, und der Verfasser
-          heisset: <persName ref="#ed_khq_sfy_qlb">Mossi</persName>.
+          heisset: <persName corresp="#ed_khq_sfy_qlb">Mossi</persName>.
         </p>
       </div>
 

--- a/encodings/17/mattheson/comments_de.xml
+++ b/encodings/17/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Siebenzehntes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/18/mattheson/comments_de.xml
+++ b/encodings/18/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Achtzehntes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/18/mattheson/comments_de.xml
+++ b/encodings/18/mattheson/comments_de.xml
@@ -204,9 +204,9 @@
       <div n="8">
         <head>§. 8.</head>
         <p xml:id="p8-1" facs="#facsZone-p8-1">
-          <lb/>Es hat der beruͤhmte <hi rendition="#b"><persName ref="#ed_uyt_trx_qlb">Herr Telemann</persName></hi> ehemals ſechs Concerte herauſge-
+          <lb/>Es hat der beruͤhmte <hi rendition="#b"><persName corresp="#ed_uyt_trx_qlb">Herr Telemann</persName></hi> ehemals ſechs Concerte herauſge-
           <lb/>geben, und gar ſauber in Kupffer ſtechen laſſen, die der weiland Durchlauchtige
-          <lb/><hi rendition="#b"><persName ref="#ed_xxh_bgy_qlb">Printz Ernſt, von Sachſen-Weymar</persName></hi>, mit eigener Hand, und aus eigener
+          <lb/><hi rendition="#b"><persName corresp="#ed_xxh_bgy_qlb">Printz Ernſt, von Sachſen-Weymar</persName></hi>, mit eigener Hand, und aus eigener
           <lb/>Erfindung geſetzet hat: in ſelbigen iſt das <hi rendition="#aq"><foreign xml:lang="ita">Concerto V.</foreign></hi> aus obigem Ton, und eins
           <lb/>der ſchoͤnſten. Freie Fuͤrſten zu finden, die muſicaliſchen Schriften verfaſſen, und
           <lb/>angefuͤhret werden koͤnnen, iſt ſonſt eine Sache, die nicht alle Tage aufſtoͤſſet;

--- a/encodings/19/mattheson/comments_de.xml
+++ b/encodings/19/mattheson/comments_de.xml
@@ -220,7 +220,7 @@
       <div n="8">
         <head>§. 8.</head>
         <p xml:id="p8-1" facs="#facsZone-p8-1">
-          <lb/><persName ref="#ed_dwf_j5x_qlb">Mſr. <hi rendition="#aq">St. Lambert</hi></persName> nennet dieſen Ton <hi rendition="#aq">p. 29.<foreign xml:lang="fra">F ut Fa Dièze mineur</foreign></hi>, und ſchrei-
+          <lb/><persName corresp="#ed_dwf_j5x_qlb">Mſr. <hi rendition="#aq">St. Lambert</hi></persName> nennet dieſen Ton <hi rendition="#aq">p. 29.<foreign xml:lang="fra">F ut Fa Dièze mineur</foreign></hi>, und ſchrei-
           <lb/>bet dabey: <hi rendition="#aq"><foreign xml:lang="fra">Rare</foreign></hi>. <hi rendition="#b">Fis mol</hi> iſt kuͤrtzer geſagt, und bey mir nichts rares.
         </p>
       </div>

--- a/encodings/19/mattheson/comments_de.xml
+++ b/encodings/19/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Neunzehntes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/2/mattheson/comments_1st.xml
+++ b/encodings/2/mattheson/comments_1st.xml
@@ -95,7 +95,7 @@
       <div>
         <p>
           <hi rendition="#aq">
-            <abbr>Vid.</abbr> <hi rendition="#i"><persName ref="#ed_fy5_r5x_qlb">Keiſers</persName></hi>
+            <abbr>Vid.</abbr> <hi rendition="#i"><persName corresp="#ed_fy5_r5x_qlb">Keiſers</persName></hi>
             <name type="musicalWork" ref="#ed_zqv_vrx_slb">Solil.</name>
             p. 6 &amp; 21.
             <foreign xml:lang="lat">ejusdem</foreign>

--- a/encodings/2/mattheson/comments_1st.xml
+++ b/encodings/2/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Zweites Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/2/mattheson/comments_de.xml
+++ b/encodings/2/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Zweites Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/2/mattheson/comments_en.xml
+++ b/encodings/2/mattheson/comments_en.xml
@@ -6,16 +6,16 @@
         <title type="part">Mattheson: Der Ober-Classe zweites Probstück (english translation)</title>
         <editor role="translator">
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/20/mattheson/comments_1st.xml
+++ b/encodings/20/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Zwanzigstes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/20/mattheson/comments_1st.xml
+++ b/encodings/20/mattheson/comments_1st.xml
@@ -190,7 +190,7 @@
 
       <div n="8">
         <p xml:id="p8-1" facs="#facsZone-p8-1">
-          <lb />§. 8. Daß dieſer Ton in Franckreich was ſeltenes ſeyn mu&#x0364;ſſe, erſehe aus <hi rendition="#aq"><persName ref="#ed_dwf_j5x_qlb">Mr. de
+          <lb />§. 8. Daß dieſer Ton in Franckreich was ſeltenes ſeyn mu&#x0364;ſſe, erſehe aus <hi rendition="#aq"><persName corresp="#ed_dwf_j5x_qlb">Mr. de
           <lb />St. <hi rendition="#i">Lambert</hi></persName></hi> seinem obangefu&#x0364;hrten Tractat vom General-Baß, da er <hi rendition="#aq">p. 27.</hi> ſetzet:
           <hi rendition="#aq"><foreign xml:lang="fra">Le B Fa Si Beccarre (H) etant un Ton, ſur lequel on compoſe rarement, <note place="foot" n="*)"><hi rendition="#fr">
             Wir haben Sachen mit Trompeten und Paucken aus dieſem Ton, das iſt zu ſagen: Cammer-Ton. Ich habe
@@ -207,21 +207,21 @@
             </choice> p. 486.
           </hi>
           <lb />ſchon gewieſen. Daß aber dieſer Ton gar nichts rares bey uns ſey, zeiget, nebſt un-
-          <lb />zehlich andern ta&#x0364;glich vorfallenden Exempeln, auch des <persName ref="#ed_uyt_trx_qlb">Herrn Capellmeiſter <hi rendition="#b">Tele-
+          <lb />zehlich andern ta&#x0364;glich vorfallenden Exempeln, auch des <persName corresp="#ed_uyt_trx_qlb">Herrn Capellmeiſter <hi rendition="#b">Tele-
           <lb />manns</hi></persName> <hi rendition="#aq"><name type="musicalWork" ref="#ed_shq_wkc_tlb">III Sonata</name></hi> aus den zu <placeName ref="https://www.geonames.org/2925533">Franckfurt</placeName> <hi rendition="#aq">gravir</hi>ten <hi rendition="#aq">Solis</hi>.
         </p>
       </div>
 
       <div n="9">
         <p xml:id="p9-1">
-          <lb />§. 9. Ein Römer, mit Nahmen <hi rendition="#aq"><persName ref="#ed_khq_sfy_qlb">Giovanni Moſſi</persName></hi>, ein Corelliner, der ſchon oben
+          <lb />§. 9. Ein Römer, mit Nahmen <hi rendition="#aq"><persName corresp="#ed_khq_sfy_qlb">Giovanni Moſſi</persName></hi>, ein Corelliner, der ſchon oben
           <lb />ein paar mal <hi rendition="#aq">citi</hi>ret worden, hat ohnla&#x0364;ngſt ein vortreffliches Werck von <hi rendition="#aq"><name type="musicalWork" ref="#ed_llx_3gc_tlb">12 Sona-
           <lb />ten à Violino ſolo</name></hi> herausgegeben, darinnen ſuche man die <hi rendition="#aq">Sonata V</hi> aus dem <hi rendition="#aq">H mol</hi>,
           <lb />und ſpiele ſie wohl, ich will Bu&#x0364;rge ſeyn, ſie ſoll Vergnu&#x0364;gen bringen. Das Werck
-          <lb />iſt zu <placeName ref="https://www.geonames.org/2759794">Amsterdam</placeName>, bey <hi rendition="#aq"><persName ref="#ed_tqx_dfy_qlb">Jeanne Roger</persName></hi>, in Kupffer geſtochen, und dem
-          <persName ref="#ed_lvf_bhy_qlb">Cardinal von
-          <lb /><hi rendition="#b">Schrottenbach</hi></persName> <hi rendition="#aq">dedicirt. C duro caret. Vid. <persName ref="#ed_svr_zhy_qlb">dell Abaco</persName> <name type="musicalWork" ref="#ed_nfp_mwc_tlb">Opera IV. Sonata
-          <lb />XI.</name> <persName ref="#ed_ntr_ghy_qlb">Ant. Vivaldi</persName> <name type="musicalWork" ref="#ed_pys_twc_tlb">Opera V. Sonata XVI.</name> <persName ref="#ed_mzk_n5x_qlb">Giacomo Sherard</persName> <name type="musicalWork" ref="#ed_i11_1fc_tlb">Opera I. Sonata XI.</name>
+          <lb />iſt zu <placeName ref="https://www.geonames.org/2759794">Amsterdam</placeName>, bey <hi rendition="#aq"><persName corresp="#ed_tqx_dfy_qlb">Jeanne Roger</persName></hi>, in Kupffer geſtochen, und dem
+          <persName corresp="#ed_lvf_bhy_qlb">Cardinal von
+          <lb /><hi rendition="#b">Schrottenbach</hi></persName> <hi rendition="#aq">dedicirt. C duro caret. Vid. <persName corresp="#ed_svr_zhy_qlb">dell Abaco</persName> <name type="musicalWork" ref="#ed_nfp_mwc_tlb">Opera IV. Sonata
+          <lb />XI.</name> <persName corresp="#ed_ntr_ghy_qlb">Ant. Vivaldi</persName> <name type="musicalWork" ref="#ed_pys_twc_tlb">Opera V. Sonata XVI.</name> <persName corresp="#ed_mzk_n5x_qlb">Giacomo Sherard</persName> <name type="musicalWork" ref="#ed_i11_1fc_tlb">Opera I. Sonata XI.</name>
           <lb />e <name type="musicalWork" ref="#ed_fp3_txc_tlb">Opera II. Sonata II.</name> &amp;c.</hi>
         </p>
       </div>

--- a/encodings/20/mattheson/comments_de.xml
+++ b/encodings/20/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Zwanzigstes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/20/mattheson/comments_de.xml
+++ b/encodings/20/mattheson/comments_de.xml
@@ -239,7 +239,7 @@
           <lb/>bertiſchen<note place="foot" n="*)"><hi rendition="#aq"><foreign xml:lang="fra">Le B Fa Si Beccarre
           etant un Ton, ſur lequel on compoſe rarement, il n'y a point
           <lb/>de modulation qui lui ſoit particulierement affectée: ſ'il en avoit une, ce croit la mineure.</foreign>
-          <bibl><hi rendition="#i"><persName ref="#ed_dwf_j5x_qlb">Mr. de St. Lambert</persName>, Traité de l'Accompagnement</hi>,
+          <bibl><hi rendition="#i"><persName corresp="#ed_dwf_j5x_qlb">Mr. de St. Lambert</persName>, Traité de l'Accompagnement</hi>,
           p.27.</bibl></hi></note> Buche vom General-Baß, da es ſo lautet: <quote>H iſt ein Ton, aus wel-
           <lb/>chem man ſelten etwas ſetzet, daher hat er auch eigentlich keine Tertz, die
           <lb/>ihm beſonders zugehoͤrt; haͤtte er aber eine, ſo muͤſte es wol die kleine

--- a/encodings/20/molinaro/comments_de.xml
+++ b/encodings/20/molinaro/comments_de.xml
@@ -6,16 +6,16 @@
         <title type="part">Description of Realization</title>
         <editor>
           <persName xml:id="rettinghaus">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/21/mattheson/comments_1st.xml
+++ b/encodings/21/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Einundzwanzigstes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/21/mattheson/comments_1st.xml
+++ b/encodings/21/mattheson/comments_1st.xml
@@ -175,7 +175,7 @@
           <lb />Wenn dieſes vorbey, ſo macht es die rechte Hand auf dieſselbe Art, wie
           <lb />der Schluß des erſten Theils iſt <hi rendition="#aq">tracti</hi>ret worden, und fa&#x0364;llt weiter nichts zu er-
           <lb />kla&#x0364;hren vor. Wer aber aus dieſem Ton eine scho&#x0364;ne <hi rendition="#aq">Aria</hi> zu <hi rendition="#aq">accompagni</hi>ren
-          <lb />Luſt hat, der ſuche ſelbige, unter andern, in <hi rendition="#b"><persName ref="#ed_fy5_r5x_qlb">Herrn Keiſers</persName></hi> ſeiner <hi rendition="#aq"><name type="musicalWork" ref="#ed_jzy_bcd_tlb">Opera Fre-
+          <lb />Luſt hat, der ſuche ſelbige, unter andern, in <hi rendition="#b"><persName corresp="#ed_fy5_r5x_qlb">Herrn Keiſers</persName></hi> ſeiner <hi rendition="#aq"><name type="musicalWork" ref="#ed_jzy_bcd_tlb">Opera Fre-
           <lb />degunda</name></hi>.
         </p>
       </div>
@@ -183,7 +183,7 @@
       <div n="7">
         <head>§. 7.</head>
         <p xml:id="p7-1">
-          <lb />Dieſer Ton heiſſet bey mehrerwehntem <persName ref="#ed_dwf_j5x_qlb">St. Lambert:</persName> <hi rendition="#aq"><foreign xml:lang="fra">B Fa Si Becarre,
+          <lb />Dieſer Ton heiſſet bey mehrerwehntem <persName corresp="#ed_dwf_j5x_qlb">St. Lambert:</persName> <hi rendition="#aq"><foreign xml:lang="fra">B Fa Si Becarre,
           <lb />majeure</foreign></hi>, und ſteht dabey: (ich weiß nicht warum) <hi rendition="#aq">rare</hi>. Wenn wir lauter
           <lb />Rarita&#x0364;ten aus unſern Tonen machen wollen, ſo wundert mich nicht, warum
           <lb />die Armuth ſo groß iſt. Wenn in der Fiebel Z. E. beym Q. beym X. beym Y.

--- a/encodings/21/mattheson/comments_de.xml
+++ b/encodings/21/mattheson/comments_de.xml
@@ -204,7 +204,7 @@
         <head>§. 6.</head>
         <p xml:id="p6-1" facs="#facsZone-p6-1">
           <lb/>Dieſer Ton, <hi rendition="#b">H dur</hi>, heiſſet, nach des
-          <persName ref="#ed_dwf_j5x_qlb">Herrn von St. Lamberts</persName> rothwelſchen
+          <persName corresp="#ed_dwf_j5x_qlb">Herrn von St. Lamberts</persName> rothwelſchen
           <note type="editorial" resp="#pfeffer">
             hier im Sinne von "unverständlich" gebraucht.
           </note>

--- a/encodings/21/mattheson/comments_de.xml
+++ b/encodings/21/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Einundzwanzigstes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/21/molinaro/comments_de.xml
+++ b/encodings/21/molinaro/comments_de.xml
@@ -6,16 +6,16 @@
         <title type="part">Description of Realization</title>
         <editor>
           <persName xml:id="rettinghaus">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/22/mattheson/comments_1st.xml
+++ b/encodings/22/mattheson/comments_1st.xml
@@ -6,22 +6,22 @@
         <title type="part">Mattheson: Der Ober-Classe zweiundzwanzigstes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/22/mattheson/comments_de.xml
+++ b/encodings/22/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe dreiundzwanzigstes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/23/mattheson/comments_1st.xml
+++ b/encodings/23/mattheson/comments_1st.xml
@@ -79,7 +79,7 @@
         <p>
           <hi rendition="#aq">
             <abbr>Conf.</abbr>
-            <persName ref="#ed_khq_sfy_qlb">Giov. Moſſi</persName>
+            <persName corresp="#ed_khq_sfy_qlb">Giov. Moſſi</persName>
             <name type="musicalWork" ref="#ed_llx_3gc_tlb">Opera I<hi rendition="#sup">ma</hi></name> pag. 59.
           </hi>
         </p>
@@ -173,14 +173,14 @@
           Wie dieſer Ton, <hi rendition="#aq">Cis moll</hi>, gar offt <hi rendition="#aq">affinaliter</hi> (des <hi rendition="#aq">Recitativi</hi> zu geſchwei-
           <lb />gen) in den kleineſten <hi rendition="#aq">Ariet</hi>ten vorkomme, kan man inſonderheit aus <persName ref="http://d-nb.info/gnd/118560999">Herrn <hi rendition="#b">Kei-
           <lb />ſers</hi></persName> <name type="musicalWork" ref="#ed_sbs_x2c_tlb">Erleſenen Sa&#x0364;tzen</name> <hi rendition="#aq">p. 67. f.</hi> ingleichen aus deſſelben <name type="musicalWork" ref="#ed_qdl_mrc_tlb"><hi rendition="#b">Erlo&#x0364;sungs-Gedan-
-          <lb />cken</hi></name> <hi rendition="#aq">pag. 25. f.</hi> erſehen. In Jnſtrumental-Sachen dienen zum Exempel des <persName ref="#ed_uyt_trx_qlb">Herrn
+          <lb />cken</hi></name> <hi rendition="#aq">pag. 25. f.</hi> erſehen. In Jnſtrumental-Sachen dienen zum Exempel des <persName corresp="#ed_uyt_trx_qlb">Herrn
           <lb /><hi rendition="#b">Telemann</hi>s</persName> <name type="musicalWork" ref="#ed_ymb_fsc_tlb"><hi rendition="#aq">Sonatine</hi></name>, allwo im Baſſe <hi rendition="#aq">pag. 9.&amp;10.</hi> Cadenzen und <hi rendition="#aq">Modulationes</hi>
           <lb />nicht nur ins <hi rendition="#aq">Cis moll</hi>, ſondern auch ins <hi rendition="#aq">Gis moll</hi> vorkommen. Sonſten finden wir
           <lb />gantze <hi rendition="#aq">Paragraphos (<foreign xml:lang="lat">ut ita loquar</foreign>)</hi> welche in dieſem Ton <hi rendition="#aq">fundamentaliter</hi> anfan-
           <lb />gen und endigen. Ich ko&#x0364;nte vom <hi rendition="#aq">Cis dur</hi> und <hi rendition="#aq">Fis dur</hi> auch viele Proben beybringen;
           <lb />aber ſie ſind eben nicht gedrucckt; und wenn ich ſie hier alle ſolte einrücken laſſen,
-          <lb />würde das Buch dreymahl ſo groß werden. Man ſuche nur in <persName ref="#ed_wrh_w5x_qlb"><hi rendition="#aq">Conti</hi></persName>, <persName ref="#ed_lhv_3sx_qlb"><hi rendition="#b">Hendels</hi></persName>
-          <lb />und <persName ref="#ed_qr2_hxx_qlb"><hi rendition="#b">Heinichens</hi></persName> Sing-Sachen, ſo wird ſich genug von dieſer Art hervorthun.
+          <lb />würde das Buch dreymahl ſo groß werden. Man ſuche nur in <persName corresp="#ed_wrh_w5x_qlb"><hi rendition="#aq">Conti</hi></persName>, <persName corresp="#ed_lhv_3sx_qlb"><hi rendition="#b">Hendels</hi></persName>
+          <lb />und <persName corresp="#ed_qr2_hxx_qlb"><hi rendition="#b">Heinichens</hi></persName> Sing-Sachen, ſo wird ſich genug von dieſer Art hervorthun.
         </p>
       </div>
 

--- a/encodings/23/mattheson/comments_1st.xml
+++ b/encodings/23/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe dreiundzwanzigstes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/23/mattheson/comments_de.xml
+++ b/encodings/23/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe dreiundzwanzigstes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/23/mattheson/comments_en.xml
+++ b/encodings/23/mattheson/comments_en.xml
@@ -6,16 +6,16 @@
         <title type="part">Mattheson: Der Ober-Classe dreiundzwanzigstes Probstück (english translation)</title>
         <editor role="translator">
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/24/mattheson/comments_de.xml
+++ b/encodings/24/mattheson/comments_de.xml
@@ -76,7 +76,7 @@
         <head>§. 1.</head>
         <p>
           Bey Ansehung der vorgesetzten Kreutze dieses letzten Prob-Stückes fallen mir
-          <lb /><persName ref="#ed_scp_svx_qlb">Printzens</persName> Worte ein, die er im dritten Capitel des ersten Theils seines
+          <lb /><persName corresp="#ed_scp_svx_qlb">Printzens</persName> Worte ein, die er im dritten Capitel des ersten Theils seines
           <hi rendition="#aq"><bibl ref="#ed_pmp_1hl_tlb">Phrynidis</bibl></hi> also führet:
           <quote>Es lachte mir das Herz im Leibe, wenn ich im An-
             <lb />fang des Systematis viel Signa chromatica oder ♭ sähe: ich hielte den Organisten,
@@ -178,10 +178,10 @@
           <surplus reason="repeated">eben</surplus>
           <lb />spielen, dahero dürffens andere gar nicht können. Es ist hier die Frage nicht, was
           <lb />der Verfasser kann, sondern was der eingebildete Bursche kann, der alles wissen will.
-          <lb />Ich könnte wol den weisen <persName ref="#ed_mnv_cks_tlb">Horatianischen</persName> Spruch:
+          <lb />Ich könnte wol den weisen <persName corresp="#ed_mnv_cks_tlb">Horatianischen</persName> Spruch:
           <lb />
           <note n="*)" place="foot">
-            <persName ref="#ed_mnv_cks_tlb">Hor.</persName> <bibl ref="#ed_hgg_fw1_5lb">de Art. Poet.</bibl> V. 306.
+            <persName corresp="#ed_mnv_cks_tlb">Hor.</persName> <bibl ref="#ed_hgg_fw1_5lb">de Art. Poet.</bibl> V. 306.
             Es hatte nehmlich Horatius nie ein theatralisches oder episches Ge-
             <lb />dicht geschrieben, und gab doch Regeln davon, die biß auf den heutigen Tag hochgeachtet
             <lb />werden.
@@ -234,7 +234,7 @@
           <lb />Stecher</bibl>
           <note type="editorial" resp="#pfeffer">
             Mattheson bezieht sich auf die gleichnamige Publikation (1730) von
-            <persName ref="#ed_arq_vfy_qlb">Gottfried Benjamin Hancke</persName>,
+            <persName corresp="#ed_arq_vfy_qlb">Gottfried Benjamin Hancke</persName>,
             in der Mattheson scharf kritisiert wurde (vgl. Hancke, S. 111f.).
           </note>
           seine Quacksalberey zu zeigen, Krafft welcher er mir neulich, ohne meine
@@ -247,17 +247,17 @@
               "–.– rumpantur ut ilia Hancken"
             </quote>
             (<quote type="translation" xml:id="mattheson-quote-trans" corresp="#mattheson-quote">
-              "dass <persName ref="#ed_arq_vfy_qlb">Hancke</persName>
+              "dass <persName corresp="#ed_arq_vfy_qlb">Hancke</persName>
               [vor Neid] der Magen platzte."
             </quote>) angefügt.</note>
-          des <persName ref="#ed_ixh_r2y_qlb">Hn. Geh. Secretar <hi rendition="#b">Königs</hi></persName>
+          des <persName corresp="#ed_ixh_r2y_qlb">Hn. Geh. Secretar <hi rendition="#b">Königs</hi></persName>
           <lb />zu untersuchen, u.zu tadeln. Allein, so lange meine Schrifften der Welt nützen können,
           <lb />wie der Augenschein erweiset, so lange ist mirs auch gleichviel, ob ich von diesem
           <lb />
           <fw place="bottom" type="catch">für</fw>
           <pb n="444" />
 
-          für einen musicalischen Grillenfänger, oder von jenem für den <persName ref="#ed_wpd_2lx_qlb">Apollo</persName> selbst ge-
+          für einen musicalischen Grillenfänger, oder von jenem für den <persName corresp="#ed_wpd_2lx_qlb">Apollo</persName> selbst ge-
           <lb />halten werde. Es kann mir nicht zuwieder seyn, ob Hintz oder Kuntz besser setzet,
           <lb />als ich: und ich würde mich wircklich darüber freuen, wenn hundert Organisten
           <lb />wären, die mich in den Sack, und wieder heraus spielen könnten.
@@ -265,7 +265,7 @@
             Mattheson zitiert damit Hancke, der a.a.O. schrieb:
             <quote>
               Es giebt aber auch Leute, welche weit besser, als Mattheson spielen, wovon ich nur einen,
-              nehmlich den Herrn <persName ref="#ed_ngx_5lx_qlb">Bach</persName> in <placeName>Leipzig</placeName> nennen will,
+              nehmlich den Herrn <persName corresp="#ed_ngx_5lx_qlb">Bach</persName> in <placeName>Leipzig</placeName> nennen will,
               welcher ihn in den Sack und wieder heraus
               spielen wird.
             </quote>
@@ -286,10 +286,10 @@
           <lb />treffen sei), wenigstens vier große und berühmte Ton-Künstler
           <note type="editorial" resp="#pfeffer">
             i.e.
-            <persName ref="#ed_lhv_3sx_qlb">Händel</persName>,
-            <persName ref="#ed_qr2_hxx_qlb">Heinichen</persName>,
-            <persName ref="#ed_uyt_trx_qlb">Telemann</persName> und
-            <persName ref="#ed_ngx_5lx_qlb">Bach</persName>.
+            <persName corresp="#ed_lhv_3sx_qlb">Händel</persName>,
+            <persName corresp="#ed_qr2_hxx_qlb">Heinichen</persName>,
+            <persName corresp="#ed_uyt_trx_qlb">Telemann</persName> und
+            <persName corresp="#ed_ngx_5lx_qlb">Bach</persName>.
           </note>
           (seinen Breslaui-
           <lb />schen Organisten ungerechnet) aufstellen und zusammen setzen muß. Allein, es ist
@@ -311,14 +311,14 @@
           <lb />welches, wenn es sein zehntes Jahr zurück gelegt hat, je länger je gelbere Zähne be-
           <lb />kömmt. Hiernächst würde ich auch, nach den Regeln einer genauen Bescheiden-
           <lb />heit, wol eben nicht läugnen, daß
-          <persName ref="#ed_ngx_5lx_qlb">Bardus</persName>
+          <persName corresp="#ed_ngx_5lx_qlb">Bardus</persName>
           <note type="editorial" resp="#pfeffer">i.e. Bach</note>
           und
-          <persName ref="#ed_lhv_3sx_qlb">Hiagnis</persName>
+          <persName corresp="#ed_lhv_3sx_qlb">Hiagnis</persName>
           <note type="editorial" resp="#pfeffer">i.e. Händel</note>,
           theils geschwinder, theils
           <lb />künstlicher spielen; daß
-          <persName ref="#ed_uyt_trx_qlb">Telephanes</persName>
+          <persName corresp="#ed_uyt_trx_qlb">Telephanes</persName>
           <note type="editorial" resp="#pfeffer">i.e. Telemann</note>
           reichlicher fetze, und daß
           <persName ref="http://d-nb.info/gnd/118709712">Hermogenes</persName>
@@ -336,7 +336,7 @@
           <pb n="445" />
 
           gehorsamen Diener
-          <lb /><hi rendition="#aq"><persName ref="#ed_b2n_mx1_5lb">Marsyas</persName></hi>
+          <lb /><hi rendition="#aq"><persName corresp="#ed_b2n_mx1_5lb">Marsyas</persName></hi>
           <note type="editorial" resp="#pfeffer">Pseodonym für Mattheson selbst.</note>.
           Die Anwendung ist leicht zu machen. Jener Su-
           <lb />perintendent <sic>in</sic> <placeName ref="https://www.geonames.org/2872570">Mecklenburgischen</placeName>
@@ -346,8 +346,8 @@
           <lb />cke der Christlichen Lehre? da antwortete der Bauer: Herr Superintendent,
           <lb /> das ist eine seltsame Frage, das wisset ihr besser, als ich. Was deucht
           <lb />dem <persName>Staarstecher</persName>, hätte er es nicht auch so machen können, und als denn mehr Ehre von
-          <lb />seiner unerbetenen Antwort gehabt. Denn <persName ref="#ed_ixh_r2y_qlb">Herr König</persName> weiß viel besser, als er,
-          <lb />wie mein Spielen, Setzen und Schreiben, beschaffen sey. <persName ref="#ed_ixh_r2y_qlb">Herr König</persName> hat auch
+          <lb />seiner unerbetenen Antwort gehabt. Denn <persName corresp="#ed_ixh_r2y_qlb">Herr König</persName> weiß viel besser, als er,
+          <lb />wie mein Spielen, Setzen und Schreiben, beschaffen sey. <persName corresp="#ed_ixh_r2y_qlb">Herr König</persName> hat auch
           <lb />nirgend gesagt, daß ich besser spiele, setze und schreibe, als andere, die sich <sic>darinu</sic>
           <lb />theilen; als ob es eine Schande wäre, groß, und nicht zugleich der grösseste zu
           <lb />seyn; sondern die Meynung ist mir gewesen, daß nicht jedermann diese drey Ei-
@@ -373,13 +373,13 @@
           lächerliches, vergrößerndes oder ausschweif-
           <lb />fendes an sich; ohne daß sich jemahls ein vernünfftiger Mensch hat gelüsten lassen,
           <lb />selbige mathematisch zu untersuchen. Ich mag nicht erwehnen, was andere grosse
-          <lb />Leute, als die Herren: <persName ref="#ed_y4p_gvx_qlb">Brockes</persName>,
-          <persName ref="#ed_tlg_lwy_qlb">Fabricius</persName>, <persName ref="#ed_jrt_bz1_5lb">Richey</persName>,
+          <lb />Leute, als die Herren: <persName corresp="#ed_y4p_gvx_qlb">Brockes</persName>,
+          <persName corresp="#ed_tlg_lwy_qlb">Fabricius</persName>, <persName corresp="#ed_jrt_bz1_5lb">Richey</persName>,
           etc. aus eigener Er-
           <lb />fahrung von meiner Wenigkeit zu rühmen beliebet, und mir dadurch mehr Ehre,
           <lb />als ich verdiene, angethan haben: das alles aber nehmen wir nicht mit Stricken, son-
           <lb />dern mit Latten, wie der <persName>Staar-Stecher</persName> redet. Und da ein eintziger von diesen in
-          <lb />der gelehrten und geschliffenen Welt wol zehn mahl so viel gilt, als funfzig <persName ref="#ed_arq_vfy_qlb">Hancken</persName>,
+          <lb />der gelehrten und geschliffenen Welt wol zehn mahl so viel gilt, als funfzig <persName corresp="#ed_arq_vfy_qlb">Hancken</persName>,
           <fw place="bottom" type="catch">so</fw>
           <pb n="446" />
 
@@ -450,8 +450,8 @@
       <div n="8">
         <lb /><head>§. 8.</head>
         <lb /><p>
-          Es haben schon, nebst verschiedenen andern, sowol <persName ref="#ed_knv_rsx_qlb">Kircher</persName>
-          als <persName ref="#ed_os2_1vx_qlb">Buliowsky</persName>,
+          Es haben schon, nebst verschiedenen andern, sowol <persName corresp="#ed_knv_rsx_qlb">Kircher</persName>
+          als <persName corresp="#ed_os2_1vx_qlb">Buliowsky</persName>,
           <lb />zwar nicht ihre eigene, doch die vermeynten vielfältigen Mängel unsers Claviers wahrgenommen,
           <lb />und denselben, durch drey Ordnungen der Palmulen, zu Hülffe
           <lb />zu kommen gesucht, da, anstatt der zwölff Stuffen, womit sich unsere Oktave bis-
@@ -461,14 +461,14 @@
           <lb />solche vermeynte Verbesserung noch lang nicht zurreichen, sondern entdecket nur
           <lb />immer mehr und mehr, was daran fehlet. Und wenn wir die Octave nach allen
           <lb />dreien Geschlechtern, der gemeinen Meynung nach, recht vollständig haben woll-
-          <lb />ten, so müsten nach <persName ref="#ed_knv_rsx_qlb">Kirchers</persName>
+          <lb />ten, so müsten nach <persName corresp="#ed_knv_rsx_qlb">Kirchers</persName>
           <note n="a)" place="foot">
             <hi rendition="#aq">
-              <abbr>vid.</abbr> <persName ref="#ed_knv_rsx_qlb">Kirch.</persName> <bibl ref="#ed_wcp_pz1_5lb">Musurg.</bibl> pag. 150.
+              <abbr>vid.</abbr> <persName corresp="#ed_knv_rsx_qlb">Kirch.</persName> <bibl ref="#ed_wcp_pz1_5lb">Musurg.</bibl> pag. 150.
             </hi>
           </note>
           Entwurff, vier und zwantzig Klang-Stuffen dar-
-          <lb />inn befindlich seyn. Es schrieb mir der berühmte <persName ref="#ed_g1w_hxy_qlb">Neidhardt</persName>
+          <lb />inn befindlich seyn. Es schrieb mir der berühmte <persName corresp="#ed_g1w_hxy_qlb">Neidhardt</persName>
           <abbr>d.</abbr> <date when="1719-10-17">17. Octob. 1719</date>.
             <lb />folgende Worte zu:
             <quote>
@@ -478,7 +478,7 @@
               <lb />dazu sind folgende:
               <note n="*)" place="foot">
                 Den hiher gehörigen sehr saubern Riß, welcher vor
-                <lb />dem <persName ref="#ed_g1w_hxy_qlb">Herrn Capellmeister Neidhardt</persName> selber dazu verertiget, und dem Kupffer-Stecher
+                <lb />dem <persName corresp="#ed_g1w_hxy_qlb">Herrn Capellmeister Neidhardt</persName> selber dazu verertiget, und dem Kupffer-Stecher
                 <date when="1728">vor
                 <lb />drittehalb Jahren</date> überreichet worden ist, hat dieser letzte, unachtsamer Weise, und zu meinem
                 <lb />grössesten Verdruß, verleget oder verloren.
@@ -493,25 +493,25 @@
         <lb /><p>
           Ja, wenn wir noch weiter, und durch <hi rendition="#aq">commata</hi> einhergehen wollten, so kä-
           <lb />men gar 53. Grade in einer eintzigen Octave zum Vorschein.
-          <hi rendition="#b"><persName ref="#ed_nhl_nxx_qlb">Sauveur</persName></hi>
+          <hi rendition="#b"><persName corresp="#ed_nhl_nxx_qlb">Sauveur</persName></hi>
           <note n="b)" place="foot">
             <abbr>voy.</abbr> <orgName ref="http://d-nb.info/gnd/35019-9"><abbr>Acad. Roy.</abbr> des Sciences</orgName>.
           </note>
-          will deren 43. haben; <hi rendition="#b"><persName ref="#ed_kyg_jgy_qlb">Mersennus</persName></hi> 32. Ein ungenannter Durlacher mag es diesem
+          will deren 43. haben; <hi rendition="#b"><persName corresp="#ed_kyg_jgy_qlb">Mersennus</persName></hi> 32. Ein ungenannter Durlacher mag es diesem
           <lb />abgesehen haben, indem er ein so genanntes fünff-faches Transponier-Clavier im
           <lb />Druck vorschlagen wollen, welches in geometrischer Fortschreitung 32. Tangenten
           <lb />in einer Octave begreiffen soll. Man kann bald sehen, wo dieser in die Schule ge-
-          <lb />gangen sey, wenn er den <persName ref="#ed_rc3_fgy_qlb">Aristoxenum</persName>
-          für einen Nachfolger des <persName ref="#ed_qqk_vy2_5lb">Pythagoras</persName> angibt,
-          <lb />und <persName ref="#ed_kyg_jgy_qlb">Mersennum</persName> mit unter diejenigen fetzt, die es nicht nach seinem Sinn getroffen
+          <lb />gangen sey, wenn er den <persName corresp="#ed_rc3_fgy_qlb">Aristoxenum</persName>
+          für einen Nachfolger des <persName corresp="#ed_qqk_vy2_5lb">Pythagoras</persName> angibt,
+          <lb />und <persName corresp="#ed_kyg_jgy_qlb">Mersennum</persName> mit unter diejenigen fetzt, die es nicht nach seinem Sinn getroffen
           <lb />haben. Hierher gehört dasjenige Clavicimbel, welches
-          <persName ref="#ed_d42_qxx_qlb">Carl <hi rendition="#b">Luyton</hi></persName> ehmahls von
+          <persName corresp="#ed_d42_qxx_qlb">Carl <hi rendition="#b">Luyton</hi></persName> ehmahls von
           <lb />77. Tangenten verfertiget hat, und dessen
           <note n="c)" place="foot">
-            <persName ref="#ed_g5m_4gy_qlb">Mich. Praetor.</persName> <bibl ref="#ed_llk_wz1_5lb">Syntagm. Mus. P. II.</bibl> c. 40.
+            <persName corresp="#ed_g5m_4gy_qlb">Mich. Praetor.</persName> <bibl ref="#ed_llk_wz1_5lb">Syntagm. Mus. P. II.</bibl> c. 40.
           </note>
           Prätorius mit grossen Ruhm geden-
-          <lb />cket. <hi rendition="#b"><persName ref="#ed_rtv_wrx_qlb">Henfling</persName></hi> wollte 50 Stuffen in der Octave wissen, und hatte eine Erfindung
+          <lb />cket. <hi rendition="#b"><persName corresp="#ed_rtv_wrx_qlb">Henfling</persName></hi> wollte 50 Stuffen in der Octave wissen, und hatte eine Erfindung
           <lb />von Claviaturen, die er Claviaria nennet, in seinem Positiv zum Stande gebracht,
           <lb />darin die Intervalle eine gantz andere Ordnung hielten, und, seiner Meynunq nach,
           <lb />weit bequemer zu greiffen seyn sollten, als sonst. Man soll auf solchem Griff-Bret,
@@ -529,7 +529,7 @@
       <div n="10">
         <lb /><head>§. 10.</head>
         <p>
-          <persName ref="#ed_ghv_kvx_qlb">Donius</persName>
+          <persName corresp="#ed_ghv_kvx_qlb">Donius</persName>
           <note n="e)" place="foot">
             <lb />Non solo non bastano le voci di questi Instromenti spezzati, che dicono chromati-
             <lb />ci, màne meno di quelli che dicono enarmonici. Oltre che sarebbe gran temeri-
@@ -538,7 +538,7 @@
             <lb />stature e armonie, secondo la nostra inventione, senza mettere a conto la com-
             <lb />modità, che si riceve da più sistemi, di poter far sentire gra diversità trà gli uni-
             <lb />soni stessi, mediante maggiore o minore tensione delle corde, come nelle viole e
-            <lb />ne' cembali s'è trattico. <persName ref="#ed_ghv_kvx_qlb">Doni</persName>, <bibl ref="#ed_s4h_t1b_5lb">Annotaz. p. 6</bibl>.
+            <lb />ne' cembali s'è trattico. <persName corresp="#ed_ghv_kvx_qlb">Doni</persName>, <bibl ref="#ed_s4h_t1b_5lb">Annotaz. p. 6</bibl>.
           </note>
           stehet in den Gedancken: <hi rendition="#b">Daß es mit den Stoffen der chro-
             <lb />matischen Claviere eben so wenig, als mit der enharmonischen Ein-
@@ -597,13 +597,13 @@
 
             Jahren</date>
           eine Ehre war, dessen schämet man sich auf gewisse Art bey itzigen Zeiten.
-          <lb /><persName ref="#ed_dwf_j5x_qlb">St. Lambert</persName>
+          <lb /><persName corresp="#ed_dwf_j5x_qlb">St. Lambert</persName>
           <note n="(g)" place="foot">
             <hi rendition="#aq">
               <quote xml:id="lambert-quote" corresp="#lambert-quote-trans">
                 ...
               </quote>
-              <persName ref="#ed_dwf_j5x_qlb">St. Lambert</persName>, <bibl ref="#ed_hfr_2cl_tlb">Traité de l'Accompagn.</bibl> p. 27.
+              <persName corresp="#ed_dwf_j5x_qlb">St. Lambert</persName>, <bibl ref="#ed_hfr_2cl_tlb">Traité de l'Accompagn.</bibl> p. 27.
             </hi>
           </note>
           redet davon also:
@@ -651,7 +651,7 @@
       <div n="14">
         <head>§. 14.</head>
         <p>
-          Nachdem mir aber das <persName ref="#ed_tj3_cwx_qlb">Marcellifche</persName> <name type="musicalWork" ref="#ed_zgj_2cb_5lb">Psalm-Werck</name> unter die Hände gerathen ist,
+          Nachdem mir aber das <persName corresp="#ed_tj3_cwx_qlb">Marcellifche</persName> <name type="musicalWork" ref="#ed_zgj_2cb_5lb">Psalm-Werck</name> unter die Hände gerathen ist,
           <lb />und in dessen dritten Bande sich eine gelehrte Vorrede befindet, welche über den vorhabenden
           <lb />Punct gantz besondere Gedancken darleget, davon auch bereits in der
           <lb /><bibl ref="#ed_app_scb_5lb">Musicalischen Critick p. 126. T. II.</bibl> mit Absicht auf die <bibl ref="#ed_pnf_pcb_5lb">Organisten-Probe</bibl>, auf-
@@ -665,7 +665,7 @@
       <div n="15">
         <head>§. 15.</head>
         <p>
-          Es sind aber des <persName ref="#ed_tj3_cwx_qlb">Herrn Marcello</persName>
+          Es sind aber des <persName corresp="#ed_tj3_cwx_qlb">Herrn Marcello</persName>
           <note n="h)" place="foot">
             <quote xml:id="marcello-quote" corresp="marcello-quote-trans">
               Affine che crescano alcune corde d'un intero tuono, dove non sieno obligati gli
@@ -725,7 +725,7 @@
       <div n="16">
         <lb /><head>§. 16</head>
         <p>
-          Wir sehen hieraus, daß der grosse <persName ref="#ed_tj3_cwx_qlb">Marcell</persName> sehr übel auf das x zu sprechen ist, u. ein
+          Wir sehen hieraus, daß der grosse <persName corresp="#ed_tj3_cwx_qlb">Marcell</persName> sehr übel auf das x zu sprechen ist, u. ein
           <lb />solches Stücklein der Semeiographie (Notenschreiberey) so weitläufttig zu behandeln,
           <lb />für nicht unwürdig geachtet habe. Er nennet diejenige unbedachtsam, eigensinnig,
           <lb />u.s.w. die sich des Zeichens in diesem Fall gebrauchen; er sagt: es sey eine Licentz, ein
@@ -734,7 +734,7 @@
           <lb />sollte, und will es lediglich auf des Lesers Urtheil ankommen lassen; ob es gleich
           <lb />nichts unerhörtes wäre, ein altes Zeichen in einer neuen Deutung zu gebrauchen.
           <lb />Wir haben <abbr>z. E.</abbr> das Doppel-Kreutz, oder die chromatische Diesin #: von der-
-          <lb />selben meynet <persName ref="#ed_jlh_wvy_qlb">Zarlinus</persName>,
+          <lb />selben meynet <persName corresp="#ed_jlh_wvy_qlb">Zarlinus</persName>,
           <note n="(i)" place="foot">
             <hi rendition="#i">Zarlin. Vol. I. pag. 169.</hi>
           </note>
@@ -795,7 +795,7 @@
           <lb />wircklich Verwirrung, wie ich solches insonderheit bey unparteyischen Schülern selbst
           <lb />offt mit Verdruß erfahren habe. Alles demnach, was einen Irrthum und Ver-
           <lb />druß verursachen kann, das soll und muß abgeschaffet werden. So lautet
-          <lb />in <persName ref="#ed_scp_svx_qlb">Printzens</persName> <bibl ref="#ed_pmp_1hl_tlb">Satyr. Componisten</bibl>, Part. II. Cap. VI, das zweite Axioma; und das
+          <lb />in <persName corresp="#ed_scp_svx_qlb">Printzens</persName> <bibl ref="#ed_pmp_1hl_tlb">Satyr. Componisten</bibl>, Part. II. Cap. VI, das zweite Axioma; und das
           <lb />vierte, welches auch hieher gehöret, ist so eingerichtet: Ein jedes Zeichen soll
           <lb />von dem andern unterschieden seyn; das ist, es soll nicht zwey oder mehr
           <lb />Dinge, sondern nur ein Ding andeuten.
@@ -855,8 +855,8 @@
                 <lb />ton celle que le dieze aura haussé.
               </foreign>
             </quote>
-            <persName ref="#ed_ewy_kxy_qlb">Brossard</persName> dans son <bibl ref="#ed_wh3_j5b_5lb">Diction. de Mus.</bibl>.
-            Voy. aussi <persName ref="#ed_xbw_55b_5lb">Roussau</persName>, dans sa <bibl ref="#ed_dyl_r5b_5lb">Methode pour chanter</bibl>, p. 77.
+            <persName corresp="#ed_ewy_kxy_qlb">Brossard</persName> dans son <bibl ref="#ed_wh3_j5b_5lb">Diction. de Mus.</bibl>.
+            Voy. aussi <persName corresp="#ed_xbw_55b_5lb">Roussau</persName>, dans sa <bibl ref="#ed_dyl_r5b_5lb">Methode pour chanter</bibl>, p. 77.
           </note>
           Verfasser also:
           <quote type="translation" xml:id="brossard-translation" corresp="#brossard-quote">
@@ -874,14 +874,14 @@
         <lb /><head>§. 21.</head>
         <lb /><p>
           Ich kehre wieder zum Vorhaben, wegen der Kreutze, und bemerke, daß
-          <lb /><persName ref="#ed_dwf_j5x_qlb">Msr. St. Lambert</persName> noch eine andere Erfindung hat, da er nemlich, vorne auf
+          <lb /><persName corresp="#ed_dwf_j5x_qlb">Msr. St. Lambert</persName> noch eine andere Erfindung hat, da er nemlich, vorne auf
           <fw place="bottom" type="catch">den</fw>
           <pb n="456" />
 
           <lb/>den Linien, gleich das eine ♯, von dem andern auf derselben Stelle befindlichen,
           <lb/>mittelst eines Durschnitts, abscheidet und trennet. Mit dem ♭ hat er auch eine sol-
           <lb/>che Verdoppelung, und es kann die Sache in Erwegung gezogen werden. Seine
-          <lb/>Sätze, bey welchen er sich ebenfalls des einfachen Kreutzes, wieder den <persName ref="#ed_tj3_cwx_qlb">Marcellischen</persName>
+          <lb/>Sätze, bey welchen er sich ebenfalls des einfachen Kreutzes, wieder den <persName corresp="#ed_tj3_cwx_qlb">Marcellischen</persName>
           <lb/>Sinn, bedienet, sehen <abbr>Z.E.</abbr> so aus:
 
           <figure type="notatedMusic"></figure>
@@ -952,7 +952,7 @@
                   Quod si forte erunt, qui has minutias contemnendas judicauerint, illi sciant, nihil
                   minutum aut leue esse, quod cum juuentutis commodo cunjunctum est.
                 </quote>
-                <hi rendition="#i"><persName ref="#ed_fwn_dvb_5lb">Mor-
+                <hi rendition="#i"><persName corresp="#ed_fwn_dvb_5lb">Mor-
                 <lb/>hof</persName>. <bibl ref="#ed_m4n_mvb_5lb">Polyhist. Tom. I. Libr. 2. cap. 13.</bibl></hi>
               </foreign>
             </hi>
@@ -965,7 +965,7 @@
             <lb/>theil der Jugend verbunden und verknüpfet ist.</hi>
           </quote>
           Zudem finde ich im
-          <lb/><persName ref="#ed_scp_svx_qlb">Printzen</persName>
+          <lb/><persName corresp="#ed_scp_svx_qlb">Printzen</persName>
           <note place="foot" n="b)">
             <hi rendition="#b"><bibl ref="#ed_pmp_1hl_tlb">Satyr. Componist</bibl></hi>, <hi rendition="#i">Part. II. cap. 19. §. 15.</hi>
           </note>
@@ -1004,7 +1004,7 @@
 
           <lb/>bekannt, daß ein kleiner Ton mehr, als acht, und weniger als neun Theilgen, inglei-
           <lb/>chen, daß ein kleiner halber Ton mehr, als drey, und weniger als vier haben sollen,
-          <lb/>davon <hi rendition="#b"><persName ref="#ed_jlh_wvy_qlb">Zarlin</persName></hi> und <hi rendition="#b"><persName ref="#ed_j5y_1xy_qlb">Boethius</persName></hi>
+          <lb/>davon <hi rendition="#b"><persName corresp="#ed_jlh_wvy_qlb">Zarlin</persName></hi> und <hi rendition="#b"><persName corresp="#ed_j5y_1xy_qlb">Boethius</persName></hi>
           <note place="foot" n="d)">
             <hi rendition="#i"><bibl>Zarl. Vol. I. pag. 169.</bibl> <bibl>Boet. Libr. III. 14 &amp; 15.</bibl></hi>
           </note>
@@ -1028,8 +1028,8 @@
           <lb/>Kunst erfordern; aber noch grössere, richtig und rein darauf zu spielen. Ich se-
           <lb/>tze diese Muthmassungen deswegen hieher, weil es wol seyn kann, daß derjenige,
           <lb/>von dem der Bericht des Engeländischen Ertz-Claviers herkömmt, chromatische
-          <lb/>genennet, und commatische gemeynet habe. <persName ref="#ed_u1q_mlx_qlb">Werckmeister</persName> bestimmet, in seiner
-          <lb/><bibl ref="#ed_dbx_tvb_5lb">Temperatur</bibl>, zwantzig Theilgen; <persName ref="#ed_g1w_hxy_qlb">Neidhardt</persName> aber sechs mehr zu einer Octave,
+          <lb/>genennet, und commatische gemeynet habe. <persName corresp="#ed_u1q_mlx_qlb">Werckmeister</persName> bestimmet, in seiner
+          <lb/><bibl ref="#ed_dbx_tvb_5lb">Temperatur</bibl>, zwantzig Theilgen; <persName corresp="#ed_g1w_hxy_qlb">Neidhardt</persName> aber sechs mehr zu einer Octave,
           <lb/>welches im gantzen Clavier, nach der ersten Art 80, und nach der andern 104. Ta-
           <lb/>sten betragen, einfolglich der obigen commatischen Eintheilung sehr nahe treten
           <lb/>würde. Wir behelffen uns inzwischen noch mit 48 Tangenten, in vier Octaven,
@@ -1040,12 +1040,12 @@
       <div n="26">
         <lb/><head>§. 26.</head>
         <p>
-          <lb/><hi rendition="#b"><persName ref="#ed_jlh_wvy_qlb">Zarlin</persName></hi>
+          <lb/><hi rendition="#b"><persName corresp="#ed_jlh_wvy_qlb">Zarlin</persName></hi>
           <note place="foot" n="*)">
             Siehe was unsere Vorbereitung p. 4. und das <bibl ref="#ed_vtr_vzb_5lb">Gelehrte Lexicon</bibl> p. 1602. von diesem Mann
             <lb/>sagen. Er war Capellmeister der <placeName>Republick Venedig</placeName>.
           </note>
-          und <hi rendition="#b"><persName ref="#ed_rpk_l2y_qlb">Salin</persName></hi>, zween der besten musicalischen Scribenten, hiel-
+          und <hi rendition="#b"><persName corresp="#ed_rpk_l2y_qlb">Salin</persName></hi>, zween der besten musicalischen Scribenten, hiel-
           <lb/>ten nicht gar viel von dergleichen zerhackten Clavieren, die man in so schrecklich
           <fw type="catch" place="bottom">kleine</fw>
           <pb n="460"/>
@@ -1057,7 +1057,7 @@
           ein so genannte <hi rendition="#aq">Grauecembalum</hi> vor-
           <lb/>stellig macht und abmahlet, daß er sich Anno <hi rendition="#aq"><date when="1548">1548.</date></hi> zu
           <placeName>Venedig</placeName>, von Meister
-          <lb/><hi rendition="#aq"><persName ref="#ed_mcb_nwb_5lb">Domenico Pesarese</persName></hi>,
+          <lb/><hi rendition="#aq"><persName corresp="#ed_mcb_nwb_5lb">Domenico Pesarese</persName></hi>,
           verfertigen lassen, und vermuthlich nicht so wol zum Spie-
           <lb/>len, als an Statt eines Probier-Steins (wie seine Worte lauten), gebraucht hat.
           <lb/>Es enthälgt dasselbige zwo Octaven, deren jede in 20. Tasten, oder Griff-Schlüs-
@@ -1077,19 +1077,19 @@
        <div n="27">
          <lb/><head>§. 27.</head>
          <p>
-           <lb/><hi rendition="#b"><persName ref="#ed_rpk_l2y_qlb">Salin</persName></hi>, wenn er von dem enharmonischen Geschlecht
+           <lb/><hi rendition="#b"><persName corresp="#ed_rpk_l2y_qlb">Salin</persName></hi>, wenn er von dem enharmonischen Geschlecht
            <note place="foot" n="f)">
              <bibl ref="#ed_h4c_wwb_5lb">de Mus. Libr. III.</bibl> cap. 8. pag. 127. 127.
            </note>
            handelt, auch
            <lb/>Messen, Motetten und Madrigalen anführet, die in solchem Geschlecht wircklich,
-           <lb/>und besondern von <hi rendition="#i"><persName ref="#ed_zt2_z1f_5lb">Joanne Montoni</persName></hi> gesetzt worden sind, gibt uns zu verstehen,
+           <lb/>und besondern von <hi rendition="#i"><persName corresp="#ed_zt2_z1f_5lb">Joanne Montoni</persName></hi> gesetzt worden sind, gibt uns zu verstehen,
            <lb/>er habe solche enharmonisch-theilte Jnstrumente zu <placeName>Florenz</placeName> gesehen und gehöret;
            <lb/>das aller vollkomenste aber solcher Art, bey sich zu <placeName>Salamanca</placeName>, welches in
            <lb/><placeName>Rom</placeName> gemacht, und auf welchem alle drey Geschlechter mit Fleiß vor Augen gele-
            <lb/>get worden. Vom Spielen sagt er kein Wort, gibt auch keinen Abriß noch fernere
-           <lb/>Beschreibung dieses Jnstruments: daß man also nicht weiß, ob es mit dem <persName ref="#ed_jlh_wvy_qlb">Zarli-
-           <lb/>nischen</persName> einerley, oder von demselben noch unterschieden sey. Des <persName ref="#ed_rpk_l2y_qlb">Salins</persName> Mey-
+           <lb/>Beschreibung dieses Jnstruments: daß man also nicht weiß, ob es mit dem <persName corresp="#ed_jlh_wvy_qlb">Zarli-
+           <lb/>nischen</persName> einerley, oder von demselben noch unterschieden sey. Des <persName corresp="#ed_rpk_l2y_qlb">Salins</persName> Mey-
            <lb/>nung geht sonst dahin,
            <note place="foot" n="g)">
              <abbr>Vid.</abbr> <abbr>ej.</abbr> <bibl ref="#ed_h4c_wwb_5lb">Lib. III. de Mus. cap. 27. pag. 166. circa med.</bibl>
@@ -1123,7 +1123,7 @@
 
            <lb/>findet auch noch hin und wieder diese Einrichtung in alten Orgel-Wercken, <abbr>Z.E.</abbr>
            <lb/>hier, in <placeName>Hamburg</placeName> in der <placeName>Marien-Magdalenen-Kirche</placeName>. Wobey denn anzumercken
-           <lb/>ist, daß erwehnter <hi rendition="#b"><persName ref="#ed_rpk_l2y_qlb">Salin</persName></hi>, der zuerst dergleichen Eintheilung verordnet hat, in
+           <lb/>ist, daß erwehnter <hi rendition="#b"><persName corresp="#ed_rpk_l2y_qlb">Salin</persName></hi>, der zuerst dergleichen Eintheilung verordnet hat, in
            <lb/>Spanien, auf der <orgName>hohen Schule zu <placeName>Salamanca</placeName></orgName>, Professor der Music, und Abt
            <lb/>zu <placeName>St. Pancratz</placeName> gewesen ist; daß er, ungeachtet des im <date>zehnten Jahr seines Alters</date>
            <lb/>verlohrenen Gesichts, eine ausnehmende Gelehrsamkeit besessen; daß er ein herrli-
@@ -1151,31 +1151,31 @@
           </note>
           Griff-Taffeln gehalten haben:
           <lb/>ungeachtet es das Ansehen gewinnet, als hätten sie die rechte Temperatur noch nicht
-          <lb/>getroffen. <hi rendition="#b"><persName ref="#ed_rpk_l2y_qlb">Salin</persName></hi> hatte dreierley Wege, sein Comma zu theilen, dabey denn hal-
-          <lb/>be, dritten, viertel und siebtel herhalten musten. <hi rendition="#b"><persName ref="#ed_jlh_wvy_qlb">Zarlin</persName></hi> aber blieb bei den sieben Theilgen
+          <lb/>getroffen. <hi rendition="#b"><persName corresp="#ed_rpk_l2y_qlb">Salin</persName></hi> hatte dreierley Wege, sein Comma zu theilen, dabey denn hal-
+          <lb/>be, dritten, viertel und siebtel herhalten musten. <hi rendition="#b"><persName corresp="#ed_jlh_wvy_qlb">Zarlin</persName></hi> aber blieb bei den sieben Theilgen
           <lb/>allein, nach Maßgebung der sieben diatonischen Stuffen. Jeder hat seine Ursachen,
-          <lb/>und werden insonderheit die Jrrthüber des <hi rendition="#b"><persName ref="#ed_c1l_mhy_qlb">Glareans</persName></hi>,
-          des <persName ref="#ed_o3z_5hy_qlb">Ludwig <hi rendition="#b">Follians</hi></persName>, ei-
+          <lb/>und werden insonderheit die Jrrthüber des <hi rendition="#b"><persName corresp="#ed_c1l_mhy_qlb">Glareans</persName></hi>,
+          des <persName corresp="#ed_o3z_5hy_qlb">Ludwig <hi rendition="#b">Follians</hi></persName>, ei-
           <lb/>nes <placeName>Modenischen</placeName> Musici,
           <note place="foot" n="(*)">
             Er hat <hi rendition="#aq"><bibl ref="#ed_ihc_fxb_5lb">Musicam theoricam</bibl></hi> geschrieben, welche <date>1529.</date> zu <placeName>Venedig</placeName>
             in <hi rendition="#aq">Folio</hi> gedruckt worden.
           </note>
-          und so gar zehn bis zwölff Fehler des <hi rendition="#b"><persName ref="#ed_jlh_wvy_qlb">Zarlins</persName></hi> vom
-          <lb/><hi rendition="#b"><persName ref="#ed_rpk_l2y_qlb">Salin</persName></hi>
+          und so gar zehn bis zwölff Fehler des <hi rendition="#b"><persName corresp="#ed_jlh_wvy_qlb">Zarlins</persName></hi> vom
+          <lb/><hi rendition="#b"><persName corresp="#ed_rpk_l2y_qlb">Salin</persName></hi>
           <note place="foot" n="(l)">
             <hi rendition="#aq">Salin <bibl ref="#ed_h4c_wwb_5lb">de Mus. p. 228-232, <aabr>sqq.</aabr></bibl></hi>
           </note>
-          <hi rendition="#b"><persName ref="#ed_ghv_kvx_qlb">Doni</persName></hi>
+          <hi rendition="#b"><persName corresp="#ed_ghv_kvx_qlb">Doni</persName></hi>
           <note place="foot" n="(m)">
             <bibl ref="#ed_s4h_t1b_5lb">Annotaz. p. 11.</bibl>
           </note>
-          sagt: Es habe <hi rendition="#b"><persName ref="#ed_jlh_wvy_qlb">Zarlin</persName></hi> von der Form und
+          sagt: Es habe <hi rendition="#b"><persName corresp="#ed_jlh_wvy_qlb">Zarlin</persName></hi> von der Form und
           <lb/>von dem rechgten Wesen der Tone gar keine Wissenschaft gehabt. Das mögte
           <lb/>mancher Wunder nehmen; und kann doch eben so wahr seyn, als daß heutiges Ta-
           <lb/>ges die zwölfftel vom Commate, welche, nach Anlaß der zwölff chromatischen Stuf-
           <lb/>fen, cdie Sache ins feine bringen sollen, gleichfalls ihre Gegensprecher finden. Wie
-          <lb/>denn der offt gedachte <persName ref="#ed_rtv_wrx_qlb">Henfling</persName>
+          <lb/>denn der offt gedachte <persName corresp="#ed_rtv_wrx_qlb">Henfling</persName>
           <note place="foot" n="(n)">
             <hi rendition="#aq">
               <foreign xml:lang="lat">
@@ -1201,12 +1201,12 @@
       <div n="29">
         <lb/><head>§. 29.</head>
         <p>
-          <lb/><hi rendition="#b"><persName ref="#ed_rpk_l2y_qlb">Salin</persName></hi> schreibet sonst im dritten Buche seiner Music ein gantzes Capitel
+          <lb/><hi rendition="#b"><persName corresp="#ed_rpk_l2y_qlb">Salin</persName></hi> schreibet sonst im dritten Buche seiner Music ein gantzes Capitel
           <note n="(o)" place="foot">
             <lb/>Es ist das sieben und zwantzigste Capitel des dritten Buchs, mit dieser Uberschrifft: <hi rendition="#aq">De prava
             <lb/>constitutione cujusdam Instrumenti, quod in Italia circa quadraginta annos fabicari
             <lb/>coeptum est, in quo reperitur omnis tonus in partes quinque divisus.</hi> Der grosse halbe
-            <lb/>Ton hat drey, und der kleine zwo Tasten. <hi rendition="#b"><persName ref="#ed_rtv_wrx_qlb">Henfling</persName></hi>
+            <lb/>Ton hat drey, und der kleine zwo Tasten. <hi rendition="#b"><persName corresp="#ed_rtv_wrx_qlb">Henfling</persName></hi>
             giebt zwar dem kleinen Ton fünff Theilgen,
             und der gantzen Octave 38, welche er abermahl in 81 kleine Abschnitte, oder Commata zerglie-
             <lb/>dert; allein er setzt ausdrücklich dabey, man könne solche Einrichtung auf keinem Jnstrument
@@ -1217,11 +1217,11 @@
           <lb/>die Erfindung eines Jnstruments, das die Octave in 31. Theile zerleget, und wieder-
           <lb/>spricht ihr mit guten Gründen. Nach ihm hat <hi rendition="#b"><persName ref="http://d-nb.info/gnd/118581201">Mersenn</persName></hi>
           auch darüber seine Gedan-
-          <lb/>cken eröffnet, und eben so wenig als <hi rendition="#b"><persName ref="#ed_rpk_l2y_qlb">Salin</persName></hi>, davon gehalten. Das Jnstrument hat man
+          <lb/>cken eröffnet, und eben so wenig als <hi rendition="#b"><persName corresp="#ed_rpk_l2y_qlb">Salin</persName></hi>, davon gehalten. Das Jnstrument hat man
           <lb/><hi rendition="#aq">Archicymbalum</hi>, das ist: ein Ertzcymbel-Werck, geheissen, und des Erfinders Nahme
-          <lb/>ist unbekannt. <persName ref="#ed_c22_mgy_qlb">Christian <hi rendition="#b">Huygens</hi></persName> glaubet zwar, daß sich beide,
-          <hi rendition="#b"><persName ref="#ed_rpk_l2y_qlb">Salin</persName></hi> und
-          <lb/><hi rendition="#b"><persName ref="#ed_kyg_jgy_qlb">Mersenn</persName></hi> betrogen haben; er aber allein auf dem rechten Wege sey, und die 31.
+          <lb/>ist unbekannt. <persName corresp="#ed_c22_mgy_qlb">Christian <hi rendition="#b">Huygens</hi></persName> glaubet zwar, daß sich beide,
+          <hi rendition="#b"><persName corresp="#ed_rpk_l2y_qlb">Salin</persName></hi> und
+          <lb/><hi rendition="#b"><persName corresp="#ed_kyg_jgy_qlb">Mersenn</persName></hi> betrogen haben; er aber allein auf dem rechten Wege sey, und die 31.
           <lb/>gleiche Theile der Octave nicht nur vor Augen legen,
           <note n="(p)" place="foot">
             <hi rendition="#aq">
@@ -1245,7 +1245,7 @@
         <p>
           <lb/>Denn, wenn man auch
           <note place="foot" n="(q)">
-            <persName ref="#ed_u1q_mlx_qlb">Werckmeister</persName> p. 70. seiner Temperatur.
+            <persName corresp="#ed_u1q_mlx_qlb">Werckmeister</persName> p. 70. seiner Temperatur.
             <persName>P. de Thyard</persName> de la Mus. p. 8. 9.
           </note>
           hundert oder tausend so genannte Subsemitone in
@@ -1263,7 +1263,7 @@
             <lb/>bannen und verwerffen, zumahl es nicht anders seyn kann.
           </hi>
           Der Hr.
-          <lb/><persName ref="#ed_g1w_hxy_qlb">Neidhardt</persName> gibt es
+          <lb/><persName corresp="#ed_g1w_hxy_qlb">Neidhardt</persName> gibt es
           <note n="(r)" place="foot">
             Jn seiner <bibl ref="#ed_jjz_syb_5lb">besten und leichtesten Temperatur. p. 27.</bibl>
           </note>
@@ -1295,7 +1295,7 @@
           <lb/>zierlich angebracht werden. Jch will es aber, wie durchgehends alle solche Auszierungen und Schmü-
           <lb/>ckungen, nicht als ein nothwendig erfordertes Stück bey einem gewöhnlichen General-Baß, sondern als
           <lb/>eine beliebte und artige Zugabe bey der Probe, bey der Uebung, und bey ersehener Gelgenheit, betrachtet
-          <lb/>haben, weil ich völlig in diesem Stück mit <persName ref="#ed_dwf_j5x_qlb">St. Lambert</persName> übereinstimme, da er sich also heraus lässt:
+          <lb/>haben, weil ich völlig in diesem Stück mit <persName corresp="#ed_dwf_j5x_qlb">St. Lambert</persName> übereinstimme, da er sich also heraus lässt:
           <quote type="translation">
             <lb/>Wenn die Bässe nicht mit vielen Noten überhäuffet sind, sondern, nach des Spielers Sinn, gar zu sehr
             <lb/>schleppen und zögern, mag er wol andre Noten hinzu thun, und mehr Figuren hervor bringen; da-

--- a/encodings/24/mattheson/comments_de.xml
+++ b/encodings/24/mattheson/comments_de.xml
@@ -7,16 +7,16 @@
         <title type="part">Mattheson: Der Ober-Classe vierundzwantzigstes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/3/hill/comments_en.xml
+++ b/encodings/3/hill/comments_en.xml
@@ -6,16 +6,16 @@
         <title type="part">Lesson by R. Hill on Probstück 3</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/3/mattheson/comments_1st.xml
+++ b/encodings/3/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Drittes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/3/mattheson/comments_de.xml
+++ b/encodings/3/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Drittes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/3/mattheson/comments_merged.xml
+++ b/encodings/3/mattheson/comments_merged.xml
@@ -6,22 +6,22 @@
                 <title type="part">Mattheson: Der Ober-Classe Drittes Probstück</title>
                 <editor>
                     <persName xml:id="pfeffer">
-                        <forename>Niels</forename>
                         <surname>Pfeffer</surname>
+                        <forename>Niels</forename>
                     </persName>
                 </editor>
                 <editor>
                     <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-                        <forename>Klaus</forename>
                         <surname>Rettinghaus</surname>
+                        <forename>Klaus</forename>
                     </persName>
                 </editor>
             </titleStmt>
             <publicationStmt>
                 <publisher>
                     <persName>
-                        <forename>Niels</forename>
                         <surname>Pfeffer</surname>
+                        <forename>Niels</forename>
                     </persName>
                 </publisher>
                 <availability>

--- a/encodings/4/hill/comments_de.xml
+++ b/encodings/4/hill/comments_de.xml
@@ -6,16 +6,16 @@
         <title type="part">Lesson by R. Hill on Probstück 4</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/4/hill/comments_de.xml
+++ b/encodings/4/hill/comments_de.xml
@@ -269,7 +269,7 @@
 
       <u who="#rh">
         Kennst du das Prelude der aus B-Dur-Suite von
-          <persName ref="#ed_lhv_3sx_qlb">Händel</persName>?
+          <persName corresp="#ed_lhv_3sx_qlb">Händel</persName>?
       </u>
 
       <incident who="#rh">

--- a/encodings/4/mattheson/comments_1st.xml
+++ b/encodings/4/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe viertes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/4/mattheson/comments_de.xml
+++ b/encodings/4/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Viertes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/4/mattheson/comments_en.xml
+++ b/encodings/4/mattheson/comments_en.xml
@@ -6,16 +6,16 @@
         <title type="part">Mattheson: Der Ober-Classe viertes Probstück (english translation)</title>
         <editor role="translator">
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/5/mattheson/comments_1st.xml
+++ b/encodings/5/mattheson/comments_1st.xml
@@ -89,7 +89,7 @@
       <div>
         <p>
           <hi rendition="#aq"><abbr>Vid.</abbr></hi>
-          <hi rendition="#b"><persName ref="#ed_fy5_r5x_qlb">Keiſers</persName></hi>
+          <hi rendition="#b"><persName corresp="#ed_fy5_r5x_qlb">Keiſers</persName></hi>
           <name type="musicalWork" ref="#ed_vsj_4rx_slb">Land-Luſt</name>
           p. 21. wenn jemand etwann ſonſt um ein Stück aus dem
           <lb/><hi rendition="#aq">C dur</hi> verlegen wäre, das ich doch nicht

--- a/encodings/5/mattheson/comments_1st.xml
+++ b/encodings/5/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Fünftes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/5/mattheson/comments_de.xml
+++ b/encodings/5/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Fünftes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/5/mattheson/comments_de.xml
+++ b/encodings/5/mattheson/comments_de.xml
@@ -199,7 +199,7 @@
           <lb/>dern jeder General-Baſſiſt, ja jeder Jnstrumentaliſt, inne haben, und wenn ſein
           <lb/>Hals gleich nichts nutzet, ſo muͤſſen doch ſeine ſingenden Gedancken den Fingern
           <lb/>ihren Befehl ertheilen; ſonſt ist alles hoͤltzern und todt. Es wuſſte dieſes schon
-          <persName ref="#ed_u2g_xgy_qlb">D.
+          <persName corresp="#ed_u2g_xgy_qlb">D.
           <lb/>Lippius</persName>
           <note place="foot" n="*)">
             <hi rendition="#aq">

--- a/encodings/5/mattheson/comments_en.xml
+++ b/encodings/5/mattheson/comments_en.xml
@@ -86,7 +86,7 @@
             It is given only to fewest; but not only every composer,
             but every thorough-bass player, infact every instrumentalist, has to know the art of singing, and if his throat is of no use,
             at least his singing thoughts have to give the fingers their order, otherwise all is wooden and dead.
-            Already <persName ref="#ed_u2g_xgy_qlb">Lippius</persName>
+            Already <persName corresp="#ed_u2g_xgy_qlb">Lippius</persName>
             knew to say that: <hi rendition="#b">That an instrumentalist is the more perfect, the more he turns to the art of singing.</hi>.
           </p>
         </div>

--- a/encodings/6/mattheson/comments_1st.xml
+++ b/encodings/6/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Sechstes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/6/mattheson/comments_1st.xml
+++ b/encodings/6/mattheson/comments_1st.xml
@@ -95,7 +95,7 @@
           die Probe anstellen will, der lasse diese Erlaͤuterung so lange zuruͤck bleiben, bis er mercket, ob sein <hi rendition="#aq">Candidat</hi>
           das rechte Fleckgen getroffen habe oder, nicht. Hat ers; <hi rendition="#aq">plaudite</hi>! Verfehlt ers; so wird ers muͤssen
           geben lassen, und sich nach eingenommenem Unterricht weidloch wundern, daß er den Lunten nicht selber riechen koͤnnen.
-          Mancher wird eben so eine Nase auffwerffen, als <hi rendition="#aq"><persName ref="#ed_lvw_2xx_qlb">Lutheri</persName></hi> Gesellschaft, wie er ihr das Ey stehend
+          Mancher wird eben so eine Nase auffwerffen, als <hi rendition="#aq"><persName corresp="#ed_lvw_2xx_qlb">Lutheri</persName></hi> Gesellschaft, wie er ihr das Ey stehend
           machte, und sagten: O! ist es nichts anders als das? ich dachte Wunder, was es seyn wuͤrde. Mit solchen Anweisungen gemahnet
           michs fast eben, wie mit Artzneyen, die mansehnlich verlanget, und wenn sie geholffen, gerne wissen
           wolte, woraus sie besanden. Erfaͤhret man denn, daß es lauter <hi rendition="#aq">ordinaire Ingredientien</hi> gewesen, so verliehret man
@@ -134,7 +134,7 @@
           dessen zweyen Viertel-Pausen?</ref> Ja, was zu den <ref target="#m-1265">folgenden</ref>
           fuͤnff oder sechs Taͤcten? Nimm dirs aus den vorhergehenden, jedoch
           dißmahl nicht Note vor Note; stolpere auch nicht, ich rathe dirs.
-          Du siehest wohl, daß in den neun Taͤcten, die ich (<hi rendition="#aq"><persName ref="#ed_wpd_2lx_qlb">Apollo</persName></hi> verzeih's
+          Du siehest wohl, daß in den neun Taͤcten, die ich (<hi rendition="#aq"><persName corresp="#ed_wpd_2lx_qlb">Apollo</persName></hi> verzeih's
           mir) bunt genennet, <ref target="#m-1110">nach dem sechsten Tact</ref> die <hi rendition="#aq"><foreign xml:lang="fra">Passage</foreign></hi> sich etwas
           weniges umkehret; solches wird <hi rendition="#aq"><foreign xml:lang="fra">mon Maitre</foreign></hi>
           auch belieben zu <hi rendition="#aq"><foreign xml:lang="lat">imitir</foreign></hi>en, wenn er an

--- a/encodings/6/mattheson/comments_de.xml
+++ b/encodings/6/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Sechstes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/6/mattheson/comments_de.xml
+++ b/encodings/6/mattheson/comments_de.xml
@@ -116,7 +116,7 @@
             <lb/>Gluͤck. Verfehlt ers; ſo wird ers muͤſſen geben laſſen, und ſich nach ein-
             <lb/>genommenem Unterricht weidlich wundern, daß er den Lunten nicht ſelber riechen
             <lb/>koͤnnen. Mancher wird hiebey eben ſo eine Nase auffwerffen, als
-            <hi rendition="#b"><persName ref="#ed_lvw_2xx_qlb">Luthers</persName></hi> Ge-
+            <hi rendition="#b"><persName corresp="#ed_lvw_2xx_qlb">Luthers</persName></hi> Ge-
             <lb/>sellschafft, wie er ihr das Ey ſtehend machte, und ſagen: <hi rendition="#b">O!</hi> iſt es nichts an-
             <lb/>ders als das? ich dachte Wunder, was es ſeyn wuͤrde. Mit ſolchen Anwei-
             <lb/>ſungen gemahnet michs faſt eben, wie mit Artzneyen, die man ſehnlich verlan-
@@ -220,7 +220,7 @@
             fuͤnff oder ſechs Taͤcten? Nimm dirs
             <lb/>aus dem vorhergehenden, jedoch dißmahl nicht Note vor Note; ſtolpere auch
             <lb/>nicht, ich rathe dirs. Du ſieheſt wohl, daß in den neun biß zehn Taͤcten, die ich
-            <lb/>(<hi rendition="#b"><persName ref="#ed_wpd_2lx_qlb">Apollo</persName></hi> verzeih
+            <lb/>(<hi rendition="#b"><persName corresp="#ed_wpd_2lx_qlb">Apollo</persName></hi> verzeih
             mirs) bunt genennet habe, <ref target="#m-1110">nach dem ſechſten Tact</ref> die Gaͤn-
             <lb/>ge ſich etwas weniges umkehren; solches wird man auch belieben nachzuma-
             <lb/>chen, wenn er an

--- a/encodings/6/mattheson/comments_en.xml
+++ b/encodings/6/mattheson/comments_en.xml
@@ -25,7 +25,7 @@
           to play the present piece according to this instruction or if everything has to be given down to the last detail.
           Whoever wants to do the test, shall put away these remarks until he sees, whether his candidate has hit the
           right spot or not. He hits it - applause! He misses it – they have to be given to him, and after having taken the lesson
-          he will be thoroughly surprised, that he did not smell the rat. Someone will turn up their noses just as <persName ref="#ed_lvw_2xx_qlb">Luther's</persName> society,
+          he will be thoroughly surprised, that he did not smell the rat. Someone will turn up their noses just as <persName corresp="#ed_lvw_2xx_qlb">Luther's</persName> society,
           when he raised their "Well!", and they will say: Oh! Is it nothing else than that? I thought it were wonders. Those instructions
           almost remind me of medicine, which one ardently demands, and when it has helped, one would like to know, of what
           it consists. As one hears that in it were nothing but ordinary ingredients, one loses the respect for the medicine, regardless
@@ -98,7 +98,7 @@
           But on with the text. What do you play on the
           <ref target="#m-1245"><hi rendition="#b">d</hi> and its two crotchet breaks</ref>? And what in the <ref target="#m-1265">following</ref> five
           or six bars? Take it from the previous music, but this time not note-for-note. But do not stumble, I advise you.
-          You see, that in the nine bars, that I (<persName ref="#ed_wpd_2lx_qlb">Apollo</persName> shall forgive me) have called colourful, <ref target="#m-1110">after the sixth
+          You see, that in the nine bars, that I (<persName corresp="#ed_wpd_2lx_qlb">Apollo</persName> shall forgive me) have called colourful, <ref target="#m-1110">after the sixth
           measure</ref> the passage is changed a little. This one should like to imitate, when reaching the
           <ref target="#m-1310">fifth measure</ref> of the so-called plain notes. If one is able to play the twelve last bars in thirds
           and sixths in the right hand with a good proportion, it will be lauded and it can be said about him: He has done well.

--- a/encodings/7/mattheson/comments_1st.xml
+++ b/encodings/7/mattheson/comments_1st.xml
@@ -145,7 +145,7 @@
           <lb/><head>§. 3.</head>
           <lb/><p xml:id="p3-1">
             Hiebey kann ich nicht unberuͤhret laſſen, was
-            <persName ref="#ed_dwf_j5x_qlb">Monſr. von St. Lambert</persName> in ſei-
+            <persName corresp="#ed_dwf_j5x_qlb">Monſr. von St. Lambert</persName> in ſei-
             <lb/>nem <bibl xml:id="lambert-traite" xml:lang="fra" ref="#ed_hfr_2cl_tlb"><hi rendition="#aq">Traité
             <lb/>d'accompagnement</hi></bibl>, von der Geſchwindigkeit fuͤr beſonders traͤge
             <fw place="bottom" type="catch">Ge-</fw>
@@ -174,7 +174,7 @@
             <lb/>nicht bey dieſer <hi rendition="#aq">Pieçe</hi> derselben bedienen. Es koͤmmt ſonſt bald ſo heraus, als wenn
             <lb/><persName>Signor Caraffa</persName> bey geſchwinden und flüchtigen Noten im Baſſe eine <hi rendition="#aq">priſe</hi> To-
             <lb/>back mit der lincken Hand nimmt, wie uns der
-            <persName ref="#ed_zzr_hfy_qlb">Herr <hi rendition="#b">Kuhnau</hi></persName>
+            <persName corresp="#ed_zzr_hfy_qlb">Herr <hi rendition="#b">Kuhnau</hi></persName>
             deſſen <hi rendition="#aq">pag. 23</hi>
             <lb/>ſeines <bibl ref="#ed_wxz_jhl_tlb">Musſicaliſchen Quacksalbers</bibl> berichtet.
           </p>

--- a/encodings/7/mattheson/comments_1st.xml
+++ b/encodings/7/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Siebentes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/7/mattheson/comments_de.xml
+++ b/encodings/7/mattheson/comments_de.xml
@@ -156,7 +156,7 @@
           <lb/><head>§. 3.</head>
           <lb/><p xml:id="p3-1" facs="#facsZone-p3-1">
             Hiebey kann ich nicht unberuͤhret laſſen, was der
-            <persName ref="#ed_dwf_j5x_qlb">Herr von St. Lambert</persName>, in
+            <persName corresp="#ed_dwf_j5x_qlb">Herr von St. Lambert</persName>, in
             ſeinem <bibl xml:id="lambert-traite" xml:lang="fra"><hi rendition="#aq">Traité
             <lb/>d'accompagnement p. 58.</hi></bibl>, von der Geſchwindigkeit fuͤr beſonders traͤge Gedancken fuͤhret. Jch
             <lb/>will die Worte immer verteutschen:
@@ -197,7 +197,7 @@
             </note>
             Jch muß geſtehen, die Erfindung gefaͤllt mir nicht uͤbel, und ſie iſt
             <lb/>ſehr gemaͤchlich. Es koͤmmt ſonſt bald eben ſo damit heraus, als wenn,
-            im <persName ref="#ed_zzr_hfy_qlb">Kuhnau</persName>iſchen <bibl ref="#ed_wxz_jhl_tlb">Quackſal-
+            im <persName corresp="#ed_zzr_hfy_qlb">Kuhnau</persName>iſchen <bibl ref="#ed_wxz_jhl_tlb">Quackſal-
             <lb/>ber</bibl> <hi rendition="#aq">p. 23</hi>.
             <persName>Signor Caraffa</persName>
             mit der lincken Hand Schnuptoback nimmt, so offt geſchwinde oder

--- a/encodings/7/mattheson/comments_de.xml
+++ b/encodings/7/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Siebentes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/7/mattheson/comments_en.xml
+++ b/encodings/7/mattheson/comments_en.xml
@@ -54,7 +54,7 @@
       <div n="3">
         <head>§. 3.</head>
         <p>
-          I cannot leave unmentioned here, what <persName ref="#ed_dwf_j5x_qlb">St. Lambert</persName> is saying about velocity for slow minds in his
+          I cannot leave unmentioned here, what <persName corresp="#ed_dwf_j5x_qlb">St. Lambert</persName> is saying about velocity for slow minds in his
           <bibl xml:lang="fra"><hi rendition="#aq">Traité d'accompagnement p. 58.</hi></bibl>:
           When a measure appears so strong that the thorough bass player does not find the comfort to play
             all the notes, he might be satisfied with striking only the first note on every beat of the measure and
@@ -63,7 +63,7 @@
             If one wants to play them on the keyboard he may only play the principal notes, which are the ones on the
             down- and upbeat of the measure.
 
-          I have to confess, I like that invention and it is very easy-going. Soon it will result in what <persName ref="#ed_zzr_hfy_qlb">Kuhnau</persName> describes
+          I have to confess, I like that invention and it is very easy-going. Soon it will result in what <persName corresp="#ed_zzr_hfy_qlb">Kuhnau</persName> describes
           in his Quacksalber p. 23,<note type="footnote">Johann Kuhnau, Der musicalische Quack-Salber, Dresden 1700</note>
           where <persName type="fictional">Signor Carassa</persName> takes snuff with the left hand, as soon as rapid notes appear in the bass.
         </p>

--- a/encodings/8/mattheson/comments_1st.xml
+++ b/encodings/8/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Achtes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/8/mattheson/comments_1st.xml
+++ b/encodings/8/mattheson/comments_1st.xml
@@ -88,9 +88,9 @@
     <body>
       <div>
         <p>
-          <lb/><abbr>Vid.</abbr> <hi rendition="#i"><persName ref="#ed_fy5_r5x_qlb">Keiſers</persName></hi>
+          <lb/><abbr>Vid.</abbr> <hi rendition="#i"><persName corresp="#ed_fy5_r5x_qlb">Keiſers</persName></hi>
           <name type="musicalWork" ref="#ed_sbs_x2c_tlb"><abbr>Erl. Sätze</abbr> etc.</name> pag. 30 &amp; 36.
-          <lb/><hi rendition="#aq"><persName ref="#ed_dwf_j5x_qlb">Monſr. de St. Lambert</persName></hi>
+          <lb/><hi rendition="#aq"><persName corresp="#ed_dwf_j5x_qlb">Monſr. de St. Lambert</persName></hi>
           ſagt <hi rendition="#aq">pag. 27.</hi> ſeines Tractats, von diesem Ton:
 
           <quote xml:id="lambert-quote" corresp="#lambert-quote-trans">
@@ -161,7 +161,7 @@
             <pb n="143"/>
 
             auch nur eine <hi rendition="#aq"><foreign xml:lang="fra">Suite</foreign></hi> des
-            <persName ref="http://d-nb.info/gnd/118718517">Herrn Capell-Meister <hi rendition="#b"><persName ref="#ed_md2_fmx_qlb">Graupners</persName></hi>
+            <persName ref="http://d-nb.info/gnd/118718517">Herrn Capell-Meister <hi rendition="#b"><persName corresp="#ed_md2_fmx_qlb">Graupners</persName></hi>
           </persName> <name type="musicalWork" ref="#ed_bj1_myc_tlb">Clavier-Sachen</name>, oder
             <lb/>aus meinem
             <hi rendition="#b"><name type="musicalWork" ref="#ed_cx1_yqx_slb">Harmonischen Denckmahl</name></hi>

--- a/encodings/8/mattheson/comments_de.xml
+++ b/encodings/8/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Achtes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/8/mattheson/comments_de.xml
+++ b/encodings/8/mattheson/comments_de.xml
@@ -90,7 +90,7 @@
     <body>
       <div>
         <p>
-          Der oberwehnte <hi rendition="#b"><persName ref="#ed_dwf_j5x_qlb">St. Lambert</persName></hi>
+          Der oberwehnte <hi rendition="#b"><persName corresp="#ed_dwf_j5x_qlb">St. Lambert</persName></hi>
           ſagt, auf der 27ſten Seite ſeines Buchs, von
           <lb/>dieſem Ton, <hi rendition="#b">G</hi>, uͤberhaupt:
           <quote type="translation">

--- a/encodings/8/mattheson/comments_en.xml
+++ b/encodings/8/mattheson/comments_en.xml
@@ -15,8 +15,8 @@
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/8/mattheson/comments_en.xml
+++ b/encodings/8/mattheson/comments_en.xml
@@ -60,11 +60,11 @@
         <p>
           But nobody should think of this aria as a solo piece, since that would have to appear very differently. A student of art
           may compare a <hi rendition="#aq"><foreign xml:lang="fra">Suite</foreign></hi> of the Capell-Meister
-          <hi rendition="#b"><persName ref="#ed_md2_fmx_qlb">Graupner's</persName></hi> so called
+          <hi rendition="#b"><persName corresp="#ed_md2_fmx_qlb">Graupner's</persName></hi> so called
           <hi rendition="#b"><name type="musicalWork" ref="#ed_bj1_myc_tlb">Partien</name></hi> for
           keyboard or from my <hi rendition="#b"><name type="musicalWork" ref="#ed_cx1_yqx_slb">Harmonisches Denckmahl</name></hi> or the
           <hi rendition="#b"><name type="musicalWork" ref="#ed_vvh_xcd_tlb">Partite</name></hi> of the
-          <persName ref="#ed_ngx_5lx_qlb">Capell-Meister Bach</persName> and
+          <persName corresp="#ed_ngx_5lx_qlb">Capell-Meister Bach</persName> and
           he can easily tell the difference. Solo works need to be practised and whoever dares to play them ex tempore, is
           acting very foolhardily and intends to bamboozle the listener with his juggler's tricks even if he was the arch-harpsichordist
           himself. This piece is disposed so that one must play it ex tempore.

--- a/encodings/9/mattheson/comments_de.xml
+++ b/encodings/9/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Mattheson: Der Ober-Classe Neuntes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/9/mattheson/comments_de.xml
+++ b/encodings/9/mattheson/comments_de.xml
@@ -168,7 +168,7 @@
             Und dieſes mag auch genug ſeyn, fuͤr einen, der ſich gar nicht zu helffen weiß. Die was heiſſen und be-
             <lb/>deuten wollen, muͤſſen ſolche Dinge noch ſchoͤner und kuͤnſtlicher, als hier angewisen worden, augenblick-
             <lb/>lich heraus bringen; sonst ſind ſie, ob wol eben keine Stuͤmper, doch nur gantz kleine Lichter. Es gefaͤllt
-            <lb/>mir ſonderlich wol, daß der <persName ref="#ed_dwf_j5x_qlb7">Herr von St. Lambert</persName> es auch ſo gar
+            <lb/>mir ſonderlich wol, daß der <persName corresp="#ed_dwf_j5x_qlb7">Herr von St. Lambert</persName> es auch ſo gar
             gut heiſſet, wenn man eine eintzige
             <lb/>Stimme <hi rendition="#aq">accompagnirt</hi>,
             und den Haupt-Satz oder die Fugen der Arie mit allen Parteyen auf ſeinem

--- a/encodings/9/mattheson/comments_en.xml
+++ b/encodings/9/mattheson/comments_en.xml
@@ -15,8 +15,8 @@
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/9/mattheson/comments_en.xml
+++ b/encodings/9/mattheson/comments_en.xml
@@ -85,7 +85,7 @@
           Those who want to stand for something and want to be of significance, must ex tempore
           bring out such things even finer
           and more elaborate than instructed here; otherwise they are, though not particularly bunglers, yet quite
-          mediocre. I very much like that <persName ref="#ed_dwf_j5x_qlb">St. Lambert</persName>
+          mediocre. I very much like that <persName corresp="#ed_dwf_j5x_qlb">St. Lambert</persName>
           even approves to imitate the subjects or entrances
           of the arias in all parts on the keyboard when accompanying a single voice. His words are:
           <quote type="translation">
@@ -113,7 +113,7 @@
           prevales and since one easily gets weary of the sweetness, it is not bad to enliven it
           a little with a somewhat cheerful and straight movement, otherwise one gets drowsy of its softness easily.
           But if it shall be a piece that needs to promote the sleep, one can spare this remark and
-          can naturally reach the intention soon. <persName ref="#ed_knv_rsx_qlb">Kircher</persName>
+          can naturally reach the intention soon. <persName corresp="#ed_knv_rsx_qlb">Kircher</persName>
           calls this key: <foreign>accidentaliter mollem</foreign>,
           soft by chance, which is rather ridiculous. Concerning its characteristics he does not say a word.
           It would not be a bad curiosity to research, if by crass error or profound ignorance this <hi rendition="#b">tender key</hi>

--- a/encodings/9/mattheson/music-example1.xml
+++ b/encodings/9/mattheson/music-example1.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 9, Example 1</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -29,6 +29,7 @@
                     <scoreDef key.pname="c" key.mode="minor" meter.unit="4" midi.bpm="100" mnum.visible="false">
                         <staffGrp>
                             <staffDef clef.shape="C" clef.line="1" key.sig="2f" n="1" lines="5">
+                                <!-- second edition only shows e flat -->
                                 <keySig sig="2f" />
                             </staffDef>
                             <staffDef clef.shape="F" clef.line="4" n="2" lines="5">
@@ -37,7 +38,7 @@
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure n="37">
+                        <measure corresp="#m-1220">
                             <staff n="1">
                                 <layer n="1">
                                     <supplied resp="#rettinghaus">
@@ -46,7 +47,7 @@
                                     </supplied>
                                     <beam>
                                         <note dur="16" oct="5" pname="f" />
-                                        <note dur="16" oct="5" pname="e" />
+                                        <note dur="16" oct="5" pname="e" accid.ges="f" />
                                     </beam>
                                     <beam>
                                         <note dur="16" oct="5" pname="d" />
@@ -55,9 +56,11 @@
                                         <note dur="16" oct="5" pname="f" />
                                     </beam>
                                     <beam>
-                                        <note dur="16" oct="4" pname="b" />
+                                        <note dur="16" oct="4" pname="b" accid.ges="f" />
                                         <note dur="16" oct="5" pname="f" />
-                                        <note dur="16" oct="4" pname="a" accid="f" />
+                                        <note dur="16" oct="4" pname="a">
+                                            <accid accid="f" />
+                                        </note>
                                         <note dur="16" oct="5" pname="f" />
                                     </beam>
                                 </layer>
@@ -68,15 +71,39 @@
                                         <note dur="4" oct="3" pname="d" />
                                         <rest dur="8" />
                                     </supplied>
-                                    <note dur="8" oct="4" pname="d" />
-                                    <beam>
-                                        <note dur="8" oct="4" pname="d" />
-                                        <note dur="8" oct="4" pname="d" />
-                                        <note dur="8" oct="4" pname="d" />
-                                        <note dur="8" oct="4" pname="d" />
-                                    </beam>
+                                    <app>
+                                        <lem source="#secondEdition">
+                                            <note dur="8" oct="4" pname="d" />
+                                            <beam>
+                                                <note dur="8" oct="4" pname="d" />
+                                                <note dur="8" oct="4" pname="d" />
+                                                <note dur="8" oct="4" pname="d" />
+                                                <note dur="8" oct="4" pname="d" />
+                                            </beam>
+                                        </lem>
+                                        <rdg source="#firstEdition">
+                                            <note dur="8" oct="3" pname="b" accid.ges="f" />
+                                            <beam>
+                                                <note dur="8" oct="3" pname="b" accid.ges="f" />
+                                                <note dur="8" oct="3" pname="b" accid.ges="f" />
+                                                <note dur="8" oct="3" pname="b" accid.ges="f" />
+                                                <note dur="8" oct="3" pname="b" accid.ges="f" />
+                                            </beam>
+                                        </rdg>
+                                    </app>
                                 </layer>
                             </staff>
+                            <app>
+                                <lem source="#secondEdtion">
+                                </lem>
+                                <rdg source="#firstEdition">
+                                    <harm place="above" staff="2" tstamp="2.5">
+                                        <fb>
+                                            <f>♮</f>
+                                        </fb>
+                                    </harm>
+                                </rdg>
+                            </app>
                             <harm place="above" staff="2" tstamp="3">
                                 <fb>
                                     <f>8</f>
@@ -98,21 +125,19 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure n="38">
+                        <measure corresp="#m-1253">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
                                         <note dur="16" oct="4" pname="g" />
                                         <note dur="16" oct="5" pname="f" />
                                         <note dur="16" oct="5" pname="e">
-                                            <accid accid.ges="f" />
+                                            <accid accid="f" />
                                         </note>
                                         <note dur="16" oct="5" pname="d" />
                                     </beam>
                                     <beam>
-                                        <note dur="8" oct="5" pname="e">
-                                            <accid accid.ges="f" />
-                                        </note>
+                                        <note dur="8" oct="5" pname="e" accid.ges="f" />
                                         <note dur="16" oct="5" pname="g" />
                                         <note dur="16" oct="5" pname="f" />
                                     </beam>
@@ -127,9 +152,7 @@
                                     <beam>
                                         <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="5" pname="g" />
-                                        <note dur="16" oct="4" pname="b">
-                                            <accid accid.ges="f" />
-                                        </note>
+                                        <note dur="16" oct="4" pname="b" accid.ges="f" />
                                         <note dur="16" oct="5" pname="g" />
                                     </beam>
                                 </layer>
@@ -140,7 +163,7 @@
                                     <note dur="4" oct="4" pname="e">
                                         <accid accid="f" />
                                     </note>
-                                    <rest dur="8" />
+                                    <rest dur="8" oloc="4" ploc="e" />
                                     <note dur="8" oct="4" pname="e" accid.ges="f" />
                                     <beam>
                                         <note dur="8" oct="4" pname="e">
@@ -183,7 +206,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure n="39">
+                        <measure corresp="#m-1295">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
@@ -196,7 +219,9 @@
                                     </beam>
                                     <beam>
                                         <note dur="8" oct="5" pname="f" />
-                                        <note dur="16" oct="5" pname="a" />
+                                        <note dur="16" oct="5" pname="a">
+                                            <accid accid="n" oloc="5" ploc="g"/>
+                                        </note>
                                         <note dur="16" oct="5" pname="g" />
                                     </beam>
                                     <beam>
@@ -220,7 +245,7 @@
                             <staff n="2">
                                 <layer n="1">
                                     <note dur="4" oct="4" pname="f" />
-                                    <rest dur="8" />
+                                    <rest dur="8" oloc="4" ploc="e" />
                                     <note dur="8" oct="4" pname="f" />
                                     <beam>
                                         <note dur="8" oct="4" pname="f">
@@ -259,23 +284,23 @@
                             </harm>
                             <harm place="above" staff="2" tstamp="4">
                                 <fb>
-                                    <f>6♭</f>
+                                    <f>6</f>
                                 </fb>
                             </harm>
                             <harm place="above" staff="2" tstamp="4.5">
                                 <fb>
-                                    <f>5</f>
+                                    <f>♭5</f>
                                 </fb>
                             </harm>
                         </measure>
-                        <measure n="40" right="invis" metcon="false">
+                        <measure corresp="#m-1334" right="invis" metcon="false">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note dur="16" oct="4" pname="b">
-                                            <accid accid.ges="f" />
+                                        <note dur="16" oct="4" pname="b" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="a">
+                                            <accid accid="n" oloc="5" ploc="g"/>
                                         </note>
-                                        <note dur="16" oct="5" pname="a" />
                                         <note dur="16" oct="5" pname="g" />
                                         <note dur="16" oct="5" pname="f">
                                             <accid accid="s" />
@@ -287,7 +312,7 @@
                                         <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="5" pname="d" />
                                     </beam>
-                                    <custos oct="4" pname="e" />
+                                    <custos oct="5" pname="e" />
                                 </layer>
                             </staff>
                             <staff n="2">
@@ -307,6 +332,13 @@
                                     <f>8</f>
                                 </fb>
                             </harm>
+                            <supplied resp="#rettinghaus">
+                                <harm place="above" staff="2" tstamp="2.5">
+                                    <fb>
+                                        <f>6</f>
+                                    </fb>
+                                </harm>
+                            </supplied>
                         </measure>
                     </section>
                 </score>

--- a/encodings/9/mattheson/music-example2.xml
+++ b/encodings/9/mattheson/music-example2.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 9, Example 2</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -56,7 +56,7 @@
                             <staff n="2">
                                 <layer n="1">
                                     <note dur="4" oct="4" pname="c" />
-                                    <rest dur="8" />
+                                    <rest dur="8" oloc="3" ploc="a" />
                                     <note dur="8" oct="4" pname="c" />
                                 </layer>
                             </staff>
@@ -85,34 +85,32 @@
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note dur="16" oct="4" pname="a" accid="f" />
-                                        <note dur="16" oct="5" pname="e">
-                                            <accid accid.ges="f" />
+                                        <note dur="16" oct="4" pname="a">
+                                            <accid accid="f" />
                                         </note>
+                                        <note dur="16" oct="5" pname="e" accid.ges="f" />
                                         <note dur="16" oct="4" pname="g" />
-                                        <note dur="16" oct="5" pname="e">
-                                            <accid accid.ges="f" />
-                                        </note>
+                                        <note dur="16" oct="5" pname="e" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <note dur="16" oct="4" pname="a" />
-                                        <note dur="16" oct="5" pname="e">
-                                            <accid accid.ges="f" />
+                                        <note dur="16" oct="4" pname="a">
+                                            <orig>
+                                                <accid accid="f" />
+                                            </orig>
                                         </note>
+                                        <note dur="16" oct="5" pname="e" accid.ges="f" />
                                         <note dur="16" oct="4" pname="f" />
                                         <note dur="16" oct="5" pname="c" />
                                     </beam>
                                     <beam>
                                         <note dur="16" oct="5" pname="d" />
-                                        <note dur="16" oct="4" pname="b">
-                                            <accid accid.ges="f" />
-                                        </note>
+                                        <note dur="16" oct="4" pname="b" accid.ges="f" />
                                         <note dur="16" oct="4" pname="a">
-                                            <accid accid="f" />
+                                            <orig>
+                                                <accid accid="f" />
+                                            </orig>
                                         </note>
-                                        <note dur="16" oct="4" pname="b">
-                                            <accid accid.ges="f" />
-                                        </note>
+                                        <note dur="16" oct="4" pname="b" accid.ges="f" />
                                     </beam>
                                     <beam>
                                         <note dur="16" oct="4" pname="g" />
@@ -125,18 +123,30 @@
                             <staff n="2">
                                 <layer n="1">
                                     <note dur="4" oct="3" pname="f" />
-                                    <rest dur="8" />
+                                    <rest dur="8" oloc="3" ploc="f" />
                                     <note dur="8" oct="3" pname="f" />
-                                    <note dur="4" oct="3" pname="b" accid="f" />
-                                    <rest dur="8" />
-                                    <note dur="8" oct="3" pname="b" />
+                                    <note dur="4" oct="3" pname="b" accid.ges="f" />
+                                    <rest dur="8" oloc="3" ploc="a" />
+                                    <note dur="8" oct="3" pname="b" accid.ges="f" />
                                 </layer>
                             </staff>
-                            <harm place="above" staff="2" tstamp="1">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
+                            <app>
+                              <lem source="#secondEdition">
+                                  <harm place="above" staff="2" tstamp="1">
+                                      <fb>
+                                          <f>♭</f>
+                                      </fb>
+                                  </harm>
+                              </lem>
+                              <rdg source="#firstEdition">
+                                  <harm place="above" staff="2" tstamp="1">
+                                      <fb>
+                                          <f>7</f>
+                                          <f>♭</f>
+                                      </fb>
+                                  </harm>
+                              </rdg>
+                            </app>
                             <harm place="above" staff="2" tstamp="3">
                                 <fb>
                                     <f>8</f>
@@ -170,28 +180,22 @@
                                     <beam>
                                         <note dur="16" oct="4" pname="g" />
                                         <note dur="16" oct="5" pname="d" />
-                                        <note dur="16" oct="4" pname="e">
-                                            <accid accid.ges="f" />
-                                        </note>
+                                        <note dur="16" oct="4" pname="e" accid.ges="f" />
                                         <note dur="16" oct="5" pname="d" />
                                     </beam>
-                                    <sb />
+                                    <sb source="#firstEdition #secondEdition" />
                                     <beam>
                                         <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="4" pname="a">
                                             <accid accid="f" />
                                         </note>
                                         <note dur="16" oct="4" pname="g" />
-                                        <note dur="16" oct="4" pname="a">
-                                            <accid accid.ges="f" />
-                                        </note>
+                                        <note dur="16" oct="4" pname="a" accid.ges="f" />
                                     </beam>
                                     <beam>
                                         <note dur="16" oct="4" pname="f" />
                                         <note dur="16" oct="5" pname="c" />
-                                        <note dur="16" oct="4" pname="e">
-                                            <accid accid.ges="f" />
-                                        </note>
+                                        <note dur="16" oct="4" pname="e" accid.ges="f" />
                                         <note dur="16" oct="5" pname="c" />
                                     </beam>
                                 </layer>
@@ -199,11 +203,13 @@
                             <staff n="2">
                                 <layer n="1">
                                     <note dur="4" oct="3" pname="e" />
-                                    <rest dur="8" />
+                                    <rest dur="8" oloc="3" ploc="d" />
                                     <note dur="8" oct="3" pname="e" />
-                                    <sb />
-                                    <note dur="4" oct="3" pname="a" accid="f" />
-                                    <rest dur="8" />
+                                    <sb source="#firstEdition #secondEdition" />
+                                    <note dur="4" oct="3" pname="a">
+                                        <accid accid="f" />
+                                    </note>
+                                    <rest dur="8" oloc="3" ploc="f" />
                                     <note dur="8" oct="3" pname="a" />
                                 </layer>
                             </staff>
@@ -239,9 +245,7 @@
                                     <beam>
                                         <note dur="16" oct="4" pname="f" />
                                         <note dur="16" oct="5" pname="c" />
-                                        <note dur="16" oct="4" pname="e">
-                                            <accid accid.ges="f" />
-                                        </note>
+                                        <note dur="16" oct="4" pname="e" accid.ges="f" />
                                         <note dur="16" oct="5" pname="c" />
                                     </beam>
                                     <beam>
@@ -259,13 +263,13 @@
                                         <note dur="16" oct="4" pname="g" />
                                     </beam>
                                     <beam>
-                                        <note dur="16" oct="4" pname="e">
-                                            <accid accid.ges="f" />
-                                        </note>
+                                        <note dur="16" oct="4" pname="e" accid.ges="f" />
                                         <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="4" pname="d" />
-                                        <note dur="16" oct="4" pname="b">
-                                            <accid accid="n" func="caution" />
+                                        <note dur="16" oct="4" pname="b" accid.ges="n">
+                                            <orig>
+                                                <accid accid="n" />
+                                            </orig>
                                         </note>
                                     </beam>
                                 </layer>
@@ -273,10 +277,10 @@
                             <staff n="2">
                                 <layer n="1">
                                     <note dur="4" oct="3" pname="d" />
-                                    <rest dur="8" />
+                                    <rest dur="8" oloc="3" ploc="d" />
                                     <note dur="8" oct="3" pname="d" />
                                     <note dur="4" oct="3" pname="g" />
-                                    <rest dur="8" />
+                                    <rest dur="8" oloc="3" ploc="f" />
                                     <note dur="8" oct="3" pname="g" />
                                 </layer>
                             </staff>
@@ -305,6 +309,18 @@
                                     <f>5</f>
                                 </fb>
                             </harm>
+                        </measure>
+                        <measure right="invis">
+                            <staff n="1">
+                                <layer>
+                                    <custos oct="4" pname="e" />
+                                </layer>
+                            </staff>
+                            <staff n="2">
+                                <layer>
+                                    <custos oct="3" pname="c" />
+                                </layer>
+                            </staff>
                         </measure>
                     </section>
                 </score>

--- a/encodings/frontpage/mattheson/comments_1st.xml
+++ b/encodings/frontpage/mattheson/comments_1st.xml
@@ -7,22 +7,22 @@
         <title type="part">Der Ober-Classe 24 Probstücke</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/frontpage/mattheson/comments_de.xml
+++ b/encodings/frontpage/mattheson/comments_de.xml
@@ -7,22 +7,22 @@
         <title type="part">Der Ober-Classe 24 Probstücke</title>
         <editor>
           <persName xml:id="pfeffer">
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </editor>
         <editor>
           <persName xml:id="rettinghaus" ref="https://d-nb.info/gnd/140541624">
-            <forename>Klaus</forename>
             <surname>Rettinghaus</surname>
+            <forename>Klaus</forename>
           </persName>
         </editor>
       </titleStmt>
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/frontpage/mattheson/comments_de.xml
+++ b/encodings/frontpage/mattheson/comments_de.xml
@@ -100,7 +100,7 @@
       <epigraph>
         <cit>
           <quote><lb/><hi rendition="#aq"><foreign xml:lang="lat"><orig>Diuiſum ſic breue fiet opus.</orig></foreign></hi></quote>
-          <bibl><hi rendition="#aq #i"><persName ref="#ed_vfy_c2m_tlb"><abbr>Mart.</abbr></persName></hi></bibl>
+          <bibl><hi rendition="#aq #i"><persName corresp="#ed_vfy_c2m_tlb"><abbr>Mart.</abbr></persName></hi></bibl>
         </cit>
       </epigraph>
     </front>

--- a/encodings/guidelines/vvaa/comments_en.xml
+++ b/encodings/guidelines/vvaa/comments_en.xml
@@ -12,8 +12,8 @@
       <publicationStmt>
         <publisher>
           <persName>
-            <forename>Niels</forename>
             <surname>Pfeffer</surname>
+            <forename>Niels</forename>
           </persName>
         </publisher>
         <availability>

--- a/encodings/indices/persons.xml
+++ b/encodings/indices/persons.xml
@@ -21,6 +21,7 @@
         <body>
             <listPerson>
                 <person xml:id="ed_wpd_2lx_qlb" role="mythological">
+                    <idno type="uri">http://d-nb.info/gnd/118503642</idno>
                     <persName type="reg">
                         <name>Apollo</name>
                     </persName>
@@ -40,8 +41,8 @@
                         <surname>Aristoxenus</surname>
                         <forename>Tarentinus</forename>
                     </persName>
-                    <birth>v360</birth>
-                    <death>v300</death>
+                    <birth>360 BC</birth>
+                    <death>300 BC</death>
                 </person>
                 <person xml:id="ed_mj2_qx2_5lb">
                     <persName type="reg">
@@ -80,6 +81,13 @@
                     </persName>
                     <birth>480</birth>
                     <death>524</death>
+                </person>
+                <person>
+                    <persName type="reg">
+                        <surname>Bottari</surname>
+                        <forename>Domenico Filippo</forename>
+                    </persName>
+                    <floruit notAfter="1703" notBefore="1703" />
                 </person>
                 <person xml:id="ed_y4p_gvx_qlb">
                     <idno type="uri">http://d-nb.info/gnd/118515586</idno>
@@ -147,11 +155,10 @@
                 <person xml:id="ed_dwf_j5x_qlb">
                     <idno type="uri">http://d-nb.info/gnd/1050676637</idno>
                     <persName type="reg">
-                        <surname>de Saint-Lambert</surname>
-                        <forename>Michel</forename>
+                        <surname>de Saint Lambert</surname>
+                        <forename></forename>
                     </persName>
-                    <birth/>
-                    <death/>
+                    <floruit notAfter="1710" notBefore="1700" />
                 </person>
                 <person xml:id="ed_ghv_kvx_qlb">
                     <idno type="uri">http://d-nb.info/gnd/119116383</idno>


### PR DESCRIPTION
changes:
* `persName@ref` to `persName@corresp`
* order of `forename` and `surname` in header
* add apparatus to examples
* fix and update index of persons

NB: "Bottari" in index needs ID.