### PR TITLE
fix examples

### DIFF
--- a/encodings/1/mattheson/music-example1.xml
+++ b/encodings/1/mattheson/music-example1.xml
@@ -5,29 +5,25 @@
         <fileDesc>
             <titleStmt>
                 <title>Prob-Stück 1, Example 1</title>
-                <composer>Johann Mattheson</composer>
+                <composer>
+                    <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
+                </composer>
                 <respStmt>
                     <resp>Edited by</resp>
                     <persName role="editor" xml:id="pfeffer">Niels Pfeffer</persName>
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-              <respStmt>
-                  <persName role="publisher">Niels Pfeffer</persName>
-              </respStmt>
-              <date>2019</date>
-              <availability>
-                  <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
-                      <p>Creative Commons Attribution 4.0 International License</p>
-                  </useRestrict>
-              </availability>
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
@@ -37,10 +33,8 @@
                 <score>
                     <scoreDef key.pname="d" key.mode="minor" meter.unit="4" mnum.visible="false">
                         <staffGrp>
-                            <staffDef xml:id="staffdef-variant-1" clef.shape="C" clef.line="1" n="1" lines="5">
-                            </staffDef>
-                            <staffDef xml:id="staffdef-bass" clef.shape="F" clef.line="4" n="2" lines="5">
-                            </staffDef>
+                            <staffDef xml:id="staffdef-variant-1" clef.shape="C" clef.line="1" n="1" lines="5"></staffDef>
+                            <staffDef xml:id="staffdef-bass" clef.shape="F" clef.line="4" n="2" lines="5"></staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
@@ -288,7 +282,9 @@
                                     <f>6⃥</f>
                                 </fb>
                             </harm>
-                            <dir place="within" staff="1" tstamp="4"><rend fontstyle="normal">&amp;c.</rend></dir>
+                            <dir place="within" staff="1" tstamp="4">
+                                <rend fontstyle="normal">&amp;c.</rend>
+                            </dir>
                         </measure>
                     </section>
                 </score>

--- a/encodings/1/mattheson/music-example2.xml
+++ b/encodings/1/mattheson/music-example2.xml
@@ -5,29 +5,25 @@
         <fileDesc>
             <titleStmt>
                 <title>Prob-Stück 1, Example 2</title>
-                <composer>Johann Mattheson</composer>
+                <composer>
+                    <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
+                </composer>
                 <respStmt>
                     <resp>Edited by</resp>
                     <persName role="editor" xml:id="pfeffer">Niels Pfeffer</persName>
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-              <respStmt>
-                  <persName role="publisher">Niels Pfeffer</persName>
-              </respStmt>
-              <date>2019</date>
-              <availability>
-                  <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
-                      <p>Creative Commons Attribution 4.0 International License</p>
-                  </useRestrict>
-              </availability>
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
@@ -37,10 +33,8 @@
                 <score>
                     <scoreDef key.pname="d" key.mode="minor" meter.unit="4" mnum.visible="false">
                         <staffGrp>
-                            <staffDef xml:id="staffdef-variant-1" clef.shape="C" clef.line="1" n="1" lines="5">
-                            </staffDef>
-                            <staffDef xml:id="staffdef-bass" clef.shape="F" clef.line="4" n="2" lines="5">
-                            </staffDef>
+                            <staffDef xml:id="staffdef-variant-1" clef.shape="C" clef.line="1" n="1" lines="5"></staffDef>
+                            <staffDef xml:id="staffdef-bass" clef.shape="F" clef.line="4" n="2" lines="5"></staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
@@ -54,7 +48,7 @@
                                         <note xml:id="ex-1003" dur="16" oct="5" pname="a" />
                                         <note xml:id="ex-1005" dur="32" oct="5" pname="e" />
                                         <note xml:id="ex-1006" dur="32" oct="5" pname="f" />
-                                        <app>
+                                        <app resp="#rettinghaus">
                                             <lem source="#secondEdition">
                                                 <note xml:id="ex-1007" dur="16" oct="5" pname="g" />
                                             </lem>
@@ -71,7 +65,7 @@
                                         <note xml:id="ex-1006a" dur="32" oct="5" pname="f">
                                             <accid xml:id="ex-1035" accid="s" />
                                         </note>
-                                        <app>
+                                        <app resp="#rettinghaus">
                                             <lem source="#secondEdition">
                                                 <note xml:id="ex-1007a" dur="16" oct="5" pname="g" />
                                             </lem>
@@ -109,14 +103,14 @@
                                 </layer>
                             </staff>
                             <harm place="above" staff="2" tstamp="2">
-                              <fb>
-                                <f>♯</f>
-                              </fb>
+                                <fb>
+                                    <f>♯</f>
+                                </fb>
                             </harm>
                             <harm place="above" staff="2" tstamp="4">
-                              <fb>
-                                <f>♯</f>
-                              </fb>
+                                <fb>
+                                    <f>♯</f>
+                                </fb>
                             </harm>
                         </measure>
                         <measure corresp="#m-1027" right="invis" metcon="false">
@@ -131,7 +125,7 @@
                                         <note xml:id="ex-1042" dur="32" oct="5" pname="d" />
                                         <note xml:id="ex-1043" dur="32" oct="5" pname="e" />
                                         <note xml:id="ex-1045" dur="16" oct="5" pname="f">
-                                          <accid xml:id="ex-1046" accid="n" func="caution" />
+                                            <accid xml:id="ex-1046" accid="n" func="caution" />
                                         </note>
                                     </beam>
                                     <note xml:id="ex-1047" dur="4" oct="5" pname="e" />
@@ -160,8 +154,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <dir place="within" staff="1" tstamp="4"><rend fontstyle="normal">&amp;c.</rend></dir>
-                            <dir place="within" staff="2" tstamp="4"><rend fontstyle="normal">&amp;c.</rend></dir>
+                            <dir place="within" staff="1" tstamp="4">
+                                <rend fontstyle="normal">&amp;c.</rend>
+                            </dir>
+                            <dir place="within" staff="2" tstamp="4">
+                                <rend fontstyle="normal">&amp;c.</rend>
+                            </dir>
                         </measure>
                     </section>
                 </score>

--- a/encodings/1/mattheson/music-example3.xml
+++ b/encodings/1/mattheson/music-example3.xml
@@ -5,29 +5,25 @@
         <fileDesc>
             <titleStmt>
                 <title>Prob-Stück 1, Example 3</title>
-                <composer>Johann Mattheson</composer>
+                <composer>
+                    <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
+                </composer>
                 <respStmt>
                     <resp>Edited by</resp>
                     <persName role="editor" xml:id="pfeffer">Niels Pfeffer</persName>
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-              <respStmt>
-                  <persName role="publisher">Niels Pfeffer</persName>
-              </respStmt>
-              <date>2019</date>
-              <availability>
-                  <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
-                      <p>Creative Commons Attribution 4.0 International License</p>
-                  </useRestrict>
-              </availability>
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
@@ -37,10 +33,8 @@
                 <score>
                     <scoreDef key.pname="d" key.mode="minor" meter.unit="4" mnum.visible="false">
                         <staffGrp>
-                            <staffDef xml:id="staffdef-variant-1" clef.shape="C" clef.line="1" n="1" lines="5">
-                            </staffDef>
-                            <staffDef xml:id="staffdef-bass" clef.shape="F" clef.line="4" n="2" lines="5">
-                            </staffDef>
+                            <staffDef xml:id="staffdef-variant-1" clef.shape="C" clef.line="1" n="1" lines="5"></staffDef>
+                            <staffDef xml:id="staffdef-bass" clef.shape="F" clef.line="4" n="2" lines="5"></staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>

--- a/encodings/10/mattheson/music-example1.xml
+++ b/encodings/10/mattheson/music-example1.xml
@@ -14,12 +14,6 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
                 <respStmt>
                     <persName role="publisher">Niels Pfeffer</persName>

--- a/encodings/11/mattheson/music-example1.xml
+++ b/encodings/11/mattheson/music-example1.xml
@@ -14,11 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>First draft, <date>2019</date></edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
@@ -207,7 +212,7 @@
                                     <beam>
                                         <note dur="8" oct="5" pname="e" stem.dir="down" accid.ges="f" />
                                         <note dur="16" oct="5" pname="d" stem.dir="down" />
-                                        <note dur="16" oct="5" pname="c" stem.dir="up"/>
+                                        <note dur="16" oct="5" pname="c" stem.dir="up" />
                                     </beam>
                                 </layer>
                             </staff>

--- a/encodings/11/mattheson/music-example2.xml
+++ b/encodings/11/mattheson/music-example2.xml
@@ -14,11 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>First draft, <date>2019</date></edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>

--- a/encodings/11/mattheson/music-example2.xml
+++ b/encodings/11/mattheson/music-example2.xml
@@ -45,7 +45,7 @@
                         <measure corresp="#measure-0000002078803044">
                             <staff n="1">
                                 <layer n="1">
-                                    <rest dur="16" staff="2" loc="6" />
+                                    <rest dur="16" staff="2" oloc="3" ploc="f" />
                                     <beam>
                                         <note dur="16" oct="3" pname="e" stem.dir="up" accid.ges="f" staff="2" />
                                         <note dur="16" oct="3" pname="g" stem.dir="up" staff="2" />
@@ -68,7 +68,7 @@
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <rest dur="16" loc="0" />
+                                    <rest dur="16" oloc="2" ploc="g" />
                                     <beam>
                                         <note dur="16" oct="2" pname="g" stem.dir="down" />
                                         <note dur="16" oct="3" pname="c" stem.dir="down" />

--- a/encodings/11/mattheson/music-example3.xml
+++ b/encodings/11/mattheson/music-example3.xml
@@ -14,11 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>First draft, <date>2019</date></edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>

--- a/encodings/11/mattheson/music-example4.xml
+++ b/encodings/11/mattheson/music-example4.xml
@@ -14,11 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>First draft, <date>2019</date></edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
@@ -37,7 +42,7 @@
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure n="54" corresp="#measure-0000000919086642">
+                        <measure corresp="#measure-0000000919086642">
                             <staff n="1">
                                 <layer n="1">
                                     <supplied resp="#pfeffer">
@@ -74,7 +79,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure n="55" corresp="#measure-0000001966821284">
+                        <measure corresp="#measure-0000001966821284">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
@@ -92,7 +97,7 @@
                                         <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="4" pname="a">
-                                            <app>
+                                            <app resp="#rettinghaus">
                                                 <lem source="#secondEdition">
                                                     <accid accid="n" />
                                                 </lem>
@@ -133,7 +138,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure n="56" corresp="#measure-0000001525394195">
+                        <measure corresp="#measure-0000001525394195">
                             <staff n="1">
                                 <layer n="1">
                                     <note dur="8" oct="4" pname="a">
@@ -170,7 +175,10 @@
                             </staff>
                             <harm place="above" staff="2" tstamp="1">
                                 <fb>
-                                    <f><supplied resp="#rettinghaus">♮</supplied>2</f>
+                                    <f>
+                                        <supplied resp="#rettinghaus">♮</supplied>
+                                        2
+                                    </f>
                                 </fb>
                             </harm>
                             <harm place="above" staff="2" tstamp="2">

--- a/encodings/13/mattheson/music-example1.xml
+++ b/encodings/13/mattheson/music-example1.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 13, Example 1</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -14,31 +14,33 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
-
     <music>
         <body>
             <mdiv>
                 <score>
-                    <scoreDef key.sig="2f" mnum.visible="false">
+                    <scoreDef key.pname="b" key.accid="f" key.mode="major" midi.bpm="100" mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5" meter.unit="16" />
-                            <staffDef clef.shape="F" clef.line="4" n="2" lines="5" meter.unit="16" />
+                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5" meter.unit="16">
+                                <keySig sig="1f" />
+                            </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure n="11">
-                            <staff n="1" visible="true">
+                        <measure corresp="#measure-0000001263987989">
+                            <staff n="1">
                                 <layer n="1">
                                     <beam>
                                         <note dur="16" oct="5" pname="g" />
@@ -47,7 +49,9 @@
                                     </beam>
                                     <beam>
                                         <note dur="16" oct="5" pname="g" />
-                                        <note dur="16" oct="5" pname="e" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="e">
+                                            <accid accid="f" />
+                                        </note>
                                         <note dur="16" oct="5" pname="e" accid.ges="f" />
                                     </beam>
                                     <beam>
@@ -58,17 +62,19 @@
                                 </layer>
                             </staff>
                         </measure>
-                        <measure right="invis" metcon="false">
+                        <measure corresp="#measure-0000001431729815" right="invis" metcon="false">
                             <staff n="1">
                                 <layer n="1">
                                     <chord dur="4">
-                                        <note dur="4" oct="4" pname="a" />
-                                        <note dur="4" oct="5" pname="c" />
                                         <note dur="4" oct="5" pname="f" />
+                                        <note dur="4" oct="5" pname="c" />
+                                        <note dur="4" oct="4" pname="a" />
                                     </chord>
                                 </layer>
                             </staff>
-                            <dir place="within" staff="1" tstamp="2"><rend fontstyle="normal">&amp;c.</rend></dir>
+                            <dir place="within" staff="1" tstamp="2">
+                                <rend fontstyle="normal">&amp;c.</rend>
+                            </dir>
                         </measure>
                     </section>
                 </score>

--- a/encodings/13/mattheson/music-example1.xml
+++ b/encodings/13/mattheson/music-example1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>

--- a/encodings/13/mattheson/music-example2.xml
+++ b/encodings/13/mattheson/music-example2.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 13, Example 2</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -14,71 +14,76 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
-
     <music>
         <body>
             <mdiv>
                 <score>
-                    <scoreDef key.sig="2f" mnum.visible="false">
+                    <scoreDef key.pname="b" key.accid="f" key.mode="major" midi.bpm="100" mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5" meter.unit="16" />
+                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5" meter.unit="16">
+                                <keySig sig="1f" />
+                            </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure n="38">
+                        <measure corresp="#measure-0000000720476607">
                             <staff n="1" visible="true">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="above">
                                         <note dur="16" oct="4" pname="d" />
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="above">
                                         <note dur="16" oct="4" pname="d" />
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="above">
                                         <note dur="16" oct="4" pname="d" />
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
+                            <dir staff="1" place="below">Achter Tact.</dir>
                         </measure>
-                        <measure n="39">
+                        <measure corresp="#measure-0000000902537430">
                             <staff n="1">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="above">
                                         <note dur="16" oct="4" pname="b">
                                             <accid accid="n" />
                                         </note>
                                         <note dur="16" oct="4" pname="d" />
                                         <note dur="16" oct="4" pname="d" />
                                     </beam>
-                                    <beam>
+                                    <beam place="above">
                                         <note dur="16" oct="4" pname="b" />
                                         <note dur="16" oct="4" pname="d" />
                                         <note dur="16" oct="4" pname="d" />
                                     </beam>
-                                    <beam>
+                                    <beam place="above">
                                         <note dur="16" oct="4" pname="b" />
                                         <note dur="16" oct="4" pname="d" />
                                         <note dur="16" oct="4" pname="d" />
                                     </beam>
                                 </layer>
                             </staff>
+                            <dir staff="1" place="below">Neunter Tact.</dir>
                         </measure>
                     </section>
                 </score>

--- a/encodings/13/mattheson/music-example2.xml
+++ b/encodings/13/mattheson/music-example2.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>

--- a/encodings/13/mattheson/music-example3.xml
+++ b/encodings/13/mattheson/music-example3.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>
@@ -53,7 +53,7 @@
                                     <beam place="below">
                                         <note dur="16" oct="4" pname="g" />
                                         <note dur="16" oct="5" pname="e">
-                                            <accid accid="f"/>
+                                            <accid accid="f" />
                                         </note>
                                         <note dur="16" oct="5" pname="e" accid.ges="f" />
                                     </beam>

--- a/encodings/13/mattheson/music-example3.xml
+++ b/encodings/13/mattheson/music-example3.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 13, Example 3</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -14,39 +14,55 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>First draft, <date>2019</date></edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
+        <encodingDesc>
+            <editorialDecl>
+                <p>In the second edition some dots are missing, to be encoded later.</p>
+            </editorialDecl>
+        </encodingDesc>
     </meiHead>
     <music>
         <body>
             <mdiv>
                 <score>
-                    <scoreDef mnum.visible="false">
+                    <scoreDef key.pname="b" key.accid="f" key.mode="major" midi.bpm="100" mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" key.sig="1f" n="1" lines="5" meter.unit="16" />
-                            <staffDef clef.shape="F" clef.line="4" key.sig="1f" n="2" lines="5" meter.unit="16" />
+                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5" meter.unit="16">
+                                <keySig sig="1f" />
+                            </staffDef>
+                            <staffDef clef.shape="F" clef.line="4" n="2" lines="5" meter.unit="16">
+                                <keySig sig="1f" />
+                            </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <measure n="1">
                             <staff n="1">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="4" pname="g" />
-                                        <note dur="16" oct="5" pname="e" accid="f" />
+                                        <note dur="16" oct="5" pname="e">
+                                            <accid accid="f"/>
+                                        </note>
                                         <note dur="16" oct="5" pname="e" accid.ges="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="4" pname="g" />
                                         <note dur="16" oct="5" pname="e" accid.ges="f" />
                                         <note dur="16" oct="5" pname="e" accid.ges="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="4" pname="g" />
                                         <note dur="16" oct="5" pname="e" accid.ges="f" />
                                         <note dur="16" oct="5" pname="e" accid.ges="f" />
@@ -66,17 +82,17 @@
                         <measure n="2">
                             <staff n="1">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="d" />
                                         <note dur="16" oct="4" pname="g" />
                                         <note dur="16" oct="4" pname="g" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="d" />
                                         <note dur="16" oct="4" pname="g" />
                                         <note dur="16" oct="4" pname="g" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="d" />
                                         <note dur="16" oct="4" pname="g" />
                                         <note dur="16" oct="4" pname="g" />

--- a/encodings/13/mattheson/music-example4.xml
+++ b/encodings/13/mattheson/music-example4.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 13, Example 4</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -14,14 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
@@ -29,67 +31,78 @@
         <body>
             <mdiv>
                 <score>
-                    <scoreDef key.sig="2f" mnum.visible="false">
+                    <scoreDef key.pname="b" key.accid="f" key.mode="major" midi.bpm="100" mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5" meter.unit="16" />
-                            <staffDef clef.shape="F" clef.line="4" n="2" lines="5" meter.unit="16" />
+                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5" meter.unit="16">
+                                <keySig sig="2f" />
+                            </staffDef>
+                            <staffDef clef.shape="F" clef.line="4" n="2" lines="5" meter.unit="16">
+                                <keySig sig="2f" />
+                            </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure n="58">
-                            <staff n="1" visible="true">
+                        <measure corresp="#measure-0000000946035271">
+                            <staff n="1">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="4" pname="a" />
                                         <note dur="16" oct="5" pname="f" />
                                         <note dur="16" oct="5" pname="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="4" pname="a" />
                                         <note dur="16" oct="5" pname="f" />
                                         <note dur="16" oct="5" pname="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="4" pname="a" />
                                         <note dur="16" oct="5" pname="f" />
                                         <note dur="16" oct="5" pname="f" />
                                     </beam>
                                 </layer>
                             </staff>
-                            <staff n="2" visible="true">
+                            <staff n="2">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="f" />
                                         <note dur="16" oct="4" pname="c" />
                                         <note dur="16" oct="4" pname="c" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="f" />
                                         <note dur="16" oct="4" pname="c" />
                                         <note dur="16" oct="4" pname="c" />
                                     </beam>
-                                    <beam>
-                                        <note dur="16" oct="3" pname="e" accid.ges="f" />
+                                    <beam place="below">
+                                        <app resp="#rettinghaus">
+                                            <lem source="#firstEdition">
+                                                <note dur="16" oct="3" pname="e" accid.ges="f" />
+                                            </lem>
+                                            <rdg source="#secondEdition">
+                                                <note dur="16" oct="3" pname="f" />
+                                            </rdg>
+                                        </app>
                                         <note dur="16" oct="4" pname="c" />
                                         <note dur="16" oct="4" pname="c" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure n="59">
+                        <measure corresp="#measure-0000001361314791">
                             <staff n="1">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                         <note dur="16" oct="5" pname="f" />
                                         <note dur="16" oct="5" pname="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                         <note dur="16" oct="5" pname="f" />
                                         <note dur="16" oct="5" pname="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                         <note dur="16" oct="5" pname="f" />
                                         <note dur="16" oct="5" pname="f" />
@@ -98,17 +111,17 @@
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="d" />
                                         <note dur="16" oct="3" pname="b" accid.ges="f" />
                                         <note dur="16" oct="3" pname="b" accid.ges="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="d" />
                                         <note dur="16" oct="3" pname="b" accid.ges="f" />
                                         <note dur="16" oct="3" pname="b" accid.ges="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="d" />
                                         <note dur="16" oct="3" pname="b" accid.ges="f" />
                                         <note dur="16" oct="3" pname="b" accid.ges="f" />
@@ -116,20 +129,20 @@
                                 </layer>
                             </staff>
                         </measure>
-                        <measure n="60">
+                        <measure corresp="#measure-0000001587207292">
                             <staff n="1">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="g" />
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="g" />
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="g" />
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
@@ -138,17 +151,17 @@
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="b" accid.ges="f" />
                                         <note dur="16" oct="3" pname="e" accid.ges="f" />
                                         <note dur="16" oct="3" pname="e" accid.ges="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="b" accid.ges="f" />
                                         <note dur="16" oct="3" pname="e" accid.ges="f" />
                                         <note dur="16" oct="3" pname="e" accid.ges="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="b" accid.ges="f" />
                                         <note dur="16" oct="3" pname="e" accid.ges="f" />
                                         <note dur="16" oct="3" pname="e" accid.ges="f" />
@@ -156,20 +169,21 @@
                                 </layer>
                             </staff>
                         </measure>
-                        <measure n="61">
+                        <sb source="#firstEditiom #secondEdition" />
+                        <measure corresp="#measure-0000001393298236">
                             <staff n="1">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="5" pname="g" />
                                         <note dur="16" oct="5" pname="g" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="5" pname="g" />
                                         <note dur="16" oct="5" pname="g" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="5" pname="g" />
                                         <note dur="16" oct="5" pname="g" />
@@ -178,81 +192,82 @@
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="e">
                                             <accid accid="n" />
                                         </note>
                                         <note dur="16" oct="4" pname="c" />
                                         <note dur="16" oct="4" pname="c" />
                                     </beam>
-                                    <beam>
-                                        <note dur="16" oct="3" pname="e" />
+                                    <beam place="below">
+                                        <note dur="16" oct="3" pname="e" accid.ges="n" />
                                         <note dur="16" oct="4" pname="c" />
                                         <note dur="16" oct="4" pname="c" />
                                     </beam>
-                                    <beam>
-                                        <note dur="16" oct="3" pname="e" />
+                                    <beam place="below">
+                                        <note dur="16" oct="3" pname="e" accid.ges="n" />
                                         <note dur="16" oct="4" pname="c" />
                                         <note dur="16" oct="4" pname="c" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <sb />
-                        <measure n="62">
-                            <staff n="1" visible="true">
-                                <layer n="1">
-                                    <beam>
-                                        <note dur="16" oct="5" pname="a" />
-                                        <note dur="16" oct="5" pname="c" />
-                                        <note dur="16" oct="5" pname="c" />
-                                    </beam>
-                                    <beam>
-                                        <note dur="16" oct="5" pname="a" />
-                                        <note dur="16" oct="5" pname="c" />
-                                        <note dur="16" oct="5" pname="c" />
-                                    </beam>
-                                    <beam>
-                                        <note dur="16" oct="5" pname="a" />
-                                        <note dur="16" oct="5" pname="c" />
-                                        <note dur="16" oct="5" pname="c" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                            <staff n="2" visible="true">
-                                <layer n="1">
-                                    <beam>
-                                        <note dur="16" oct="4" pname="c" />
-                                        <note dur="16" oct="3" pname="f" />
-                                        <note dur="16" oct="3" pname="f" />
-                                    </beam>
-                                    <beam>
-                                        <note dur="16" oct="4" pname="c" />
-                                        <note dur="16" oct="3" pname="f" />
-                                        <note dur="16" oct="3" pname="f" />
-                                    </beam>
-                                    <beam>
-                                        <note dur="16" oct="4" pname="c" />
-                                        <note dur="16" oct="3" pname="f" />
-                                        <note dur="16" oct="3" pname="f" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure n="63">
+                        <measure corresp="#measure-0000001782921444">
                             <staff n="1">
                                 <layer n="1">
-                                    <beam>
-                                        <note dur="16" oct="5" pname="e" accid.ges="f" />
+                                    <beam place="below">
+                                        <note dur="16" oct="5" pname="a" />
+                                        <note dur="16" oct="5" pname="c" />
+                                        <note dur="16" oct="5" pname="c" />
+                                    </beam>
+                                    <beam place="below">
+                                        <note dur="16" oct="5" pname="a" />
+                                        <note dur="16" oct="5" pname="c" />
+                                        <note dur="16" oct="5" pname="c" />
+                                    </beam>
+                                    <beam place="below">
+                                        <note dur="16" oct="5" pname="a" />
+                                        <note dur="16" oct="5" pname="c" />
+                                        <note dur="16" oct="5" pname="c" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <staff n="2">
+                                <layer n="1">
+                                    <beam place="below">
+                                        <note dur="16" oct="4" pname="c" />
+                                        <note dur="16" oct="3" pname="f" />
+                                        <note dur="16" oct="3" pname="f" />
+                                    </beam>
+                                    <beam place="below">
+                                        <note dur="16" oct="4" pname="c" />
+                                        <note dur="16" oct="3" pname="f" />
+                                        <note dur="16" oct="3" pname="f" />
+                                    </beam>
+                                    <beam place="below">
+                                        <note dur="16" oct="4" pname="c" />
+                                        <note dur="16" oct="3" pname="f" />
+                                        <note dur="16" oct="3" pname="f" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure corresp="#measure-0000001673525869">
+                            <staff n="1">
+                                <layer n="1">
+                                    <beam place="below">
+                                        <note dur="16" oct="5" pname="e">
+                                            <accid accid="f" />
+                                        </note>
                                         <note dur="16" oct="6" pname="c" />
                                         <note dur="16" oct="6" pname="c" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="b" accid.ges="f" />
                                         <note dur="16" oct="5" pname="d" />
                                         <note dur="16" oct="5" pname="d" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="5" pname="a" />
                                         <note dur="16" oct="5" pname="a" />
@@ -261,17 +276,19 @@
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="g" />
-                                        <note dur="16" oct="4" pname="e" accid.ges="f" />
+                                        <note dur="16" oct="4" pname="e">
+                                            <accid accid="f" />
+                                        </note>
                                         <note dur="16" oct="4" pname="e" accid.ges="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="4" pname="d" />
                                         <note dur="16" oct="3" pname="f" />
                                         <note dur="16" oct="3" pname="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="e" accid.ges="f" />
                                         <note dur="16" oct="4" pname="c" />
                                         <note dur="16" oct="4" pname="c" />
@@ -279,21 +296,24 @@
                                 </layer>
                             </staff>
                         </measure>
-                        <measure n="64">
+                        <sb source="#firstEditiom #secondEdition" />
+                        <measure corresp="#measure-0000000684667663">
                             <staff n="1">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="g" />
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="4" pname="a" />
                                         <note dur="16" oct="5" pname="f" />
                                         <note dur="16" oct="5" pname="f" />
                                     </beam>
-                                    <beam>
-                                        <note dur="16" oct="5" pname="e" accid.ges="f" />
+                                    <beam place="below">
+                                        <note dur="16" oct="5" pname="e">
+                                            <accid accid="f" />
+                                        </note>
                                         <note dur="16" oct="6" pname="c" />
                                         <note dur="16" oct="6" pname="c" />
                                     </beam>
@@ -301,38 +321,40 @@
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="b" accid.ges="f" />
                                         <note dur="16" oct="3" pname="d" />
                                         <note dur="16" oct="3" pname="d" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="c" />
                                         <note dur="16" oct="3" pname="a" />
                                         <note dur="16" oct="3" pname="a" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="g" />
-                                        <note dur="16" oct="4" pname="e" accid.ges="f" />
+                                        <note dur="16" oct="4" pname="e">
+                                            <accid accid="f" />
+                                        </note>
                                         <note dur="16" oct="4" pname="e" accid.ges="f" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure n="65">
+                        <measure corresp="#measure-0000001186854121">
                             <staff n="1">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="d" />
                                         <note dur="16" oct="6" pname="c" />
                                         <note dur="16" oct="6" pname="c" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="d" />
                                         <note dur="16" oct="5" pname="b" accid.ges="f" />
                                         <note dur="16" oct="5" pname="b" accid.ges="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="5" pname="d" />
                                         <note dur="16" oct="5" pname="a" />
                                         <note dur="16" oct="5" pname="a" />
@@ -341,17 +363,17 @@
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="f" />
                                         <note dur="16" oct="4" pname="e" accid.ges="f" />
                                         <note dur="16" oct="4" pname="e" accid.ges="f" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="f" />
                                         <note dur="16" oct="4" pname="d" />
                                         <note dur="16" oct="4" pname="d" />
                                     </beam>
-                                    <beam>
+                                    <beam place="below">
                                         <note dur="16" oct="3" pname="f" />
                                         <note dur="16" oct="4" pname="c" />
                                         <note dur="16" oct="4" pname="c" />
@@ -359,22 +381,34 @@
                                 </layer>
                             </staff>
                         </measure>
-                        <measure right="rptend" n="66">
+                        <measure corresp="#measure-0000000996654926" right="rptend">
                             <staff n="1">
                                 <layer n="1">
-                                    <chord dots="1" dur="4">
-                                        <note oct="4" pname="b" accid.ges="f" />
-                                        <note oct="5" pname="d" />
-                                        <note oct="5" pname="f" />
-                                        <note oct="5" pname="b" accid.ges="f" />
-                                    </chord>
-                                    <rest dots="1" dur="8" />
+                                    <choice>
+                                        <corr resp="#rettinghaus" cert="high">
+                                            <chord dots="1" dur="4">
+                                                <note oct="5" pname="b" accid.ges="f" />
+                                                <note oct="5" pname="f" />
+                                                <note oct="5" pname="d" />
+                                                <note oct="4" pname="b" accid.ges="f" />
+                                            </chord>
+                                        </corr>
+                                        <sic source="#firstEditiom #secondEdition">
+                                            <chord dots="0" dots.ges="1" dur="4">
+                                                <note oct="5" pname="b" accid.ges="f" />
+                                                <note oct="5" pname="f" />
+                                                <note oct="5" pname="d" />
+                                                <note oct="4" pname="b" accid.ges="f" />
+                                            </chord>
+                                        </sic>
+                                    </choice>
+                                    <rest dots="1" dur="8" oloc="5" ploc="d" />
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
                                     <note dots="1" dur="4" oct="3" pname="b" accid.ges="f" />
-                                    <rest dots="1" dur="8" />
+                                    <rest dots="1" dur="8" oloc="3" ploc="a" />
                                 </layer>
                             </staff>
                         </measure>

--- a/encodings/13/mattheson/music-example4.xml
+++ b/encodings/13/mattheson/music-example4.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>

--- a/encodings/13/mattheson/score.xml
+++ b/encodings/13/mattheson/score.xml
@@ -504,26 +504,24 @@
               </staff>
             </measure>
             <measure xml:id="measure-0000001263987989" n="11">
-              <staff xml:id="staff-0000001444818936" n="1">
-                <layer xml:id="layer-0000001398373203" n="1">
+              <staff n="1">
+                <layer n="1">
                   <beam>
-                    <note xml:id="note-0000001864682191" dur="16" oct="5" pname="g"/>
-                    <note xml:id="note-0000000693228704" dur="16" oct="5" pname="f"/>
-                    <note xml:id="note-0000000804191720" dur="16" oct="5" pname="f"/>
+                    <note dur="16" oct="5" pname="g" />
+                    <note dur="16" oct="5" pname="f" />
+                    <note dur="16" oct="5" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000002110203088" dur="16" oct="5" pname="g"/>
-                    <note xml:id="note-0000001076990229" dur="16" oct="5" pname="e" accid.ges="f">
-                      <orig>
-                        <accid accid="f"/>
-                      </orig>
+                    <note dur="16" oct="5" pname="g" />
+                    <note dur="16" oct="5" pname="e">
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="note-0000000998238957" dur="16" oct="5" pname="e" accid.ges="f"/>
+                    <note dur="16" oct="5" pname="e" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000002146659783" dur="16" oct="5" pname="g"/>
-                    <note xml:id="note-0000001028153089" dur="16" oct="5" pname="d"/>
-                    <note xml:id="note-0000000772497578" dur="16" oct="5" pname="d"/>
+                    <note dur="16" oct="5" pname="g" />
+                    <note dur="16" oct="5" pname="d" />
+                    <note dur="16" oct="5" pname="d" />
                   </beam>
                 </layer>
               </staff>
@@ -539,16 +537,22 @@
               </staff>
             </measure>
             <measure xml:id="measure-0000001431729815" n="12">
-              <staff xml:id="staff-0000002106769917" n="1">
-                <layer xml:id="layer-0000001474502925" n="1">
-                  <chord xml:id="chord-0000000088694271" dur="4">
-                    <note xml:id="note-0000001529755247" oct="4" pname="a"/>
-                    <note xml:id="note-0000000606316480" oct="5" pname="c"/>
-                    <note xml:id="note-0000001937427025" oct="5" pname="f"/>
+              <staff n="1">
+                <layer n="1">
+                  <chord dur="4" dots="0" dots.ges="1">
+                    <note dur="4" oct="5" pname="f">
+                      <supplied><dot/></supplied>
+                    </note>
+                    <note dur="4" oct="5" pname="c">
+                      <supplied><dot/></supplied>
+                    </note>
+                    <note dur="4" oct="4" pname="a">
+                      <supplied><dot/></supplied>
+                    </note>
                   </chord>
-                  <space xml:id="space-0000000194618509" dur="16"/>
-                  <space xml:id="space-0000000216764041" dur="16"/>
-                  <space xml:id="space-0000000670553220" dur="8"/>
+                  <supplied resp="#rettinghaus">
+                    <rest dur="8" dots="1" />
+                  </supplied>
                 </layer>
               </staff>
               <staff xml:id="staff-0000001465178070" n="2" facs="#facsZone-staff-0000001465178070">
@@ -577,9 +581,25 @@
               </harm>
             </measure>
             <measure xml:id="measure-0000000401264624" n="13">
-              <staff xml:id="staff-0000000986928062" n="1">
-                <layer xml:id="layer-0000000809109765" n="1">
-                  <mSpace/>
+              <staff n="1">
+                <layer n="1">
+                  <supplied resp="#rettinghaus">
+                    <beam>
+                      <note dur="16" oct="5" pname="f" />
+                      <note dur="16" oct="5" pname="e" accid.ges="f" />
+                      <note dur="16" oct="5" pname="e" accid.ges="f" />
+                    </beam>
+                    <beam>
+                      <note dur="16" oct="5" pname="f" />
+                      <note dur="16" oct="5" pname="d" />
+                      <note dur="16" oct="5" pname="d" />
+                    </beam>
+                    <beam>
+                      <note dur="16" oct="5" pname="f" />
+                      <note dur="16" oct="5" pname="c" />
+                      <note dur="16" oct="5" pname="c" />
+                    </beam>
+                  </supplied>
                 </layer>
               </staff>
               <staff xml:id="staff-0000000645481157" n="2" facs="#facsZone-staff-0000000645481157">
@@ -590,9 +610,18 @@
               </staff>
             </measure>
             <measure xml:id="measure-0000000157892179" n="14">
-              <staff xml:id="staff-0000000476697041" n="1">
-                <layer xml:id="layer-0000000463979027" n="1">
-                  <mSpace/>
+              <staff n="1">
+                <layer n="1">
+                  <supplied resp="#rettinghaus">
+                    <chord dur="4" dots="1">
+                      <note dur="4" oct="5" pname="e">
+                        <accid accid="n"/>
+                      </note>
+                      <note dur="4" oct="4" pname="b" accid.ges="f" />
+                      <note dur="4" oct="4" pname="g" />
+                    </chord>
+                    <rest dur="8" dots="1" />
+                  </supplied>
                 </layer>
               </staff>
               <staff xml:id="staff-0000002054422776" n="2" facs="#facsZone-staff-0000002054422776">

--- a/encodings/14/mattheson/music-example1.xml
+++ b/encodings/14/mattheson/music-example1.xml
@@ -4,7 +4,7 @@
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title></title>
+                <title>Prob-Stück 14, Example 1</title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -14,14 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
@@ -35,59 +37,57 @@
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure n="8" label="Achter Tact">
-                            <staff n="1" visible="true">
-                                <layer n="1">
-                                    <supplied resp="#pfeffer">
-                                        <space dur="8" />
-                                        <space dur="8" />
-                                        <space dur="8" />
-                                        <space dur="8" />
-                                        <space dur="8" />
-                                        <space dur="8" />
-                                    </supplied>
-                                    <beam>
-                                        <note xml:id="ex-1" dur="16" oct="4" pname="b" stem.dir="down" accid.ges="f" />
-                                        <note dur="16" oct="5" pname="g" stem.dir="down" accid.ges="f">
-                                            <accid accid="f" />
-                                        </note>
-                                        <note dur="16" oct="4" pname="b" stem.dir="down" accid.ges="f" />
-                                        <note dur="16" oct="5" pname="g" stem.dir="down" accid.ges="f" />
-                                        <note dur="16" oct="4" pname="b" stem.dir="down" accid.ges="f" />
-                                        <note dur="16" oct="5" pname="g" stem.dir="down" accid.ges="f" />
-                                    </beam>
-                                    <beam>
-                                        <note dur="16" oct="4" pname="a" stem.dir="down" accid.ges="f" />
-                                        <note dur="16" oct="5" pname="g" stem.dir="down" accid.ges="f" />
-                                        <note dur="16" oct="4" pname="a" stem.dir="down" accid.ges="f" />
-                                        <note dur="16" oct="5" pname="g" stem.dir="down" accid.ges="f" />
-                                        <note dur="16" oct="4" pname="a" stem.dir="down" accid.ges="f" />
-                                        <note dur="16" oct="5" pname="g" stem.dir="down" accid.ges="f" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                            <dir place="below" startid="#ex-1"><rend fontstyle="normal">Achter Tact</rend></dir>
-                        </measure>
-                        <measure n="9" label="Neuter Tact." right="invis">
+                        <measure corresp="#measure-0000002110347575" label="Achter Tact">
                             <staff n="1">
                                 <layer n="1">
-                                    <beam>
-                                        <note xml:id="ex-2" dur="16" oct="4" pname="a" stem.dir="down" accid.ges="f" />
-                                        <note dur="16" oct="5" pname="f" stem.dir="down" />
-                                        <note dur="16" oct="4" pname="a" stem.dir="down" accid.ges="f" />
-                                        <note dur="16" oct="5" pname="f" stem.dir="down" />
-                                        <note dur="16" oct="4" pname="a" stem.dir="down" accid.ges="f" />
-                                        <note dur="16" oct="5" pname="f" stem.dir="down" />
+                                    <beam place="below">
+                                        <note xml:id="ex-1" dur="16" oct="4" pname="b" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="g">
+                                            <accid accid="f" />
+                                        </note>
+                                        <note dur="16" oct="4" pname="b" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="g" accid.ges="f" />
+                                        <note dur="16" oct="4" pname="b" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="g" accid.ges="f" />
                                     </beam>
-                                    <space dur="8" />
-                                    <space dur="8" />
-                                    <space dur="8" />
-                                    <space dur="8" />
-                                    <space dur="8" />
-                                    <space dur="8" />
+                                    <beam place="below">
+                                        <note dur="16" oct="4" pname="a" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="g" accid.ges="f" />
+                                        <note dur="16" oct="4" pname="a" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="g" accid.ges="f" />
+                                        <note dur="16" oct="4" pname="a" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="g" accid.ges="f" />
+                                    </beam>
                                 </layer>
                             </staff>
-                            <dir place="below" startid="#ex-2"><rend fontstyle="normal">Neunter Tact.</rend></dir>
+                            <dir place="below" startid="#ex-1">
+                                <rend fontstyle="normal">Achter Tact</rend>
+                            </dir>
+                        </measure>
+                        <measure corresp="#measure-0000000003979548" label="Neuter Tact." right="invis" metcon="false">
+                            <staff n="1">
+                                <layer n="1">
+                                    <beam place="below">
+                                        <note xml:id="ex-2" dur="16" oct="4" pname="a" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="f" />
+                                        <note dur="16" oct="4" pname="a" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="f" />
+                                        <note dur="16" oct="4" pname="a" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="f" />
+                                    </beam>
+                                    <beam place="below">
+                                        <note dur="16" oct="4" pname="g" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="f" />
+                                        <note dur="16" oct="4" pname="g" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="f" />
+                                        <note dur="16" oct="4" pname="g" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="f" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <dir place="below" startid="#ex-2">
+                                <rend fontstyle="normal">Neunter Tact.</rend>
+                            </dir>
                         </measure>
                     </section>
                 </score>

--- a/encodings/14/mattheson/score.xml
+++ b/encodings/14/mattheson/score.xml
@@ -433,7 +433,10 @@
             <measure xml:id="measure-0000002110347575" n="8">
               <staff xml:id="staff-0000001801070812" n="1">
                 <layer xml:id="layer-0000001800056424" n="1">
-                  <space xml:id="space-0000001828046208" dur="2" dots="1"/>
+                  <supplied resp="#pfeffer">
+                      <space dur="4" dots="1" />
+                      <space dur="4" dots="1" />
+                  </supplied>
                   <beam>
                     <note xml:id="note-0000001879358786" dur="16" oct="4" pname="b" accid.ges="f"/>
                     <note xml:id="note-0000001341139309" dur="16" oct="5" pname="g">
@@ -483,16 +486,22 @@
             <measure xml:id="measure-0000000003979548" n="9">
               <staff xml:id="staff-0000000355872925" n="1">
                 <layer xml:id="layer-0000000890207321" n="1">
-                  <beam>
-                    <note xml:id="note-0000001464456062" dur="16" oct="4" pname="a" accid.ges="f"/>
-                    <note xml:id="note-0000000006209161" dur="16" oct="5" pname="f"/>
-                    <note xml:id="note-0000000772412964" dur="16" oct="4" pname="a" accid.ges="f"/>
-                    <note xml:id="note-0000001564104788" dur="16" oct="5" pname="f"/>
-                    <note xml:id="note-0000002064315460" dur="16" oct="4" pname="a" accid.ges="f"/>
-                    <note xml:id="note-0000000185923118" dur="16" oct="5" pname="f"/>
+                  <beam place="below">
+                      <note xml:id="ex-2" dur="16" oct="4" pname="a" accid.ges="f" />
+                      <note dur="16" oct="5" pname="f" />
+                      <note dur="16" oct="4" pname="a" accid.ges="f" />
+                      <note dur="16" oct="5" pname="f" />
+                      <note dur="16" oct="4" pname="a" accid.ges="f" />
+                      <note dur="16" oct="5" pname="f" />
                   </beam>
-                  <space xml:id="space-0000001935035009" dur="2"/>
-                  <space xml:id="space-0000000131276027" dur="4"/>
+                  <beam place="below">
+                      <note dur="16" oct="4" pname="g" accid.ges="f" />
+                      <note dur="16" oct="5" pname="f" />
+                      <note dur="16" oct="4" pname="g" accid.ges="f" />
+                      <note dur="16" oct="5" pname="f" />
+                      <note dur="16" oct="4" pname="g" accid.ges="f" />
+                      <note dur="16" oct="5" pname="f" />
+                  </beam>
                 </layer>
               </staff>
               <staff xml:id="staff-0000001092734230" n="2" facs="#facsZone-staff-0000001092734230">

--- a/encodings/18/mattheson/music-example1.xml
+++ b/encodings/18/mattheson/music-example1.xml
@@ -39,31 +39,35 @@
         <body>
             <mdiv>
                 <score>
-                    <scoreDef mnum.visible="false">
+                    <scoreDef key.pname="e" key.mode="major" midi.bpm="90" mnum.visible="false">
                         <staffGrp>
-                            <staffDef n="1" lines="5" label="Mattheson's annotations" clef.shape="G" clef.line="2" key.sig="4s" meter.unit="8" />
-                            <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.sig="4s" meter.unit="8" />
+                            <staffDef n="1" lines="5" clef.shape="C" clef.line="1" meter.unit="8">
+                                <keySig sig="4s" />
+                            </staffDef>
+                            <staffDef n="2" lines="5" clef.shape="F" clef.line="4" meter.unit="8">
+                                <keySig sig="4s" />
+                            </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure xml:id="measure-0000000068514885" n="84">
+                        <measure corresp="#measure-0000000068514885">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note xml:id="note-0000001032458662" dur="8" oct="5" pname="f" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000000032116147" dur="16" oct="5" pname="c" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000000587660240" dur="16" oct="5" pname="f" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000001216058078" dur="16" oct="5" pname="c" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000001020446849" dur="16" oct="5" pname="f" stem.dir="down" accid.ges="s" />
+                                        <note xml:id="ex-1032458662" dur="8" oct="5" pname="f" accid.ges="s" />
+                                        <note xml:id="ex-0032116147" dur="16" oct="5" pname="c" accid.ges="s" />
+                                        <note xml:id="ex-0587660240" dur="16" oct="5" pname="f" accid.ges="s" />
+                                        <note xml:id="ex-1216058078" dur="16" oct="5" pname="c" accid.ges="s" />
+                                        <note xml:id="ex-1020446849" dur="16" oct="5" pname="f" accid.ges="s" />
                                     </beam>
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <note xml:id="note-0000000615990694" dur="4" oct="3" pname="a" stem.dir="down">
+                                    <note xml:id="ex-0615990694" dur="4" oct="3" pname="a">
                                         <accid accid="s" />
                                     </note>
-                                    <rest xml:id="rest-0000000578191196" dur="8" />
+                                    <rest dur="8" oloc="3" ploc="a" />
                                 </layer>
                             </staff>
                             <harm place="above" staff="2" tstamp="1">
@@ -72,48 +76,48 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure xml:id="measure-0000001342814931" n="85">
+                        <measure corresp="measure-0000001342814931">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note xml:id="note-0000001008877041" dur="32" oct="5" pname="d" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000000502987528" dur="32" oct="4" pname="f" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000000213674679" dur="32" oct="4" pname="g" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000000669731228" dur="32" oct="4" pname="a" stem.dir="down" />
-                                        <note xml:id="note-0000000321651074" dur="32" oct="4" pname="b" stem.dir="down" />
-                                        <note xml:id="note-0000000429913132" dur="32" oct="5" pname="c" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000000279291270" dur="32" oct="5" pname="d" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000000131920451" dur="32" oct="5" pname="e" stem.dir="down" />
-                                        <note xml:id="note-0000001176776428" dur="32" oct="5" pname="f" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000001885233941" dur="32" oct="5" pname="g" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000000060088481" dur="32" oct="5" pname="a" stem.dir="down" />
-                                        <note xml:id="note-0000002036185473" dur="32" oct="5" pname="f" stem.dir="down" accid.ges="s" />
+                                        <note xml:id="ex-1008877041" dur="32" oct="5" pname="d" accid.ges="s" />
+                                        <note xml:id="ex-0502987528" dur="32" oct="4" pname="f" accid.ges="s" />
+                                        <note xml:id="ex-0213674679" dur="32" oct="4" pname="g" accid.ges="s" />
+                                        <note xml:id="ex-0669731228" dur="32" oct="4" pname="a" />
+                                        <note xml:id="ex-0321651074" dur="32" oct="4" pname="b" />
+                                        <note xml:id="ex-0429913132" dur="32" oct="5" pname="c" accid.ges="s" />
+                                        <note xml:id="ex-0279291270" dur="32" oct="5" pname="d" accid.ges="s" />
+                                        <note xml:id="ex-0131920451" dur="32" oct="5" pname="e" />
+                                        <note xml:id="ex-1176776428" dur="32" oct="5" pname="f" accid.ges="s" />
+                                        <note xml:id="ex-1885233941" dur="32" oct="5" pname="g" accid.ges="s" />
+                                        <note xml:id="ex-0060088481" dur="32" oct="5" pname="a" />
+                                        <note xml:id="ex-2036185473" dur="32" oct="5" pname="f" accid.ges="s" />
                                     </beam>
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <note xml:id="note-0000000991388010" dur="4" oct="3" pname="b" stem.dir="down" />
-                                    <rest xml:id="rest-0000001696270438" dur="8" />
+                                    <note xml:id="ex-0991388010" dur="4" oct="3" pname="b" />
+                                    <rest dur="8" oloc="3" ploc="a" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000000313220876" n="86">
+                        <measure corresp="#measure-0000000313220876">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note xml:id="note-0000000017063613" dur="8" oct="5" pname="b" stem.dir="down" />
-                                        <note xml:id="note-0000000304073069" dur="16" oct="5" pname="f" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000001927531305" dur="16" oct="5" pname="b" stem.dir="down" />
-                                        <note xml:id="note-0000001900862181" dur="16" oct="5" pname="f" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000002012533928" dur="16" oct="5" pname="b" stem.dir="down" />
+                                        <note xml:id="ex-0017063613" dur="8" oct="5" pname="b" />
+                                        <note xml:id="ex-0304073069" dur="16" oct="5" pname="f" accid.ges="s" />
+                                        <note xml:id="ex-1927531305" dur="16" oct="5" pname="b" />
+                                        <note xml:id="ex-1900862181" dur="16" oct="5" pname="f" accid.ges="s" />
+                                        <note xml:id="ex-2012533928" dur="16" oct="5" pname="b" />
                                     </beam>
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <note xml:id="note-0000001129677842" dur="4" oct="3" pname="d" stem.dir="down" accid.ges="s" />
-                                    <rest xml:id="rest-0000001556188989" dur="8" />
+                                    <note xml:id="ex-1129677842" dur="4" oct="3" pname="d" accid.ges="s" />
+                                    <rest dur="8" oloc="3" ploc="d" />
                                 </layer>
                             </staff>
                             <harm place="above" staff="2" tstamp="1">
@@ -122,41 +126,41 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure xml:id="measure-0000000836496999" n="87">
+                        <measure corresp="#measure-0000000836496999">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note xml:id="note-0000000370006282" dur="8" oct="5" pname="b" stem.dir="down" />
-                                        <note xml:id="note-0000001415068875" dur="16" oct="5" pname="g" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000002004886623" dur="16" oct="5" pname="b" stem.dir="down" />
-                                        <note xml:id="note-0000002001900975" dur="16" oct="5" pname="g" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000002098299217" dur="16" oct="5" pname="b" stem.dir="down" />
+                                        <note xml:id="ex-0370006282" dur="8" oct="5" pname="b" />
+                                        <note xml:id="ex-1415068875" dur="16" oct="5" pname="g" accid.ges="s" />
+                                        <note xml:id="ex-2004886623" dur="16" oct="5" pname="b" />
+                                        <note xml:id="ex-2001900975" dur="16" oct="5" pname="g" accid.ges="s" />
+                                        <note xml:id="ex-2098299217" dur="16" oct="5" pname="b" />
                                     </beam>
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <note xml:id="note-0000000302110439" dur="4" oct="3" pname="e" stem.dir="down" />
-                                    <rest xml:id="rest-0000000841171272" dur="8" />
+                                    <note xml:id="ex-0302110439" dur="4" oct="3" pname="e" />
+                                    <rest dur="8" oloc="3" ploc="d" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure xml:id="measure-0000001502822882" n="88">
-                            <staff n="1" visible="true">
+                        <measure corresp="#measure-0000001502822882">
+                            <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note xml:id="note-0000000553895053" dur="8" oct="5" pname="b" stem.dir="down" />
-                                        <note xml:id="note-0000001893451956" dur="16" oct="5" pname="f" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000001152106882" dur="16" oct="5" pname="b" stem.dir="down" />
-                                        <note xml:id="note-0000000832760578" dur="16" oct="5" pname="f" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000001070933084" dur="16" oct="5" pname="b" stem.dir="down" />
+                                        <note xml:id="ex-0553895053" dur="8" oct="5" pname="b" />
+                                        <note xml:id="ex-1893451956" dur="16" oct="5" pname="f" accid.ges="s" />
+                                        <note xml:id="ex-1152106882" dur="16" oct="5" pname="b" />
+                                        <note xml:id="ex-0832760578" dur="16" oct="5" pname="f" accid.ges="s" />
+                                        <note xml:id="ex-1070933084" dur="16" oct="5" pname="b" />
                                     </beam>
                                 </layer>
                             </staff>
-                            <staff n="2" visible="true">
+                            <staff n="2">
                                 <layer n="1">
-                                    <note xml:id="note-0000000810311922" dur="4" oct="3" pname="d" stem.dir="down" accid.ges="s" />
-                                    <rest xml:id="rest-0000000676206229" dur="8" />
+                                    <note xml:id="ex-0810311922" dur="4" oct="3" pname="d" accid.ges="s" />
+                                    <rest dur="8" oloc="3" ploc="d" />
                                 </layer>
                             </staff>
                             <harm place="above" staff="2" tstamp="1">
@@ -167,22 +171,22 @@
                         </measure>
                         <pb source="#firstEdition" n="203" />
                         <pb source="#secondEdition" n="409" />
-                        <measure xml:id="measure-0000000326648818" n="89">
+                        <measure corresp="#measure-0000000326648818">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note xml:id="note-0000001207085895" dur="8" oct="5" pname="b" stem.dir="down" />
-                                        <note xml:id="note-0000001052691334" dur="16" oct="5" pname="e" stem.dir="down" />
-                                        <note xml:id="note-0000000031151544" dur="16" oct="5" pname="b" stem.dir="down" />
-                                        <note xml:id="note-0000001550441857" dur="16" oct="5" pname="e" stem.dir="down" />
-                                        <note xml:id="note-0000001845194587" dur="16" oct="5" pname="b" stem.dir="down" />
+                                        <note xml:id="ex-1207085895" dur="8" oct="5" pname="b" />
+                                        <note xml:id="ex-1052691334" dur="16" oct="5" pname="e" />
+                                        <note xml:id="ex-0031151544" dur="16" oct="5" pname="b" />
+                                        <note xml:id="ex-1550441857" dur="16" oct="5" pname="e" />
+                                        <note xml:id="ex-1845194587" dur="16" oct="5" pname="b" />
                                     </beam>
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <note xml:id="note-0000000016315891" dur="4" oct="3" pname="c" stem.dir="up" accid.ges="s" />
-                                    <rest xml:id="rest-0000000020348568" dur="8" />
+                                    <note xml:id="ex-0016315891" dur="4" oct="3" pname="c" accid.ges="s" />
+                                    <rest dur="8" oloc="2" ploc="b" />
                                 </layer>
                             </staff>
                             <harm place="above" staff="2" tstamp="1">
@@ -191,24 +195,24 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure xml:id="measure-0000001667069604" n="90">
+                        <measure corresp="#measure-0000001667069604">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note xml:id="note-0000001965456835" dur="8" oct="5" pname="b" stem.dir="down" />
-                                        <note xml:id="note-0000000852707750" dur="16" oct="5" pname="d" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000002054507536" dur="16" oct="5" pname="b" stem.dir="down" />
-                                        <note xml:id="note-0000001315168870" dur="16" oct="5" pname="d" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000002017373996" dur="16" oct="5" pname="b" stem.dir="down" />
+                                        <note xml:id="ex-1965456835" dur="8" oct="5" pname="b" />
+                                        <note xml:id="ex-0852707750" dur="16" oct="5" pname="d" accid.ges="s" />
+                                        <note xml:id="ex-2054507536" dur="16" oct="5" pname="b" />
+                                        <note xml:id="ex-1315168870" dur="16" oct="5" pname="d" accid.ges="s" />
+                                        <note xml:id="ex-2017373996" dur="16" oct="5" pname="b" />
                                     </beam>
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
                                     <beam>
-                                        <note xml:id="note-0000001609754545" dur="8" oct="2" pname="b" stem.dir="up" />
-                                        <note xml:id="note-0000001182126025" dur="8" oct="3" pname="c" stem.dir="up" accid.ges="s" />
-                                        <note xml:id="note-0000001790428265" dur="8" oct="3" pname="d" stem.dir="up" accid.ges="s" />
+                                        <note xml:id="ex-1609754545" dur="8" oct="2" pname="b" />
+                                        <note xml:id="ex-1182126025" dur="8" oct="3" pname="c" accid.ges="s" />
+                                        <note xml:id="ex-1790428265" dur="8" oct="3" pname="d" accid.ges="s" />
                                     </beam>
                                 </layer>
                             </staff>
@@ -223,15 +227,15 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure xml:id="measure-0000001570199981" n="91">
+                        <measure corresp="#measure-0000001570199981">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note xml:id="note-0000000231453905" dur="8" oct="5" pname="b" stem.dir="down" />
-                                        <note xml:id="note-0000001425588143" dur="16" oct="5" pname="c" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000001820808890" dur="16" oct="5" pname="b" stem.dir="down" />
-                                        <note xml:id="note-0000000582826963" dur="16" oct="5" pname="c" stem.dir="down" accid.ges="s" />
-                                        <note xml:id="note-0000001542267604" dur="16" oct="5" pname="a" stem.dir="down">
+                                        <note xml:id="ex-0231453905" dur="8" oct="5" pname="b" />
+                                        <note xml:id="ex-1425588143" dur="16" oct="5" pname="c" accid.ges="s" />
+                                        <note xml:id="ex-1820808890" dur="16" oct="5" pname="b" />
+                                        <note xml:id="ex-0582826963" dur="16" oct="5" pname="c" accid.ges="s" />
+                                        <note xml:id="ex-1542267604" dur="16" oct="5" pname="a">
                                             <accid accid="s" />
                                         </note>
                                     </beam>
@@ -240,9 +244,9 @@
                             <staff n="2">
                                 <layer n="1">
                                     <beam>
-                                        <note xml:id="note-0000000832465483" dur="8" oct="3" pname="e" stem.dir="up" />
-                                        <note xml:id="note-0000001226665190" dur="8" oct="3" pname="f" stem.dir="up" accid.ges="s" />
-                                        <note xml:id="note-0000001454635477" dur="8" oct="2" pname="f" stem.dir="up" accid.ges="s" />
+                                        <note xml:id="ex-0832465483" dur="8" oct="3" pname="e" />
+                                        <note xml:id="ex-1226665190" dur="8" oct="3" pname="f" accid.ges="s" />
+                                        <note xml:id="ex-1454635477" dur="8" oct="2" pname="f" accid.ges="s" />
                                     </beam>
                                 </layer>
                             </staff>
@@ -260,19 +264,19 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <measure xml:id="measure-0000001020212109" n="92" right="end">
+                        <measure corresp="#measure-0000001020212109" right="end">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note xml:id="note-0000000867206699" dur="8" oct="5" pname="b" stem.dir="down" />
-                                        <note xml:id="note-0000000949643562" dur="8" oct="4" pname="b" stem.dir="down" />
+                                        <note xml:id="ex-0867206699" dur="8" oct="5" pname="b" />
+                                        <note xml:id="ex-0949643562" dur="8" oct="4" pname="b" />
                                     </beam>
-                                    <rest xml:id="rest-0000001085693272" dur="8" />
+                                    <rest dur="8" oloc="4" ploc="b" />
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <note xml:id="note-0000000042871459" dots="1" dur="4" oct="2" pname="b" stem.dir="up" />
+                                    <note xml:id="ex-0042871459" dots="1" dur="4" oct="2" pname="b" />
                                 </layer>
                             </staff>
                         </measure>

--- a/encodings/3/mattheson/music-example1.xml
+++ b/encodings/3/mattheson/music-example1.xml
@@ -15,15 +15,15 @@
                 </respStmt>
             </titleStmt>
             <pubStmt>
-              <respStmt>
-                  <persName role="publisher">Niels Pfeffer</persName>
-              </respStmt>
-              <date>2019</date>
-              <availability>
-                  <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
-                      <p>Creative Commons Attribution 4.0 International License</p>
-                  </useRestrict>
-              </availability>
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>

--- a/encodings/4/mattheson/music-example1.xml
+++ b/encodings/4/mattheson/music-example1.xml
@@ -14,14 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
@@ -54,13 +56,13 @@
                                     <note xml:id="ex-120" dur="4" dots="1" oct="4" pname="a" />
                                 </layer>
                                 <layer n="2">
-                                  <space dur="4" dots="1"/>
-                                  <chord dur="4" dots="1">
-                                      <note xml:id="ex-118" oct="4" pname="f" />
-                                      <note xml:id="ex-116" oct="4" pname="d" >
-                                          <accid accid="s" />
-                                      </note>
-                                  </chord>
+                                    <space dur="4" dots="1" />
+                                    <chord dur="4" dots="1">
+                                        <note xml:id="ex-118" oct="4" pname="f" />
+                                        <note xml:id="ex-116" oct="4" pname="d">
+                                            <accid accid="s" />
+                                        </note>
+                                    </chord>
                                 </layer>
                             </staff>
                         </measure>

--- a/encodings/4/mattheson/music-example2.xml
+++ b/encodings/4/mattheson/music-example2.xml
@@ -14,14 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
@@ -49,7 +51,7 @@
                                     <space xml:id="ex-365" dur="8" />
                                 </layer>
                                 <layer n="2">
-                                    <app>
+                                    <app resp="#rettinghaus">
                                         <lem source="#secondEdition">
                                             <rest dur="16" oloc="5" ploc="d" />
                                         </lem>
@@ -89,7 +91,7 @@
                                     <custos oct="4" pname="g" />
                                 </layer>
                             </staff>
-                            <app>
+                            <app resp="#rettinghaus">
                                 <lem source="#secondEdition">
                                     <bracketSpan func="analytical" startid="#ex-337" endid="#ex-343" lform="solid" />
                                     <bracketSpan func="analytical" startid="#ex-350" endid="#ex-356" lform="solid" />
@@ -97,8 +99,7 @@
                                         <bracketSpan func="analytical" startid="#ex-363" endid="#ex-369" lform="solid" />
                                     </supplied>
                                 </lem>
-                                <rdg source="#firstEdition">
-                                </rdg>
+                                <rdg source="#firstEdition"></rdg>
                             </app>
                         </measure>
                     </section>

--- a/encodings/4/mattheson/music-example3.xml
+++ b/encodings/4/mattheson/music-example3.xml
@@ -14,14 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
@@ -38,7 +40,7 @@
                         <measure corresp="#m-588" metcon="false" right="invis">
                             <staff n="1">
                                 <layer>
-                                    <app>
+                                    <app resp="#rettinghaus">
                                         <lem source="#secondEdition">
                                             <rest dur="16" oloc="5" ploc="b" />
                                         </lem>

--- a/encodings/4/mattheson/music-example4.xml
+++ b/encodings/4/mattheson/music-example4.xml
@@ -14,14 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>

--- a/encodings/4/mattheson/music-example5.xml
+++ b/encodings/4/mattheson/music-example5.xml
@@ -14,14 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>

--- a/encodings/6/mattheson/music-example1.xml
+++ b/encodings/6/mattheson/music-example1.xml
@@ -14,14 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>

--- a/encodings/6/mattheson/music-example2.xml
+++ b/encodings/6/mattheson/music-example2.xml
@@ -14,14 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
@@ -130,7 +132,7 @@
                                 </fb>
                             </harm>
                         </measure>
-                        <sb/>
+                        <sb />
                         <measure corresp="#m-1145">
                             <staff n="1">
                                 <layer>
@@ -192,8 +194,8 @@
                             <staff n="1">
                                 <layer>
                                     <chord dur="4" stem.dir="up">
-                                      <note oct="2" pname="d" />
-                                      <note oct="3" pname="d" />
+                                        <note oct="2" pname="d" />
+                                        <note oct="3" pname="d" />
                                     </chord>
                                     <rest dur="4" />
                                     <rest dur="4" />

--- a/encodings/9/mattheson/music-example1.xml
+++ b/encodings/9/mattheson/music-example1.xml
@@ -14,11 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>First draft, <date>2019</date></edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
@@ -71,7 +76,7 @@
                                         <note dur="4" oct="3" pname="d" />
                                         <rest dur="8" />
                                     </supplied>
-                                    <app>
+                                    <app resp="#rettinghaus">
                                         <lem source="#secondEdition">
                                             <note dur="8" oct="4" pname="d" />
                                             <beam>
@@ -93,9 +98,8 @@
                                     </app>
                                 </layer>
                             </staff>
-                            <app>
-                                <lem source="#secondEdtion">
-                                </lem>
+                            <app resp="#rettinghaus">
+                                <lem source="#secondEdtion"></lem>
                                 <rdg source="#firstEdition">
                                     <harm place="above" staff="2" tstamp="2.5">
                                         <fb>
@@ -220,7 +224,7 @@
                                     <beam>
                                         <note dur="8" oct="5" pname="f" />
                                         <note dur="16" oct="5" pname="a">
-                                            <accid accid="n" oloc="5" ploc="g"/>
+                                            <accid accid="n" oloc="5" ploc="g" />
                                         </note>
                                         <note dur="16" oct="5" pname="g" />
                                     </beam>
@@ -299,7 +303,7 @@
                                     <beam>
                                         <note dur="16" oct="4" pname="b" accid.ges="f" />
                                         <note dur="16" oct="5" pname="a">
-                                            <accid accid="n" oloc="5" ploc="g"/>
+                                            <accid accid="n" oloc="5" ploc="g" />
                                         </note>
                                         <note dur="16" oct="5" pname="g" />
                                         <note dur="16" oct="5" pname="f">

--- a/encodings/9/mattheson/music-example2.xml
+++ b/encodings/9/mattheson/music-example2.xml
@@ -14,14 +14,16 @@
                     <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
                 </respStmt>
             </titleStmt>
-            <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
-            </editionStmt>
             <pubStmt>
-                <unpub />
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
             </pubStmt>
         </fileDesc>
     </meiHead>
@@ -130,22 +132,22 @@
                                     <note dur="8" oct="3" pname="b" accid.ges="f" />
                                 </layer>
                             </staff>
-                            <app>
-                              <lem source="#secondEdition">
-                                  <harm place="above" staff="2" tstamp="1">
-                                      <fb>
-                                          <f>♭</f>
-                                      </fb>
-                                  </harm>
-                              </lem>
-                              <rdg source="#firstEdition">
-                                  <harm place="above" staff="2" tstamp="1">
-                                      <fb>
-                                          <f>7</f>
-                                          <f>♭</f>
-                                      </fb>
-                                  </harm>
-                              </rdg>
+                            <app resp="#rettinghaus">
+                                <lem source="#secondEdition">
+                                    <harm place="above" staff="2" tstamp="1">
+                                        <fb>
+                                            <f>♭</f>
+                                        </fb>
+                                    </harm>
+                                </lem>
+                                <rdg source="#firstEdition">
+                                    <harm place="above" staff="2" tstamp="1">
+                                        <fb>
+                                            <f>7</f>
+                                            <f>♭</f>
+                                        </fb>
+                                    </harm>
+                                </rdg>
                             </app>
                             <harm place="above" staff="2" tstamp="3">
                                 <fb>


### PR DESCRIPTION
This fixes and extends all examples up to PS 18, bringing in line all the headers.