### PR TITLE
Regularize accidental positioning in figured bass

### DIFF
--- a/encodings/1/mattheson/score.xml
+++ b/encodings/1/mattheson/score.xml
@@ -386,7 +386,14 @@
               </harm>
               <harm place="above" staff="2" startid="#m-161">
                 <fb>
-                  <f>♭6</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>6♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭6</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -788,7 +795,14 @@
                 <rdg source="#firstEdition">
                   <harm place="above" staff="2" startid="#m-373">
                     <fb>
-                      <f>♭5</f>
+                      <choice>
+                        <reg resp="#rettinghaus">
+                          <f>5♭</f>
+                        </reg>
+                        <orig>
+                          <f>♭5</f>
+                        </orig>
+                      </choice>
                     </fb>
                   </harm>
                 </rdg>
@@ -2402,7 +2416,14 @@
               </harm>
               <harm place="above" staff="2" startid="#m-1247">
                 <fb>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" startid="#m-1252">

--- a/encodings/10/mattheson/score.xml
+++ b/encodings/10/mattheson/score.xml
@@ -474,7 +474,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="1" xml:id="fb-09-01">
                 <fb>
-                  <f>♭6</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>6♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭6</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -683,7 +690,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="4" xml:id="fb-15-01">
                 <fb>
-                  <f>♭5</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭5</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -824,12 +838,26 @@
               </staff>
               <harm place="above" staff="2" tstamp="1" xml:id="fb-19-01">
                 <fb>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="4" xml:id="fb-19-02">
                 <fb>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -1560,7 +1588,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="4" xml:id="fb-38-02">
                 <fb>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -1926,7 +1961,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="5" xml:id="fb-47-02">
                 <fb>
-                  <f>♭6</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>6♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭6</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -2175,7 +2217,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="4" xml:id="fb-53-02">
                 <fb>
-                  <f>♭6</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>6♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭6</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -2432,7 +2481,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="1" xml:id="fb-60-01">
                 <fb>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="4" xml:id="fb-60-02">

--- a/encodings/11/mattheson/score.xml
+++ b/encodings/11/mattheson/score.xml
@@ -2840,7 +2840,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="1.0">
                 <fb>
-                  <f>♮2</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>2♮</f>
+                    </reg>
+                    <orig>
+                      <f>♮2</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="2.0">

--- a/encodings/12/mattheson/score.xml
+++ b/encodings/12/mattheson/score.xml
@@ -238,7 +238,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="1">
                 <fb>
-                  <f>♭5</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭5</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="2">
@@ -559,7 +566,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="1">
                 <fb>
-                  <f>♭5</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭5</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="4">
@@ -1504,7 +1518,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="2">
                 <fb>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                   <f>5</f>
                 </fb>
               </harm>
@@ -1515,7 +1536,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="4">
                 <fb>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                   <f>5</f>
                 </fb>
               </harm>

--- a/encodings/13/mattheson/score.xml
+++ b/encodings/13/mattheson/score.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://music-encoding.org/schema/4.0.1/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
   <meiHead>
@@ -74,79 +74,79 @@
     </facsimile>
     <facsimile decls="#secondEdition">
       <surface ulx="0" uly="0" lrx="1998" lry="2422" xml:id="facs-p456">
-        <graphic width="1998" height="2422" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/456"/>
-        <zone ulx="123" uly="314" lrx="903" lry="676" xml:id="facsZone-staff-0000001187236975"/>
-        <zone ulx="864" uly="341" lrx="1332" lry="655" xml:id="facsZone-staff-0000000729514545"/>
-        <zone ulx="1308" uly="335" lrx="1950" lry="661" xml:id="facsZone-staff-0000001042730708"/>
-        <zone ulx="132" uly="671" lrx="828" lry="1006" xml:id="facsZone-staff-0000002133324819"/>
-        <zone ulx="792" uly="683" lrx="1350" lry="1000" xml:id="facsZone-staff-0000001753886009"/>
-        <zone ulx="1305" uly="716" lrx="1950" lry="994" xml:id="facsZone-staff-0000001228301858"/>
-        <zone ulx="132" uly="1010" lrx="846" lry="1306" xml:id="facsZone-staff-0000000298501518"/>
-        <zone ulx="822" uly="1013" lrx="1365" lry="1294" xml:id="facsZone-staff-0000001087459487"/>
-        <zone ulx="1317" uly="1001" lrx="1950" lry="1291" xml:id="facsZone-staff-0000000884199577"/>
-        <zone ulx="132" uly="1331" lrx="720" lry="1603" xml:id="facsZone-staff-0000000164967432"/>
-        <zone ulx="687" uly="1358" lrx="864" lry="1603" xml:id="facsZone-staff-0000001612754645"/>
-        <zone ulx="837" uly="1337" lrx="1266" lry="1606" xml:id="facsZone-staff-0000001465178070"/>
-        <zone ulx="1233" uly="1349" lrx="1392" lry="1594" xml:id="facsZone-staff-0000000645481157"/>
-        <zone ulx="1371" uly="1322" lrx="1956" lry="1594" xml:id="facsZone-staff-0000002054422776"/>
-        <zone ulx="138" uly="1616" lrx="924" lry="1897" xml:id="facsZone-staff-0000000095272025"/>
-        <zone ulx="873" uly="1607" lrx="1376" lry="1897" xml:id="facsZone-staff-0000001663225224"/>
-        <zone ulx="1335" uly="1607" lrx="1950" lry="1879" xml:id="facsZone-staff-0000000154454955"/>
-        <zone ulx="141" uly="1910" lrx="726" lry="2224" xml:id="facsZone-staff-0000001205568531"/>
-        <zone ulx="687" uly="1952" lrx="969" lry="2236" xml:id="facsZone-staff-0000002146797807"/>
-        <zone ulx="933" uly="1937" lrx="1347" lry="2212" xml:id="facsZone-staff-0000000933404617"/>
-        <zone ulx="1314" uly="1934" lrx="1632" lry="2212" xml:id="facsZone-staff-0000001952892403"/>
-        <zone ulx="1590" uly="1916" lrx="1950" lry="2221" xml:id="facsZone-staff-0000000833770025"/>
+        <graphic width="1998" height="2422" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/456" />
+        <zone ulx="123" uly="314" lrx="903" lry="676" xml:id="facsZone-staff-0000001187236975" />
+        <zone ulx="864" uly="341" lrx="1332" lry="655" xml:id="facsZone-staff-0000000729514545" />
+        <zone ulx="1308" uly="335" lrx="1950" lry="661" xml:id="facsZone-staff-0000001042730708" />
+        <zone ulx="132" uly="671" lrx="828" lry="1006" xml:id="facsZone-staff-0000002133324819" />
+        <zone ulx="792" uly="683" lrx="1350" lry="1000" xml:id="facsZone-staff-0000001753886009" />
+        <zone ulx="1305" uly="716" lrx="1950" lry="994" xml:id="facsZone-staff-0000001228301858" />
+        <zone ulx="132" uly="1010" lrx="846" lry="1306" xml:id="facsZone-staff-0000000298501518" />
+        <zone ulx="822" uly="1013" lrx="1365" lry="1294" xml:id="facsZone-staff-0000001087459487" />
+        <zone ulx="1317" uly="1001" lrx="1950" lry="1291" xml:id="facsZone-staff-0000000884199577" />
+        <zone ulx="132" uly="1331" lrx="720" lry="1603" xml:id="facsZone-staff-0000000164967432" />
+        <zone ulx="687" uly="1358" lrx="864" lry="1603" xml:id="facsZone-staff-0000001612754645" />
+        <zone ulx="837" uly="1337" lrx="1266" lry="1606" xml:id="facsZone-staff-0000001465178070" />
+        <zone ulx="1233" uly="1349" lrx="1392" lry="1594" xml:id="facsZone-staff-0000000645481157" />
+        <zone ulx="1371" uly="1322" lrx="1956" lry="1594" xml:id="facsZone-staff-0000002054422776" />
+        <zone ulx="138" uly="1616" lrx="924" lry="1897" xml:id="facsZone-staff-0000000095272025" />
+        <zone ulx="873" uly="1607" lrx="1376" lry="1897" xml:id="facsZone-staff-0000001663225224" />
+        <zone ulx="1335" uly="1607" lrx="1950" lry="1879" xml:id="facsZone-staff-0000000154454955" />
+        <zone ulx="141" uly="1910" lrx="726" lry="2224" xml:id="facsZone-staff-0000001205568531" />
+        <zone ulx="687" uly="1952" lrx="969" lry="2236" xml:id="facsZone-staff-0000002146797807" />
+        <zone ulx="933" uly="1937" lrx="1347" lry="2212" xml:id="facsZone-staff-0000000933404617" />
+        <zone ulx="1314" uly="1934" lrx="1632" lry="2212" xml:id="facsZone-staff-0000001952892403" />
+        <zone ulx="1590" uly="1916" lrx="1950" lry="2221" xml:id="facsZone-staff-0000000833770025" />
       </surface>
       <surface ulx="0" uly="0" lrx="1998" lry="2428" xml:id="facs-p457">
-        <graphic width="1998" height="2428" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/457"/>
-        <zone ulx="54" uly="224" lrx="462" lry="496" xml:id="facsZone-staff-0000000989474965"/>
-        <zone ulx="435" uly="221" lrx="714" lry="499" xml:id="facsZone-staff-0000001493249073"/>
-        <zone ulx="678" uly="215" lrx="981" lry="508" xml:id="facsZone-staff-0000001434416158"/>
-        <zone ulx="948" uly="218" lrx="1236" lry="505" xml:id="facsZone-staff-0000001059459023"/>
-        <zone ulx="1191" uly="230" lrx="1503" lry="514" xml:id="facsZone-staff-0000001649131703"/>
-        <zone ulx="1482" uly="206" lrx="1884" lry="517" xml:id="facsZone-staff-0000001254952802"/>
-        <zone ulx="54" uly="482" lrx="513" lry="772" xml:id="facsZone-staff-0000001762430193"/>
-        <zone ulx="483" uly="518" lrx="729" lry="769" xml:id="facsZone-staff-0000001014442029"/>
-        <zone ulx="669" uly="515" lrx="1338" lry="811" xml:id="facsZone-staff-0000000553486794"/>
-        <zone ulx="1293" uly="533" lrx="1878" lry="811" xml:id="facsZone-staff-0000001417932063"/>
-        <zone ulx="33" uly="788" lrx="639" lry="1081" xml:id="facsZone-staff-0000001465239683"/>
-        <zone ulx="609" uly="818" lrx="1008" lry="1063" xml:id="facsZone-staff-0000002064800377"/>
-        <zone ulx="981" uly="794" lrx="1416" lry="1084" xml:id="facsZone-staff-0000000996720892"/>
-        <zone ulx="1383" uly="800" lrx="1884" lry="1087" xml:id="facsZone-staff-0000000403725705"/>
-        <zone ulx="48" uly="1079" lrx="657" lry="1396" xml:id="facsZone-staff-0000001720384706"/>
-        <zone ulx="621" uly="1100" lrx="1065" lry="1393" xml:id="facsZone-staff-0000000613511162"/>
-        <zone ulx="1032" uly="1091" lrx="1283" lry="1399" xml:id="facsZone-staff-0000000697785775"/>
-        <zone ulx="1257" uly="1094" lrx="1530" lry="1432" xml:id="facsZone-staff-0000001007695716"/>
-        <zone ulx="1506" uly="1097" lrx="1890" lry="1441" xml:id="facsZone-staff-0000001502070359"/>
-        <zone ulx="45" uly="1403" lrx="447" lry="1720" xml:id="facsZone-staff-0000001353862818"/>
-        <zone ulx="426" uly="1406" lrx="705" lry="1663" xml:id="facsZone-staff-0000000875885004"/>
-        <zone ulx="678" uly="1424" lrx="996" lry="1651" xml:id="facsZone-staff-0000000394889156"/>
-        <zone ulx="966" uly="1400" lrx="1248" lry="1687" xml:id="facsZone-staff-0000000374188136"/>
-        <zone ulx="1215" uly="1415" lrx="1518" lry="1687" xml:id="facsZone-staff-0000000420377805"/>
-        <zone ulx="1494" uly="1412" lrx="1884" lry="1690" xml:id="facsZone-staff-0000001828936528"/>
-        <zone ulx="45" uly="1688" lrx="588" lry="1954" xml:id="facsZone-staff-0000001551523357"/>
-        <zone ulx="564" uly="1676" lrx="963" lry="1945" xml:id="facsZone-staff-0000000568096570"/>
-        <zone ulx="930" uly="1631" lrx="1401" lry="1942" xml:id="facsZone-staff-0000002045395794"/>
-        <zone ulx="1374" uly="1670" lrx="1875" lry="1945" xml:id="facsZone-staff-0000000978579471"/>
-        <zone ulx="42" uly="1958" lrx="672" lry="2275" xml:id="facsZone-staff-0000000317349326"/>
-        <zone ulx="645" uly="1943" lrx="1053" lry="2269" xml:id="facsZone-staff-0000001513787909"/>
-        <zone ulx="1022" uly="1931" lrx="1520" lry="2245" xml:id="facsZone-staff-0000001213204359"/>
-        <zone ulx="1494" uly="1940" lrx="1875" lry="2248" xml:id="facsZone-staff-0000000976468647"/>
+        <graphic width="1998" height="2428" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/457" />
+        <zone ulx="54" uly="224" lrx="462" lry="496" xml:id="facsZone-staff-0000000989474965" />
+        <zone ulx="435" uly="221" lrx="714" lry="499" xml:id="facsZone-staff-0000001493249073" />
+        <zone ulx="678" uly="215" lrx="981" lry="508" xml:id="facsZone-staff-0000001434416158" />
+        <zone ulx="948" uly="218" lrx="1236" lry="505" xml:id="facsZone-staff-0000001059459023" />
+        <zone ulx="1191" uly="230" lrx="1503" lry="514" xml:id="facsZone-staff-0000001649131703" />
+        <zone ulx="1482" uly="206" lrx="1884" lry="517" xml:id="facsZone-staff-0000001254952802" />
+        <zone ulx="54" uly="482" lrx="513" lry="772" xml:id="facsZone-staff-0000001762430193" />
+        <zone ulx="483" uly="518" lrx="729" lry="769" xml:id="facsZone-staff-0000001014442029" />
+        <zone ulx="669" uly="515" lrx="1338" lry="811" xml:id="facsZone-staff-0000000553486794" />
+        <zone ulx="1293" uly="533" lrx="1878" lry="811" xml:id="facsZone-staff-0000001417932063" />
+        <zone ulx="33" uly="788" lrx="639" lry="1081" xml:id="facsZone-staff-0000001465239683" />
+        <zone ulx="609" uly="818" lrx="1008" lry="1063" xml:id="facsZone-staff-0000002064800377" />
+        <zone ulx="981" uly="794" lrx="1416" lry="1084" xml:id="facsZone-staff-0000000996720892" />
+        <zone ulx="1383" uly="800" lrx="1884" lry="1087" xml:id="facsZone-staff-0000000403725705" />
+        <zone ulx="48" uly="1079" lrx="657" lry="1396" xml:id="facsZone-staff-0000001720384706" />
+        <zone ulx="621" uly="1100" lrx="1065" lry="1393" xml:id="facsZone-staff-0000000613511162" />
+        <zone ulx="1032" uly="1091" lrx="1283" lry="1399" xml:id="facsZone-staff-0000000697785775" />
+        <zone ulx="1257" uly="1094" lrx="1530" lry="1432" xml:id="facsZone-staff-0000001007695716" />
+        <zone ulx="1506" uly="1097" lrx="1890" lry="1441" xml:id="facsZone-staff-0000001502070359" />
+        <zone ulx="45" uly="1403" lrx="447" lry="1720" xml:id="facsZone-staff-0000001353862818" />
+        <zone ulx="426" uly="1406" lrx="705" lry="1663" xml:id="facsZone-staff-0000000875885004" />
+        <zone ulx="678" uly="1424" lrx="996" lry="1651" xml:id="facsZone-staff-0000000394889156" />
+        <zone ulx="966" uly="1400" lrx="1248" lry="1687" xml:id="facsZone-staff-0000000374188136" />
+        <zone ulx="1215" uly="1415" lrx="1518" lry="1687" xml:id="facsZone-staff-0000000420377805" />
+        <zone ulx="1494" uly="1412" lrx="1884" lry="1690" xml:id="facsZone-staff-0000001828936528" />
+        <zone ulx="45" uly="1688" lrx="588" lry="1954" xml:id="facsZone-staff-0000001551523357" />
+        <zone ulx="564" uly="1676" lrx="963" lry="1945" xml:id="facsZone-staff-0000000568096570" />
+        <zone ulx="930" uly="1631" lrx="1401" lry="1942" xml:id="facsZone-staff-0000002045395794" />
+        <zone ulx="1374" uly="1670" lrx="1875" lry="1945" xml:id="facsZone-staff-0000000978579471" />
+        <zone ulx="42" uly="1958" lrx="672" lry="2275" xml:id="facsZone-staff-0000000317349326" />
+        <zone ulx="645" uly="1943" lrx="1053" lry="2269" xml:id="facsZone-staff-0000001513787909" />
+        <zone ulx="1022" uly="1931" lrx="1520" lry="2245" xml:id="facsZone-staff-0000001213204359" />
+        <zone ulx="1494" uly="1940" lrx="1875" lry="2248" xml:id="facsZone-staff-0000000976468647" />
       </surface>
       <surface ulx="0" uly="0" lrx="1998" lry="2419" xml:id="facs-p458">
-        <graphic width="1998" height="2419" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/458"/>
-        <zone ulx="114" uly="122" lrx="639" lry="400" xml:id="facsZone-staff-0000001543994193"/>
-        <zone ulx="612" uly="146" lrx="924" lry="394" xml:id="facsZone-staff-0000001094559103"/>
-        <zone ulx="897" uly="146" lrx="1371" lry="409" xml:id="facsZone-staff-0000001176830573"/>
-        <zone ulx="1344" uly="140" lrx="1950" lry="433" xml:id="facsZone-staff-0000000345144481"/>
-        <zone ulx="120" uly="389" lrx="687" lry="610" xml:id="facsZone-staff-0000001817517022"/>
-        <zone ulx="651" uly="374" lrx="1083" lry="634" xml:id="facsZone-staff-0000000589253176"/>
-        <zone ulx="1053" uly="389" lrx="1446" lry="649" xml:id="facsZone-staff-0000000468336033"/>
-        <zone ulx="1419" uly="392" lrx="1935" lry="670" xml:id="facsZone-staff-0000001691854142"/>
-        <zone ulx="123" uly="599" lrx="759" lry="901" xml:id="facsZone-staff-0000000516967649"/>
-        <zone ulx="726" uly="602" lrx="1245" lry="889" xml:id="facsZone-staff-0000000240521592"/>
-        <zone ulx="1203" uly="629" lrx="1647" lry="913" xml:id="facsZone-staff-0000002024245590"/>
+        <graphic width="1998" height="2419" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/458" />
+        <zone ulx="114" uly="122" lrx="639" lry="400" xml:id="facsZone-staff-0000001543994193" />
+        <zone ulx="612" uly="146" lrx="924" lry="394" xml:id="facsZone-staff-0000001094559103" />
+        <zone ulx="897" uly="146" lrx="1371" lry="409" xml:id="facsZone-staff-0000001176830573" />
+        <zone ulx="1344" uly="140" lrx="1950" lry="433" xml:id="facsZone-staff-0000000345144481" />
+        <zone ulx="120" uly="389" lrx="687" lry="610" xml:id="facsZone-staff-0000001817517022" />
+        <zone ulx="651" uly="374" lrx="1083" lry="634" xml:id="facsZone-staff-0000000589253176" />
+        <zone ulx="1053" uly="389" lrx="1446" lry="649" xml:id="facsZone-staff-0000000468336033" />
+        <zone ulx="1419" uly="392" lrx="1935" lry="670" xml:id="facsZone-staff-0000001691854142" />
+        <zone ulx="123" uly="599" lrx="759" lry="901" xml:id="facsZone-staff-0000000516967649" />
+        <zone ulx="726" uly="602" lrx="1245" lry="889" xml:id="facsZone-staff-0000000240521592" />
+        <zone ulx="1203" uly="629" lrx="1647" lry="913" xml:id="facsZone-staff-0000002024245590" />
       </surface>
     </facsimile>
     <body>
@@ -159,40 +159,40 @@
             <staffGrp>
               <staffDef type="embeddedAnnotation" clef.shape="C" clef.line="1" n="1" lines="5">
                 <label>Mattheson's annotations</label>
-                <keySig sig="2f"/>
-                <meterSig count="9" unit="16"/>
+                <keySig sig="2f" />
+                <meterSig count="9" unit="16" />
               </staffDef>
               <staffDef clef.shape="F" clef.line="4" n="2" lines="5">
-                <keySig sig="2f"/>
-                <meterSig count="9" unit="16"/>
+                <keySig sig="2f" />
+                <meterSig count="9" unit="16" />
               </staffDef>
             </staffGrp>
           </scoreDef>
           <section>
-            <pb n="372" source="#secondEdition" facs="#facs-p456"/>
-            <pb n="168" source="#firstEdition" facs="#facs-p384"/>
+            <pb n="372" source="#secondEdition" facs="#facs-p456" />
+            <pb n="168" source="#firstEdition" facs="#facs-p384" />
             <measure xml:id="measure-0000001329733354" n="1">
               <staff xml:id="staff-0000001029842644" n="1">
                 <layer xml:id="layer-0000001218265116" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001187236975" n="2" facs="#facsZone-staff-0000001187236975">
                 <layer xml:id="layer-0000000555932818" n="1">
                   <beam>
-                    <note xml:id="note-0000001326230254" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000001562532133" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001747737973" dur="16" oct="3" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000001326230254" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000001562532133" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001747737973" dur="16" oct="3" pname="b" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001613666461" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000001355942212" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000002779257" dur="16" oct="3" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000001613666461" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000001355942212" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000002779257" dur="16" oct="3" pname="b" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001361296094" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000001555611281" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000218866992" dur="16" oct="3" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000001361296094" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000001555611281" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000218866992" dur="16" oct="3" pname="b" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -201,60 +201,67 @@
             <measure xml:id="measure-0000001880145409" n="2">
               <staff xml:id="staff-0000000263804474" n="1">
                 <layer xml:id="layer-0000000625705221" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000729514545" n="2" facs="#facsZone-staff-0000000729514545">
                 <layer xml:id="layer-0000000168443720" n="1">
                   <beam>
-                    <note xml:id="note-0000000753277349" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000000218031968" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001349946707" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000000753277349" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000000218031968" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001349946707" dur="16" oct="4" pname="c" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001205946218" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000000026734294" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001789820126" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000001205946218" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000000026734294" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001789820126" dur="16" oct="4" pname="c" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000023487269" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000001844792511" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000000344423833" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000000023487269" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000001844792511" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000000344423833" dur="16" oct="4" pname="c" />
                   </beam>
                 </layer>
               </staff>
               <harm place="above" staff="2" tstamp="1">
                 <fb>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
             <measure xml:id="measure-0000001307314690" n="3">
               <staff xml:id="staff-0000001298606448" n="1">
                 <layer xml:id="layer-0000001804030290" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001042730708" n="2" facs="#facsZone-staff-0000001042730708">
                 <layer xml:id="layer-0000000636532489" n="1">
                   <beam>
-                    <note xml:id="note-0000000399371304" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000000271527456" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000001708470045" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000000399371304" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000000271527456" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000001708470045" dur="16" oct="4" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001969986868" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000000220915488" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000000503857972" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000001969986868" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000000220915488" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000000503857972" dur="16" oct="4" pname="d" />
                   </beam>
                   <beam>
                     <note xml:id="note-0000000745214601" dur="16" oct="4" pname="e" accid.ges="f">
                       <orig>
-                        <accid accid="f"/>
+                        <accid accid="f" />
                       </orig>
                     </note>
-                    <note xml:id="note-0000000303343504" dur="16" oct="4" pname="f"/>
-                    <note xml:id="note-0000001801763933" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000000303343504" dur="16" oct="4" pname="f" />
+                    <note xml:id="note-0000001801763933" dur="16" oct="4" pname="d" />
                   </beam>
                 </layer>
               </staff>
@@ -268,25 +275,25 @@
             <measure xml:id="measure-0000001052904491" n="4">
               <staff xml:id="staff-0000000554723499" n="1">
                 <layer xml:id="layer-0000000821492969" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000002133324819" n="2" facs="#facsZone-staff-0000002133324819">
                 <layer xml:id="layer-0000000454261842" n="1">
                   <beam>
-                    <note xml:id="note-0000001324940393" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001788766392" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000000574766855" dur="16" oct="3" pname="f"/>
+                    <note xml:id="note-0000001324940393" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001788766392" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000000574766855" dur="16" oct="3" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001493080793" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000000634347229" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000001492818575" dur="16" oct="3" pname="f"/>
+                    <note xml:id="note-0000001493080793" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000000634347229" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000001492818575" dur="16" oct="3" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000688314889" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000000349923557" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000000083158129" dur="16" oct="3" pname="f"/>
+                    <note xml:id="note-0000000688314889" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000000349923557" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000000083158129" dur="16" oct="3" pname="f" />
                   </beam>
                 </layer>
               </staff>
@@ -300,65 +307,72 @@
             <measure xml:id="measure-0000001800951868" n="5">
               <staff xml:id="staff-0000000753023921" n="1">
                 <layer xml:id="layer-0000000223964168" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001753886009" n="2" facs="#facsZone-staff-0000001753886009">
                 <layer xml:id="layer-0000001872086700" n="1">
                   <beam>
-                    <note xml:id="note-0000001588971579" dur="16" oct="3" pname="d"/>
-                    <note xml:id="note-0000000960722010" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000000765073715" dur="16" oct="3" pname="f"/>
+                    <note xml:id="note-0000001588971579" dur="16" oct="3" pname="d" />
+                    <note xml:id="note-0000000960722010" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000000765073715" dur="16" oct="3" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000265423881" dur="16" oct="2" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000002756677" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000001952730493" dur="16" oct="3" pname="f"/>
+                    <note xml:id="note-0000000265423881" dur="16" oct="2" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000002756677" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000001952730493" dur="16" oct="3" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001648382655" dur="16" oct="2" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000001648382655" dur="16" oct="2" pname="b" accid.ges="f" />
                     <note xml:id="note-0000001243374736" dur="16" oct="3" pname="a">
-                      <accid accid="f"/>
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="note-0000001757272755" dur="16" oct="3" pname="a" accid.ges="f"/>
+                    <note xml:id="note-0000001757272755" dur="16" oct="3" pname="a" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
               <harm place="above" staff="2" tstamp="1">
                 <fb>
                   <f>6</f>
-                  <f>♭5</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭5</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
             <measure xml:id="measure-0000001672252442" n="6">
               <staff xml:id="staff-0000000335719736" n="1">
                 <layer xml:id="layer-0000001179499129" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001228301858" n="2" facs="#facsZone-staff-0000001228301858">
                 <layer xml:id="layer-0000000481640772" n="1">
                   <beam>
-                    <note xml:id="note-0000000070547143" dur="16" oct="3" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000001451382132" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000001531961610" dur="16" oct="3" pname="g"/>
+                    <note xml:id="note-0000000070547143" dur="16" oct="3" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000001451382132" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000001531961610" dur="16" oct="3" pname="g" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001716166766" dur="16" oct="3" pname="c"/>
-                    <note xml:id="note-0000000002571368" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000001979170437" dur="16" oct="3" pname="g"/>
+                    <note xml:id="note-0000001716166766" dur="16" oct="3" pname="c" />
+                    <note xml:id="note-0000000002571368" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000001979170437" dur="16" oct="3" pname="g" />
                   </beam>
                   <beam>
                     <note xml:id="note-0000001443884011" dur="16" oct="2" pname="a">
                       <supplied resp="#pfeffer">
                         <reg>
-                          <accid accid="n" func="caution"/>
+                          <accid accid="n" func="caution" />
                         </reg>
                       </supplied>
                     </note>
-                    <note xml:id="note-0000001687326191" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000000586402621" dur="16" oct="3" pname="g"/>
+                    <note xml:id="note-0000001687326191" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000000586402621" dur="16" oct="3" pname="g" />
                   </beam>
                 </layer>
               </staff>
@@ -376,25 +390,25 @@
             <measure xml:id="measure-0000002094420549" n="7">
               <staff xml:id="staff-0000000215213593" n="1">
                 <layer xml:id="layer-0000000425262959" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000298501518" n="2" facs="#facsZone-staff-0000000298501518">
                 <layer xml:id="layer-0000001836274419" n="1">
                   <beam>
-                    <note xml:id="note-0000001815997370" dur="16" oct="2" pname="a"/>
-                    <note xml:id="note-0000001605616020" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000001870833693" dur="16" oct="3" pname="f"/>
+                    <note xml:id="note-0000001815997370" dur="16" oct="2" pname="a" />
+                    <note xml:id="note-0000001605616020" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000001870833693" dur="16" oct="3" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001678068056" dur="16" oct="2" pname="a"/>
-                    <note xml:id="note-0000002015797663" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000001400019928" dur="16" oct="3" pname="f"/>
+                    <note xml:id="note-0000001678068056" dur="16" oct="2" pname="a" />
+                    <note xml:id="note-0000002015797663" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000001400019928" dur="16" oct="3" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001316773707" dur="16" oct="2" pname="g"/>
-                    <note xml:id="note-0000001974207118" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000000630245241" dur="16" oct="3" pname="f"/>
+                    <note xml:id="note-0000001316773707" dur="16" oct="2" pname="g" />
+                    <note xml:id="note-0000001974207118" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000000630245241" dur="16" oct="3" pname="f" />
                   </beam>
                 </layer>
               </staff>
@@ -412,25 +426,25 @@
             <measure xml:id="measure-0000000845043698" n="8">
               <staff xml:id="staff-0000000431084790" n="1">
                 <layer xml:id="layer-0000000922540330" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001087459487" n="2" facs="#facsZone-staff-0000001087459487">
                 <layer xml:id="layer-0000000096390248" n="1">
                   <beam>
-                    <note xml:id="note-0000000390876975" dur="16" oct="2" pname="g"/>
-                    <note xml:id="note-0000001253293640" dur="16" oct="3" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000001468998604" dur="16" oct="3" pname="e" accid.ges="f"/>
+                    <note xml:id="note-0000000390876975" dur="16" oct="2" pname="g" />
+                    <note xml:id="note-0000001253293640" dur="16" oct="3" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000001468998604" dur="16" oct="3" pname="e" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001147505014" dur="16" oct="2" pname="g"/>
-                    <note xml:id="note-0000000663860490" dur="16" oct="3" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000000602033513" dur="16" oct="3" pname="e" accid.ges="f"/>
+                    <note xml:id="note-0000001147505014" dur="16" oct="2" pname="g" />
+                    <note xml:id="note-0000000663860490" dur="16" oct="3" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000000602033513" dur="16" oct="3" pname="e" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000613532599" dur="16" oct="2" pname="f"/>
-                    <note xml:id="note-0000000966506129" dur="16" oct="3" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000000704122777" dur="16" oct="3" pname="e" accid.ges="f"/>
+                    <note xml:id="note-0000000613532599" dur="16" oct="2" pname="f" />
+                    <note xml:id="note-0000000966506129" dur="16" oct="3" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000000704122777" dur="16" oct="3" pname="e" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -448,25 +462,25 @@
             <measure xml:id="measure-0000001014969737" n="9">
               <staff xml:id="staff-0000000581620582" n="1">
                 <layer xml:id="layer-0000001780050325" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000884199577" n="2" facs="#facsZone-staff-0000000884199577">
                 <layer xml:id="layer-0000001596109874" n="1">
                   <beam>
-                    <note xml:id="note-0000001411747744" dur="16" oct="2" pname="f"/>
-                    <note xml:id="note-0000001472453676" dur="16" oct="3" pname="d"/>
-                    <note xml:id="note-0000000996405682" dur="16" oct="3" pname="d"/>
+                    <note xml:id="note-0000001411747744" dur="16" oct="2" pname="f" />
+                    <note xml:id="note-0000001472453676" dur="16" oct="3" pname="d" />
+                    <note xml:id="note-0000000996405682" dur="16" oct="3" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001571492091" dur="16" oct="2" pname="f"/>
-                    <note xml:id="note-0000000002065036" dur="16" oct="3" pname="c"/>
-                    <note xml:id="note-0000000742716509" dur="16" oct="3" pname="c"/>
+                    <note xml:id="note-0000001571492091" dur="16" oct="2" pname="f" />
+                    <note xml:id="note-0000000002065036" dur="16" oct="3" pname="c" />
+                    <note xml:id="note-0000000742716509" dur="16" oct="3" pname="c" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001213940215" dur="16" oct="2" pname="f"/>
-                    <note xml:id="note-0000001218595890" dur="16" oct="3" pname="c"/>
-                    <note xml:id="note-0000000830326273" dur="16" oct="3" pname="c"/>
+                    <note xml:id="note-0000001213940215" dur="16" oct="2" pname="f" />
+                    <note xml:id="note-0000001218595890" dur="16" oct="3" pname="c" />
+                    <note xml:id="note-0000000830326273" dur="16" oct="3" pname="c" />
                   </beam>
                 </layer>
               </staff>
@@ -479,26 +493,26 @@
             <measure xml:id="measure-0000001874999834" n="10">
               <staff xml:id="staff-0000002016811673" n="1">
                 <layer xml:id="layer-0000002050012154" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000164967432" n="2" facs="#facsZone-staff-0000000164967432">
                 <layer xml:id="layer-0000000346625226" n="1">
-                  <clef xml:id="clef-0000001728549025" shape="C" line="3"/>
+                  <clef xml:id="clef-0000001728549025" shape="C" line="3" />
                   <beam>
-                    <note xml:id="note-0000000797230462" dur="16" oct="4" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001147428950" dur="16" oct="4" pname="a"/>
-                    <note xml:id="note-0000002052164569" dur="16" oct="4" pname="a"/>
+                    <note xml:id="note-0000000797230462" dur="16" oct="4" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001147428950" dur="16" oct="4" pname="a" />
+                    <note xml:id="note-0000002052164569" dur="16" oct="4" pname="a" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000681854671" dur="16" oct="4" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001303651037" dur="16" oct="4" pname="g"/>
-                    <note xml:id="note-0000001692392140" dur="16" oct="4" pname="g"/>
+                    <note xml:id="note-0000000681854671" dur="16" oct="4" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001303651037" dur="16" oct="4" pname="g" />
+                    <note xml:id="note-0000001692392140" dur="16" oct="4" pname="g" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000002116280329" dur="16" oct="4" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001567350568" dur="16" oct="4" pname="f"/>
-                    <note xml:id="note-0000001201891940" dur="16" oct="4" pname="f"/>
+                    <note xml:id="note-0000002116280329" dur="16" oct="4" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001567350568" dur="16" oct="4" pname="f" />
+                    <note xml:id="note-0000001201891940" dur="16" oct="4" pname="f" />
                   </beam>
                 </layer>
               </staff>
@@ -529,10 +543,10 @@
                 <layer xml:id="layer-0000000663499538" n="1">
                   <note xml:id="note-0000000898451013" dots="1" dur="4" oct="4" pname="e" accid.ges="f">
                     <orig>
-                      <accid accid="f"/>
+                      <accid accid="f" />
                     </orig>
                   </note>
-                  <rest xml:id="rest-0000001282774378" dots="1" dur="8"/>
+                  <rest xml:id="rest-0000001282774378" dots="1" dur="8" />
                 </layer>
               </staff>
             </measure>
@@ -541,13 +555,19 @@
                 <layer n="1">
                   <chord dur="4" dots="0" dots.ges="1">
                     <note dur="4" oct="5" pname="f">
-                      <supplied><dot/></supplied>
+                      <supplied>
+                        <dot />
+                      </supplied>
                     </note>
                     <note dur="4" oct="5" pname="c">
-                      <supplied><dot/></supplied>
+                      <supplied>
+                        <dot />
+                      </supplied>
                     </note>
                     <note dur="4" oct="4" pname="a">
-                      <supplied><dot/></supplied>
+                      <supplied>
+                        <dot />
+                      </supplied>
                     </note>
                   </chord>
                   <supplied resp="#rettinghaus">
@@ -558,19 +578,19 @@
               <staff xml:id="staff-0000001465178070" n="2" facs="#facsZone-staff-0000001465178070">
                 <layer xml:id="layer-0000000829990197" n="1">
                   <beam>
-                    <note xml:id="note-0000000726249132" dur="16" oct="4" pname="a"/>
-                    <note xml:id="note-0000001273344507" dur="16" oct="4" pname="g"/>
-                    <note xml:id="note-0000001670531043" dur="16" oct="4" pname="g"/>
+                    <note xml:id="note-0000000726249132" dur="16" oct="4" pname="a" />
+                    <note xml:id="note-0000001273344507" dur="16" oct="4" pname="g" />
+                    <note xml:id="note-0000001670531043" dur="16" oct="4" pname="g" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000002012910770" dur="16" oct="4" pname="a"/>
-                    <note xml:id="note-0000001136430227" dur="16" oct="4" pname="f"/>
-                    <note xml:id="note-0000001447339967" dur="16" oct="4" pname="f"/>
+                    <note xml:id="note-0000002012910770" dur="16" oct="4" pname="a" />
+                    <note xml:id="note-0000001136430227" dur="16" oct="4" pname="f" />
+                    <note xml:id="note-0000001447339967" dur="16" oct="4" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001300726281" dur="16" oct="4" pname="a"/>
-                    <note xml:id="note-0000000065103012" dur="16" oct="4" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000000217469273" dur="16" oct="4" pname="e" accid.ges="f"/>
+                    <note xml:id="note-0000001300726281" dur="16" oct="4" pname="a" />
+                    <note xml:id="note-0000000065103012" dur="16" oct="4" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000000217469273" dur="16" oct="4" pname="e" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -604,8 +624,8 @@
               </staff>
               <staff xml:id="staff-0000000645481157" n="2" facs="#facsZone-staff-0000000645481157">
                 <layer xml:id="layer-0000000384584196" n="1">
-                  <note xml:id="note-0000001993337031" dots="1" dur="4" oct="4" pname="d"/>
-                  <rest xml:id="rest-0000000803671878" dots="1" dur="8"/>
+                  <note xml:id="note-0000001993337031" dots="1" dur="4" oct="4" pname="d" />
+                  <rest xml:id="rest-0000000803671878" dots="1" dur="8" />
                 </layer>
               </staff>
             </measure>
@@ -615,7 +635,7 @@
                   <supplied resp="#rettinghaus">
                     <chord dur="4" dots="1">
                       <note dur="4" oct="5" pname="e">
-                        <accid accid="n"/>
+                        <accid accid="n" />
                       </note>
                       <note dur="4" oct="4" pname="b" accid.ges="f" />
                       <note dur="4" oct="4" pname="g" />
@@ -627,21 +647,21 @@
               <staff xml:id="staff-0000002054422776" n="2" facs="#facsZone-staff-0000002054422776">
                 <layer xml:id="layer-0000001133496462" n="1">
                   <beam>
-                    <note xml:id="note-0000000437031243" dur="16" oct="4" pname="g"/>
-                    <note xml:id="note-0000001846608484" dur="16" oct="4" pname="f"/>
-                    <note xml:id="note-0000000738277070" dur="16" oct="4" pname="f"/>
+                    <note xml:id="note-0000000437031243" dur="16" oct="4" pname="g" />
+                    <note xml:id="note-0000001846608484" dur="16" oct="4" pname="f" />
+                    <note xml:id="note-0000000738277070" dur="16" oct="4" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001608402005" dur="16" oct="4" pname="g"/>
+                    <note xml:id="note-0000001608402005" dur="16" oct="4" pname="g" />
                     <note xml:id="note-0000001844995144" dur="16" oct="4" pname="e">
-                      <accid accid="n"/>
+                      <accid accid="n" />
                     </note>
-                    <note xml:id="note-0000001006263501" dur="16" oct="4" pname="e"/>
+                    <note xml:id="note-0000001006263501" dur="16" oct="4" pname="e" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000688450809" dur="16" oct="4" pname="g"/>
-                    <note xml:id="note-0000000610798964" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000001762606478" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000000688450809" dur="16" oct="4" pname="g" />
+                    <note xml:id="note-0000000610798964" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000001762606478" dur="16" oct="4" pname="d" />
                   </beam>
                 </layer>
               </staff>
@@ -654,35 +674,35 @@
             <measure xml:id="measure-0000000201187720" n="15">
               <staff xml:id="staff-0000001259781258" n="1">
                 <layer xml:id="layer-0000000438375398" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000095272025" n="2" facs="#facsZone-staff-0000000095272025">
                 <layer xml:id="layer-0000000775784527" n="1">
                   <beam>
-                    <note xml:id="note-0000000926807446" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000000926807446" dur="16" oct="4" pname="c" />
                     <note xml:id="note-0000001672845834" dur="16" oct="4" pname="e">
-                      <accid accid="n"/>
+                      <accid accid="n" />
                     </note>
-                    <note xml:id="note-0000001865324289" dur="16" oct="4" pname="e"/>
+                    <note xml:id="note-0000001865324289" dur="16" oct="4" pname="e" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001678870645" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000001678870645" dur="16" oct="4" pname="c" />
                     <note xml:id="note-0000001350897614" dur="16" oct="4" pname="e">
                       <orig>
-                        <accid accid="n"/>
+                        <accid accid="n" />
                       </orig>
                     </note>
-                    <note xml:id="note-0000000675645511" dur="16" oct="4" pname="e"/>
+                    <note xml:id="note-0000000675645511" dur="16" oct="4" pname="e" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000425485175" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000000425485175" dur="16" oct="4" pname="c" />
                     <note xml:id="note-0000001569860444" dur="16" oct="4" pname="e">
                       <orig>
-                        <accid accid="n"/>
+                        <accid accid="n" />
                       </orig>
                     </note>
-                    <note xml:id="note-0000000415352684" dur="16" oct="4" pname="e"/>
+                    <note xml:id="note-0000000415352684" dur="16" oct="4" pname="e" />
                   </beam>
                 </layer>
               </staff>
@@ -690,25 +710,25 @@
             <measure xml:id="measure-0000000558018772" n="16">
               <staff xml:id="staff-0000000038166300" n="1">
                 <layer xml:id="layer-0000001999501527" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001663225224" n="2" facs="#facsZone-staff-0000001663225224">
                 <layer xml:id="layer-0000001893957183" n="1">
                   <beam>
-                    <note xml:id="note-0000002080699199" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001184796002" dur="16" oct="4" pname="f"/>
-                    <note xml:id="note-0000000590674405" dur="16" oct="4" pname="f"/>
+                    <note xml:id="note-0000002080699199" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001184796002" dur="16" oct="4" pname="f" />
+                    <note xml:id="note-0000000590674405" dur="16" oct="4" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001323531394" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000000448425721" dur="16" oct="4" pname="f"/>
-                    <note xml:id="note-0000000478351450" dur="16" oct="4" pname="f"/>
+                    <note xml:id="note-0000001323531394" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000000448425721" dur="16" oct="4" pname="f" />
+                    <note xml:id="note-0000000478351450" dur="16" oct="4" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000383298558" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001544732785" dur="16" oct="4" pname="f"/>
-                    <note xml:id="note-0000000231684023" dur="16" oct="4" pname="f"/>
+                    <note xml:id="note-0000000383298558" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001544732785" dur="16" oct="4" pname="f" />
+                    <note xml:id="note-0000000231684023" dur="16" oct="4" pname="f" />
                   </beam>
                 </layer>
               </staff>
@@ -716,25 +736,25 @@
             <measure xml:id="measure-0000001993175068" n="17">
               <staff xml:id="staff-0000000057562883" n="1">
                 <layer xml:id="layer-0000001268689367" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000154454955" n="2" facs="#facsZone-staff-0000000154454955">
                 <layer xml:id="layer-0000000457994250" n="1">
                   <beam>
-                    <note xml:id="note-0000001751719027" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001617369774" dur="16" oct="4" pname="g"/>
-                    <note xml:id="note-0000001824117971" dur="16" oct="4" pname="g"/>
+                    <note xml:id="note-0000001751719027" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001617369774" dur="16" oct="4" pname="g" />
+                    <note xml:id="note-0000001824117971" dur="16" oct="4" pname="g" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000672731819" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001744114470" dur="16" oct="4" pname="g"/>
-                    <note xml:id="note-0000001050775358" dur="16" oct="4" pname="g"/>
+                    <note xml:id="note-0000000672731819" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001744114470" dur="16" oct="4" pname="g" />
+                    <note xml:id="note-0000001050775358" dur="16" oct="4" pname="g" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000444619733" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001715151672" dur="16" oct="4" pname="g"/>
-                    <note xml:id="note-0000000160778422" dur="16" oct="4" pname="g"/>
+                    <note xml:id="note-0000000444619733" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001715151672" dur="16" oct="4" pname="g" />
+                    <note xml:id="note-0000000160778422" dur="16" oct="4" pname="g" />
                   </beam>
                 </layer>
               </staff>
@@ -747,27 +767,27 @@
             <measure xml:id="measure-0000002069318362" n="18">
               <staff xml:id="staff-0000002088408580" n="1">
                 <layer xml:id="layer-0000001895206704" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001205568531" n="2" facs="#facsZone-staff-0000001205568531">
                 <layer xml:id="layer-0000002049835744" n="1">
                   <beam>
-                    <note xml:id="note-0000000298791962" dur="16" oct="4" pname="f"/>
-                    <note xml:id="note-0000001573241543" dur="16" oct="4" pname="a"/>
-                    <note xml:id="note-0000000144255870" dur="16" oct="4" pname="a"/>
+                    <note xml:id="note-0000000298791962" dur="16" oct="4" pname="f" />
+                    <note xml:id="note-0000001573241543" dur="16" oct="4" pname="a" />
+                    <note xml:id="note-0000000144255870" dur="16" oct="4" pname="a" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001279627766" dur="16" oct="4" pname="f"/>
-                    <note xml:id="note-0000001195095352" dur="16" oct="4" pname="g"/>
-                    <note xml:id="note-0000001483967379" dur="16" oct="4" pname="g"/>
+                    <note xml:id="note-0000001279627766" dur="16" oct="4" pname="f" />
+                    <note xml:id="note-0000001195095352" dur="16" oct="4" pname="g" />
+                    <note xml:id="note-0000001483967379" dur="16" oct="4" pname="g" />
                   </beam>
                   <beam>
                     <note xml:id="note-0000000009585258" dur="16" oct="4" pname="e">
-                      <accid accid="n"/>
+                      <accid accid="n" />
                     </note>
-                    <note xml:id="note-0000000992194548" dur="16" oct="4" pname="g"/>
-                    <note xml:id="note-0000001138196268" dur="16" oct="4" pname="e"/>
+                    <note xml:id="note-0000000992194548" dur="16" oct="4" pname="g" />
+                    <note xml:id="note-0000001138196268" dur="16" oct="4" pname="e" />
                   </beam>
                 </layer>
               </staff>
@@ -787,15 +807,15 @@
             <measure xml:id="measure-0000000398572267" n="19">
               <staff xml:id="staff-0000002033932803" n="1">
                 <layer xml:id="layer-0000001152583148" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000002146797807" n="2" facs="#facsZone-staff-0000002146797807">
                 <layer xml:id="layer-0000000826678663" n="1">
                   <beam>
-                    <note xml:id="note-0000001302606000" dots="1" dur="8" oct="4" pname="f"/>
-                    <note xml:id="note-0000002100004876" dots="1" dur="8" oct="3" pname="a"/>
-                    <note xml:id="note-0000002062137656" dots="1" dur="8" oct="4" pname="f"/>
+                    <note xml:id="note-0000001302606000" dots="1" dur="8" oct="4" pname="f" />
+                    <note xml:id="note-0000002100004876" dots="1" dur="8" oct="3" pname="a" />
+                    <note xml:id="note-0000002062137656" dots="1" dur="8" oct="4" pname="f" />
                   </beam>
                 </layer>
               </staff>
@@ -808,16 +828,16 @@
             <measure xml:id="measure-0000001900745793" n="20">
               <staff xml:id="staff-0000001544168375" n="1">
                 <layer xml:id="layer-0000001570457005" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000933404617" n="2" facs="#facsZone-staff-0000000933404617">
                 <layer xml:id="layer-0000001891623984" n="1">
-                  <clef xml:id="clef-0000001940010594" shape="F" line="4"/>
+                  <clef xml:id="clef-0000001940010594" shape="F" line="4" />
                   <beam>
-                    <note xml:id="note-0000000170883754" dots="1" dur="8" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000689536351" dots="1" dur="8" oct="2" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000348537188" dots="1" dur="8" oct="3" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000000170883754" dots="1" dur="8" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000689536351" dots="1" dur="8" oct="2" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000348537188" dots="1" dur="8" oct="3" pname="b" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -825,17 +845,17 @@
             <measure xml:id="measure-0000001575829327" n="21">
               <staff xml:id="staff-0000001878650351" n="1">
                 <layer xml:id="layer-0000001595732936" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001952892403" n="2" facs="#facsZone-staff-0000001952892403">
                 <layer xml:id="layer-0000000382168197" n="1">
                   <beam>
-                    <note xml:id="note-0000001454486603" dots="1" dur="8" oct="3" pname="g"/>
+                    <note xml:id="note-0000001454486603" dots="1" dur="8" oct="3" pname="g" />
                     <note xml:id="note-0000001471194061" dots="1" dur="8" oct="2" pname="b">
-                      <accid accid="n"/>
+                      <accid accid="n" />
                     </note>
-                    <note xml:id="note-0000000061778323" dots="1" dur="8" oct="3" pname="g"/>
+                    <note xml:id="note-0000000061778323" dots="1" dur="8" oct="3" pname="g" />
                   </beam>
                 </layer>
               </staff>
@@ -853,15 +873,15 @@
             <measure xml:id="measure-0000001918951321" n="22">
               <staff xml:id="staff-0000001975740009" n="1">
                 <layer xml:id="layer-0000001592855383" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000833770025" n="2" facs="#facsZone-staff-0000000833770025">
                 <layer xml:id="layer-0000000082419427" n="1">
                   <beam>
-                    <note xml:id="note-0000000371915841" dots="1" dur="8" oct="4" pname="c"/>
-                    <note xml:id="note-0000001185019994" dots="1" dur="8" oct="3" pname="c"/>
-                    <note xml:id="note-0000002086494668" dots="1" dur="8" oct="4" pname="c"/>
+                    <note xml:id="note-0000000371915841" dots="1" dur="8" oct="4" pname="c" />
+                    <note xml:id="note-0000001185019994" dots="1" dur="8" oct="3" pname="c" />
+                    <note xml:id="note-0000002086494668" dots="1" dur="8" oct="4" pname="c" />
                   </beam>
                 </layer>
               </staff>
@@ -872,19 +892,19 @@
               </harm>
             </measure>
             <measure xml:id="measure-0000001125131244" n="23">
-              <pb n="373" source="#secondEdition" facs="#facs-p457"/>
-              <pb n="169" source="#firstEdition" facs="#facs-p385"/>
+              <pb n="373" source="#secondEdition" facs="#facs-p457" />
+              <pb n="169" source="#firstEdition" facs="#facs-p385" />
               <staff xml:id="staff-0000000421142581" n="1">
                 <layer xml:id="layer-0000001911423132" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000989474965" n="2" facs="#facsZone-staff-0000000989474965">
                 <layer xml:id="layer-0000000298126040" n="1">
                   <beam>
-                    <note xml:id="note-0000001204393054" dots="1" dur="8" oct="3" pname="a"/>
-                    <note xml:id="note-0000000110474036" dots="1" dur="8" oct="3" pname="f"/>
-                    <note xml:id="note-0000000537562665" dots="1" dur="8" oct="3" pname="a"/>
+                    <note xml:id="note-0000001204393054" dots="1" dur="8" oct="3" pname="a" />
+                    <note xml:id="note-0000000110474036" dots="1" dur="8" oct="3" pname="f" />
+                    <note xml:id="note-0000000537562665" dots="1" dur="8" oct="3" pname="a" />
                   </beam>
                 </layer>
               </staff>
@@ -897,15 +917,15 @@
             <measure xml:id="measure-0000001952800919" n="24">
               <staff xml:id="staff-0000001042553524" n="1">
                 <layer xml:id="layer-0000000851581840" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001493249073" n="2" facs="#facsZone-staff-0000001493249073">
                 <layer xml:id="layer-0000000003440798" n="1">
                   <beam>
-                    <note xml:id="note-0000000197200429" dots="1" dur="8" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000002010232986" dots="1" dur="8" oct="3" pname="g"/>
-                    <note xml:id="note-0000000358839287" dots="1" dur="8" oct="3" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000000197200429" dots="1" dur="8" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000002010232986" dots="1" dur="8" oct="3" pname="g" />
+                    <note xml:id="note-0000000358839287" dots="1" dur="8" oct="3" pname="b" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -919,15 +939,15 @@
             <measure xml:id="measure-0000001265592404" n="25">
               <staff xml:id="staff-0000001901220184" n="1">
                 <layer xml:id="layer-0000002070187590" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001434416158" n="2" facs="#facsZone-staff-0000001434416158">
                 <layer xml:id="layer-0000001556611374" n="1">
                   <beam>
-                    <note xml:id="note-0000000928245561" dots="1" dur="8" oct="4" pname="c"/>
-                    <note xml:id="note-0000001852043148" dots="1" dur="8" oct="3" pname="a"/>
-                    <note xml:id="note-0000001693310061" dots="1" dur="8" oct="4" pname="c"/>
+                    <note xml:id="note-0000000928245561" dots="1" dur="8" oct="4" pname="c" />
+                    <note xml:id="note-0000001852043148" dots="1" dur="8" oct="3" pname="a" />
+                    <note xml:id="note-0000001693310061" dots="1" dur="8" oct="4" pname="c" />
                   </beam>
                 </layer>
               </staff>
@@ -935,15 +955,15 @@
             <measure xml:id="measure-0000001673900654" n="26">
               <staff xml:id="staff-0000001687876181" n="1">
                 <layer xml:id="layer-0000001616294278" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001059459023" n="2" facs="#facsZone-staff-0000001059459023">
                 <layer xml:id="layer-0000000522554602" n="1">
                   <beam>
-                    <note xml:id="note-0000001180293901" dots="1" dur="8" oct="4" pname="d"/>
-                    <note xml:id="note-0000000368268809" dots="1" dur="8" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001418902701" dots="1" dur="8" oct="4" pname="d"/>
+                    <note xml:id="note-0000001180293901" dots="1" dur="8" oct="4" pname="d" />
+                    <note xml:id="note-0000000368268809" dots="1" dur="8" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001418902701" dots="1" dur="8" oct="4" pname="d" />
                   </beam>
                 </layer>
               </staff>
@@ -956,15 +976,15 @@
             <measure xml:id="measure-0000000737957088" n="27">
               <staff xml:id="staff-0000000355394647" n="1">
                 <layer xml:id="layer-0000001209210011" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001649131703" n="2" facs="#facsZone-staff-0000001649131703">
                 <layer xml:id="layer-0000000088739758" n="1">
                   <beam>
-                    <note xml:id="note-0000001405300593" dots="1" dur="8" oct="3" pname="a"/>
-                    <note xml:id="note-0000000334762852" dots="1" dur="8" oct="3" pname="f"/>
-                    <note xml:id="note-0000001345406591" dots="1" dur="8" oct="3" pname="a"/>
+                    <note xml:id="note-0000001405300593" dots="1" dur="8" oct="3" pname="a" />
+                    <note xml:id="note-0000000334762852" dots="1" dur="8" oct="3" pname="f" />
+                    <note xml:id="note-0000001345406591" dots="1" dur="8" oct="3" pname="a" />
                   </beam>
                 </layer>
               </staff>
@@ -977,15 +997,15 @@
             <measure xml:id="measure-0000000212373561" n="28">
               <staff xml:id="staff-0000001120858223" n="1">
                 <layer xml:id="layer-0000000668179275" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001254952802" n="2" facs="#facsZone-staff-0000001254952802">
                 <layer xml:id="layer-0000000832322924" n="1">
                   <beam>
-                    <note xml:id="note-0000001977749713" dots="1" dur="8" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000002099501593" dots="1" dur="8" oct="3" pname="g"/>
-                    <note xml:id="note-0000000079436391" dots="1" dur="8" oct="3" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000001977749713" dots="1" dur="8" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000002099501593" dots="1" dur="8" oct="3" pname="g" />
+                    <note xml:id="note-0000000079436391" dots="1" dur="8" oct="3" pname="b" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -999,15 +1019,15 @@
             <measure xml:id="measure-0000001382748932" n="29">
               <staff xml:id="staff-0000001133586424" n="1">
                 <layer xml:id="layer-0000001340068011" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001762430193" n="2" facs="#facsZone-staff-0000001762430193">
                 <layer xml:id="layer-0000002066597062" n="1">
                   <beam>
-                    <note xml:id="note-0000001943240779" dots="1" dur="8" oct="4" pname="c"/>
-                    <note xml:id="note-0000001630517571" dots="1" dur="8" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001785226977" dots="1" dur="8" oct="4" pname="c"/>
+                    <note xml:id="note-0000001943240779" dots="1" dur="8" oct="4" pname="c" />
+                    <note xml:id="note-0000001630517571" dots="1" dur="8" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001785226977" dots="1" dur="8" oct="4" pname="c" />
                   </beam>
                 </layer>
               </staff>
@@ -1026,44 +1046,44 @@
             <measure xml:id="measure-0000000135352827" right="rptend" n="30">
               <staff xml:id="staff-0000000065728892" n="1">
                 <layer xml:id="layer-0000000640109848" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001014442029" n="2" facs="#facsZone-staff-0000001014442029">
                 <layer xml:id="layer-0000001986678090" n="1">
-                  <note xml:id="note-0000000342988351" dots="1" dur="4" oct="3" pname="f"/>
-                  <note xml:id="note-0000001742548691" dots="1" dur="8" oct="3" pname="f"/>
+                  <note xml:id="note-0000000342988351" dots="1" dur="4" oct="3" pname="f" />
+                  <note xml:id="note-0000001742548691" dots="1" dur="8" oct="3" pname="f" />
                 </layer>
               </staff>
-              <tie xml:id="tie-0000000052058316" startid="#note-0000000342988351" endid="#note-0000001742548691"/>
+              <tie xml:id="tie-0000000052058316" startid="#note-0000000342988351" endid="#note-0000001742548691" />
             </measure>
           </section>
           <section>
             <measure xml:id="measure-0000000130901804" left="rptstart" n="31">
               <staff xml:id="staff-0000000238153064" n="1">
                 <layer xml:id="layer-0000000659701381" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000553486794" n="2" facs="#facsZone-staff-0000000553486794">
                 <layer xml:id="layer-0000002089404158" n="1">
-                  <clef shape="C" line="4"/>
+                  <clef shape="C" line="4" />
                   <beam>
                     <note xml:id="note-0000001725328275" dur="16" oct="3" pname="f">
-                      <accid accid="s"/>
+                      <accid accid="s" />
                     </note>
-                    <note xml:id="note-0000001800118747" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000001360821314" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000001800118747" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000001360821314" dur="16" oct="4" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001333641427" dur="16" oct="3" pname="f" accid.ges="s"/>
-                    <note xml:id="note-0000000384783933" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000000367853414" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000001333641427" dur="16" oct="3" pname="f" accid.ges="s" />
+                    <note xml:id="note-0000000384783933" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000000367853414" dur="16" oct="4" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001891682129" dur="16" oct="3" pname="f" accid.ges="s"/>
-                    <note xml:id="note-0000001771401348" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000000450068791" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000001891682129" dur="16" oct="3" pname="f" accid.ges="s" />
+                    <note xml:id="note-0000001771401348" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000000450068791" dur="16" oct="4" pname="d" />
                   </beam>
                 </layer>
               </staff>
@@ -1076,25 +1096,25 @@
             <measure xml:id="measure-0000000302622192" n="32">
               <staff xml:id="staff-0000001652635507" n="1">
                 <layer xml:id="layer-0000000794161445" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001417932063" n="2" facs="#facsZone-staff-0000001417932063">
                 <layer xml:id="layer-0000000974213574" n="1">
                   <beam>
-                    <note xml:id="note-0000002136584230" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000000338069091" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000001760461625" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000002136584230" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000000338069091" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000001760461625" dur="16" oct="4" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000016002432" dur="16" oct="3" pname="a"/>
-                    <note xml:id="note-0000001057707394" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000001317036300" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000000016002432" dur="16" oct="3" pname="a" />
+                    <note xml:id="note-0000001057707394" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000001317036300" dur="16" oct="4" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001841571355" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001876195137" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000000058799109" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000001841571355" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001876195137" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000000058799109" dur="16" oct="4" pname="d" />
                   </beam>
                 </layer>
               </staff>
@@ -1102,27 +1122,27 @@
             <measure xml:id="measure-0000000812775626" n="33">
               <staff xml:id="staff-0000000939815122" n="1">
                 <layer xml:id="layer-0000001015086205" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001465239683" n="2" facs="#facsZone-staff-0000001465239683">
                 <layer xml:id="layer-0000000114755087" n="1">
                   <beam>
                     <note xml:id="note-0000000448303982" dur="16" oct="3" pname="f">
-                      <accid accid="s"/>
+                      <accid accid="s" />
                     </note>
-                    <note xml:id="note-0000001666807676" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000001860353277" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000001666807676" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000001860353277" dur="16" oct="4" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001627112500" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000001477139609" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000001025653595" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000001627112500" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000001477139609" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000001025653595" dur="16" oct="4" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000742706476" dur="16" oct="3" pname="a"/>
-                    <note xml:id="note-0000001343748726" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000000167004815" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000000742706476" dur="16" oct="3" pname="a" />
+                    <note xml:id="note-0000001343748726" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000000167004815" dur="16" oct="4" pname="d" />
                   </beam>
                 </layer>
               </staff>
@@ -1135,25 +1155,25 @@
             <measure xml:id="measure-0000000504835033" n="34">
               <staff xml:id="staff-0000000292106562" n="1">
                 <layer xml:id="layer-0000001238796575" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000002064800377" n="2" facs="#facsZone-staff-0000002064800377">
                 <layer xml:id="layer-0000000764913299" n="1">
                   <beam>
-                    <note xml:id="note-0000000463160159" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000001778457752" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000001659835057" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000000463160159" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000001778457752" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000001659835057" dur="16" oct="4" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001453503377" dur="16" oct="3" pname="a"/>
-                    <note xml:id="note-0000000962752448" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000001607318697" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000001453503377" dur="16" oct="3" pname="a" />
+                    <note xml:id="note-0000000962752448" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000001607318697" dur="16" oct="4" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000537555378" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001551398789" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000000321658256" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000000537555378" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001551398789" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000000321658256" dur="16" oct="4" pname="d" />
                   </beam>
                 </layer>
               </staff>
@@ -1166,65 +1186,72 @@
             <measure xml:id="measure-0000001306537453" n="35">
               <staff xml:id="staff-0000001887260753" n="1">
                 <layer xml:id="layer-0000000196770770" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000996720892" n="2" facs="#facsZone-staff-0000000996720892">
                 <layer xml:id="layer-0000000988527133" n="1">
                   <beam>
                     <note xml:id="note-0000001270148842" dur="16" oct="3" pname="b">
-                      <accid accid="n"/>
+                      <accid accid="n" />
                     </note>
-                    <note xml:id="note-0000001753951040" dur="16" oct="4" pname="g"/>
-                    <note xml:id="note-0000001360666320" dur="16" oct="4" pname="g"/>
+                    <note xml:id="note-0000001753951040" dur="16" oct="4" pname="g" />
+                    <note xml:id="note-0000001360666320" dur="16" oct="4" pname="g" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000060193405" dur="16" oct="3" pname="b"/>
-                    <note xml:id="note-0000000797447342" dur="16" oct="4" pname="g"/>
-                    <note xml:id="note-0000001111859463" dur="16" oct="4" pname="g"/>
+                    <note xml:id="note-0000000060193405" dur="16" oct="3" pname="b" />
+                    <note xml:id="note-0000000797447342" dur="16" oct="4" pname="g" />
+                    <note xml:id="note-0000001111859463" dur="16" oct="4" pname="g" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000952609785" dur="16" oct="3" pname="b"/>
-                    <note xml:id="note-0000001442200452" dur="16" oct="4" pname="f"/>
-                    <note xml:id="note-0000000150008519" dur="16" oct="4" pname="f"/>
+                    <note xml:id="note-0000000952609785" dur="16" oct="3" pname="b" />
+                    <note xml:id="note-0000001442200452" dur="16" oct="4" pname="f" />
+                    <note xml:id="note-0000000150008519" dur="16" oct="4" pname="f" />
                   </beam>
                 </layer>
               </staff>
               <harm place="above" staff="2" tstamp="1">
                 <fb>
                   <f>6</f>
-                  <f>♭5</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭5</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
             <measure xml:id="measure-0000000267547746" n="36">
               <staff xml:id="staff-0000000770418179" n="1">
                 <layer xml:id="layer-0000001787111610" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000403725705" n="2" facs="#facsZone-staff-0000000403725705">
                 <layer xml:id="layer-0000002120504386" n="1">
                   <beam>
-                    <note xml:id="note-0000000923595185" dur="16" oct="4" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000001646534183" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000000387615656" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000000923595185" dur="16" oct="4" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000001646534183" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000000387615656" dur="16" oct="4" pname="c" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000124123485" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000000124123485" dur="16" oct="4" pname="d" />
                     <note xml:id="note-0000000284556096" dur="16" oct="3" pname="b">
                       <supplied resp="#pfeffer">
                         <reg>
-                          <accid accid="f" func="caution"/>
+                          <accid accid="f" func="caution" />
                         </reg>
                       </supplied>
                     </note>
-                    <note xml:id="note-0000000695949989" dur="16" oct="3" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000000695949989" dur="16" oct="3" pname="b" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000970364303" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000000689331577" dur="16" oct="3" pname="a"/>
-                    <note xml:id="note-0000000060047248" dur="16" oct="3" pname="a"/>
+                    <note xml:id="note-0000000970364303" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000000689331577" dur="16" oct="3" pname="a" />
+                    <note xml:id="note-0000000060047248" dur="16" oct="3" pname="a" />
                   </beam>
                 </layer>
               </staff>
@@ -1250,25 +1277,25 @@
             <measure xml:id="measure-0000000994418442" n="37">
               <staff xml:id="staff-0000001037512003" n="1">
                 <layer xml:id="layer-0000000281024568" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001720384706" n="2" facs="#facsZone-staff-0000001720384706">
                 <layer xml:id="layer-0000000494011427" n="1">
                   <beam>
-                    <note xml:id="note-0000001412776455" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000002105762144" dur="16" oct="3" pname="d"/>
-                    <note xml:id="note-0000000630556266" dur="16" oct="3" pname="d"/>
+                    <note xml:id="note-0000001412776455" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000002105762144" dur="16" oct="3" pname="d" />
+                    <note xml:id="note-0000000630556266" dur="16" oct="3" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000247302899" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000923734208" dur="16" oct="3" pname="d"/>
-                    <note xml:id="note-0000000498575380" dur="16" oct="3" pname="d"/>
+                    <note xml:id="note-0000000247302899" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000923734208" dur="16" oct="3" pname="d" />
+                    <note xml:id="note-0000000498575380" dur="16" oct="3" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001688897626" dur="16" oct="3" pname="a"/>
-                    <note xml:id="note-0000000205144338" dur="16" oct="3" pname="d"/>
-                    <note xml:id="note-0000000695039773" dur="16" oct="3" pname="d"/>
+                    <note xml:id="note-0000001688897626" dur="16" oct="3" pname="a" />
+                    <note xml:id="note-0000000205144338" dur="16" oct="3" pname="d" />
+                    <note xml:id="note-0000000695039773" dur="16" oct="3" pname="d" />
                   </beam>
                 </layer>
               </staff>
@@ -1288,29 +1315,29 @@
               <staff xml:id="staff-0000001432301287" n="1">
                 <layer xml:id="layer-0000000026405285" n="1">
                   <beam>
-                    <note xml:id="note-0000001552556184" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000001771067725" dur="16" oct="4" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000781906933" dur="16" oct="4" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000001552556184" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000001771067725" dur="16" oct="4" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000781906933" dur="16" oct="4" pname="b" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001376342699" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000000110680627" dur="16" oct="4" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001461300917" dur="16" oct="4" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000001376342699" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000000110680627" dur="16" oct="4" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001461300917" dur="16" oct="4" pname="b" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000638545471" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000000506597188" dur="16" oct="4" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000002007540736" dur="16" oct="4" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000000638545471" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000000506597188" dur="16" oct="4" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000002007540736" dur="16" oct="4" pname="b" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
               <staff xml:id="staff-0000000613511162" n="2" facs="#facsZone-staff-0000000613511162">
                 <layer xml:id="layer-0000000703129923" n="1">
-                  <clef shape="F" line="4"/>
+                  <clef shape="F" line="4" />
                   <beam>
-                    <note xml:id="note-0000000668731714" dots="1" dur="8" oct="2" pname="g"/>
-                    <note xml:id="note-0000002055803936" dots="1" dur="8" oct="3" pname="g"/>
-                    <note xml:id="note-0000001904033714" dots="1" dur="8" oct="2" pname="g"/>
+                    <note xml:id="note-0000000668731714" dots="1" dur="8" oct="2" pname="g" />
+                    <note xml:id="note-0000002055803936" dots="1" dur="8" oct="3" pname="g" />
+                    <note xml:id="note-0000001904033714" dots="1" dur="8" oct="2" pname="g" />
                   </beam>
                 </layer>
               </staff>
@@ -1320,29 +1347,29 @@
                 <layer xml:id="layer-0000000824153632" n="1">
                   <beam>
                     <note xml:id="note-0000001789980551" dur="16" oct="4" pname="b">
-                      <accid accid="n"/>
+                      <accid accid="n" />
                     </note>
-                    <note xml:id="note-0000001470794828" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000002004472380" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000001470794828" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000002004472380" dur="16" oct="4" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000002103231393" dur="16" oct="4" pname="b"/>
-                    <note xml:id="note-0000000203280399" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000000659839939" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000002103231393" dur="16" oct="4" pname="b" />
+                    <note xml:id="note-0000000203280399" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000000659839939" dur="16" oct="4" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000788325000" dur="16" oct="4" pname="b"/>
-                    <note xml:id="note-0000000163387875" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000001696365954" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000000788325000" dur="16" oct="4" pname="b" />
+                    <note xml:id="note-0000000163387875" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000001696365954" dur="16" oct="4" pname="d" />
                   </beam>
                 </layer>
               </staff>
               <staff xml:id="staff-0000000697785775" n="2" facs="#facsZone-staff-0000000697785775">
                 <layer xml:id="layer-0000000816991420" n="1">
                   <beam>
-                    <note xml:id="note-0000000872228851" dots="1" dur="8" oct="2" pname="f"/>
-                    <note xml:id="note-0000000251472937" dots="1" dur="8" oct="3" pname="f"/>
-                    <note xml:id="note-0000001232987936" dots="1" dur="8" oct="2" pname="f"/>
+                    <note xml:id="note-0000000872228851" dots="1" dur="8" oct="2" pname="f" />
+                    <note xml:id="note-0000000251472937" dots="1" dur="8" oct="3" pname="f" />
+                    <note xml:id="note-0000001232987936" dots="1" dur="8" oct="2" pname="f" />
                   </beam>
                 </layer>
               </staff>
@@ -1357,7 +1384,7 @@
             <measure xml:id="measure-0000001692641009" n="40">
               <staff xml:id="staff-0000002147281581" n="1">
                 <layer xml:id="layer-0000000498568067" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001007695716" n="2" facs="#facsZone-staff-0000001007695716">
@@ -1365,11 +1392,11 @@
                   <beam>
                     <note xml:id="note-0000001828437394" dots="1" dur="8" oct="2" pname="e" accid.ges="f">
                       <orig>
-                        <accid accid="f"/>
+                        <accid accid="f" />
                       </orig>
                     </note>
-                    <note xml:id="note-0000000810697702" dots="1" dur="8" oct="3" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000001706720046" dots="1" dur="8" oct="2" pname="e" accid.ges="f"/>
+                    <note xml:id="note-0000000810697702" dots="1" dur="8" oct="3" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000001706720046" dots="1" dur="8" oct="2" pname="e" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -1382,15 +1409,15 @@
             <measure xml:id="measure-0000000980772493" n="41">
               <staff xml:id="staff-0000001553808667" n="1">
                 <layer xml:id="layer-0000000515582918" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001502070359" n="2" facs="#facsZone-staff-0000001502070359">
                 <layer xml:id="layer-0000001876554453" n="1">
                   <beam>
-                    <note xml:id="note-0000000334875929" dots="1" dur="8" oct="2" pname="d"/>
-                    <note xml:id="note-0000000335459993" dots="1" dur="8" oct="3" pname="d"/>
-                    <note xml:id="note-0000001108180152" dots="1" dur="8" oct="2" pname="d"/>
+                    <note xml:id="note-0000000334875929" dots="1" dur="8" oct="2" pname="d" />
+                    <note xml:id="note-0000000335459993" dots="1" dur="8" oct="3" pname="d" />
+                    <note xml:id="note-0000001108180152" dots="1" dur="8" oct="2" pname="d" />
                   </beam>
                 </layer>
               </staff>
@@ -1403,15 +1430,15 @@
             <measure xml:id="measure-0000000813644631" n="42">
               <staff xml:id="staff-0000000143696238" n="1">
                 <layer xml:id="layer-0000000683724859" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001353862818" n="2" facs="#facsZone-staff-0000001353862818">
                 <layer xml:id="layer-0000000064865544" n="1">
                   <beam>
-                    <note xml:id="note-0000002060027981" dots="1" dur="8" oct="2" pname="c"/>
-                    <note xml:id="note-0000000591393306" dots="1" dur="8" oct="3" pname="c"/>
-                    <note xml:id="note-0000000817354052" dots="1" dur="8" oct="2" pname="c"/>
+                    <note xml:id="note-0000002060027981" dots="1" dur="8" oct="2" pname="c" />
+                    <note xml:id="note-0000000591393306" dots="1" dur="8" oct="3" pname="c" />
+                    <note xml:id="note-0000000817354052" dots="1" dur="8" oct="2" pname="c" />
                   </beam>
                 </layer>
               </staff>
@@ -1419,15 +1446,15 @@
             <measure xml:id="measure-0000000663286333" n="43">
               <staff xml:id="staff-0000001894166165" n="1">
                 <layer xml:id="layer-0000001555342574" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000875885004" n="2" facs="#facsZone-staff-0000000875885004">
                 <layer xml:id="layer-0000000389518629" n="1">
                   <beam>
-                    <note xml:id="note-0000002100727727" dots="1" dur="8" oct="3" pname="f"/>
-                    <note xml:id="note-0000001186664533" dots="1" dur="8" oct="3" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000000622602666" dots="1" dur="8" oct="3" pname="d"/>
+                    <note xml:id="note-0000002100727727" dots="1" dur="8" oct="3" pname="f" />
+                    <note xml:id="note-0000001186664533" dots="1" dur="8" oct="3" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000000622602666" dots="1" dur="8" oct="3" pname="d" />
                   </beam>
                 </layer>
               </staff>
@@ -1450,17 +1477,17 @@
             <measure xml:id="measure-0000000999021806" n="44">
               <staff xml:id="staff-0000002111537805" n="1">
                 <layer xml:id="layer-0000000786007626" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000394889156" n="2" facs="#facsZone-staff-0000000394889156">
                 <layer xml:id="layer-0000001793956252" n="1">
                   <beam>
-                    <note xml:id="note-0000002004074732" dots="1" dur="8" oct="3" pname="c"/>
+                    <note xml:id="note-0000002004074732" dots="1" dur="8" oct="3" pname="c" />
                     <note xml:id="note-0000000028204532" dots="1" dur="8" oct="2" pname="b">
-                      <accid accid="n"/>
+                      <accid accid="n" />
                     </note>
-                    <note xml:id="note-0000001474682114" dots="1" dur="8" oct="3" pname="c"/>
+                    <note xml:id="note-0000001474682114" dots="1" dur="8" oct="3" pname="c" />
                   </beam>
                 </layer>
               </staff>
@@ -1473,15 +1500,15 @@
             <measure xml:id="measure-0000001793469207" n="45">
               <staff xml:id="staff-0000001842787701" n="1">
                 <layer xml:id="layer-0000001021393394" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000374188136" n="2" facs="#facsZone-staff-0000000374188136">
                 <layer xml:id="layer-0000001248389955" n="1">
                   <beam>
-                    <note xml:id="note-0000000034095058" dots="1" dur="8" oct="3" pname="f"/>
-                    <note xml:id="note-0000001844170961" dots="1" dur="8" oct="3" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000000982018075" dots="1" dur="8" oct="3" pname="d"/>
+                    <note xml:id="note-0000000034095058" dots="1" dur="8" oct="3" pname="f" />
+                    <note xml:id="note-0000001844170961" dots="1" dur="8" oct="3" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000000982018075" dots="1" dur="8" oct="3" pname="d" />
                   </beam>
                 </layer>
               </staff>
@@ -1504,17 +1531,17 @@
             <measure xml:id="measure-0000001588451851" n="46">
               <staff xml:id="staff-0000000704144196" n="1">
                 <layer xml:id="layer-0000001077520505" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000420377805" n="2" facs="#facsZone-staff-0000000420377805">
                 <layer xml:id="layer-0000001324543587" n="1">
                   <beam>
-                    <note xml:id="note-0000000594272501" dots="1" dur="8" oct="3" pname="c"/>
+                    <note xml:id="note-0000000594272501" dots="1" dur="8" oct="3" pname="c" />
                     <note xml:id="note-0000001041355364" dots="1" dur="8" oct="2" pname="b">
-                      <accid accid="n"/>
+                      <accid accid="n" />
                     </note>
-                    <note xml:id="note-0000002014876967" dots="1" dur="8" oct="3" pname="c"/>
+                    <note xml:id="note-0000002014876967" dots="1" dur="8" oct="3" pname="c" />
                   </beam>
                 </layer>
               </staff>
@@ -1527,15 +1554,15 @@
             <measure xml:id="measure-0000002054719802" n="47">
               <staff xml:id="staff-0000001269837506" n="1">
                 <layer xml:id="layer-0000000372876866" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001828936528" n="2" facs="#facsZone-staff-0000001828936528">
                 <layer xml:id="layer-0000000921048557" n="1">
                   <beam>
-                    <note xml:id="note-0000000673671560" dots="1" dur="8" oct="3" pname="f"/>
-                    <note xml:id="note-0000001776467254" dots="1" dur="8" oct="3" pname="g"/>
-                    <note xml:id="note-0000001023779581" dots="1" dur="8" oct="2" pname="g"/>
+                    <note xml:id="note-0000000673671560" dots="1" dur="8" oct="3" pname="f" />
+                    <note xml:id="note-0000001776467254" dots="1" dur="8" oct="3" pname="g" />
+                    <note xml:id="note-0000001023779581" dots="1" dur="8" oct="2" pname="g" />
                   </beam>
                 </layer>
               </staff>
@@ -1559,27 +1586,27 @@
             <measure xml:id="measure-0000000042885421" n="48">
               <staff xml:id="staff-0000001905347483" n="1">
                 <layer xml:id="layer-0000000297679249" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001551523357" n="2" facs="#facsZone-staff-0000001551523357">
                 <layer xml:id="layer-0000000401137875" n="1">
                   <beam>
-                    <note xml:id="note-0000000092626170" dur="16" oct="3" pname="c"/>
-                    <note xml:id="note-0000001497855482" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000002100200511" dur="16" oct="3" pname="g"/>
+                    <note xml:id="note-0000000092626170" dur="16" oct="3" pname="c" />
+                    <note xml:id="note-0000001497855482" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000002100200511" dur="16" oct="3" pname="g" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000508037499" dur="16" oct="3" pname="c"/>
-                    <note xml:id="note-0000001739527344" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000000272159163" dur="16" oct="3" pname="g"/>
+                    <note xml:id="note-0000000508037499" dur="16" oct="3" pname="c" />
+                    <note xml:id="note-0000001739527344" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000000272159163" dur="16" oct="3" pname="g" />
                   </beam>
                   <beam>
                     <note xml:id="note-0000001965794308" dur="16" oct="3" pname="e">
-                      <accid accid="n"/>
+                      <accid accid="n" />
                     </note>
-                    <note xml:id="note-0000001198551003" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000000760784608" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000001198551003" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000000760784608" dur="16" oct="4" pname="c" />
                   </beam>
                 </layer>
               </staff>
@@ -1592,25 +1619,25 @@
             <measure xml:id="measure-0000002109919644" n="49">
               <staff xml:id="staff-0000001048197442" n="1">
                 <layer xml:id="layer-0000000295893346" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000568096570" n="2" facs="#facsZone-staff-0000000568096570">
                 <layer xml:id="layer-0000001988795794" n="1">
                   <beam>
-                    <note xml:id="note-0000001203163915" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000001012805746" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001879015118" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000001203163915" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000001012805746" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001879015118" dur="16" oct="4" pname="c" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000171164881" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000001615593471" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000002064292223" dur="16" oct="3" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000000171164881" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000001615593471" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000002064292223" dur="16" oct="3" pname="b" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000800697166" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000001840880222" dur="16" oct="3" pname="a"/>
-                    <note xml:id="note-0000002070826820" dur="16" oct="3" pname="a"/>
+                    <note xml:id="note-0000000800697166" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000001840880222" dur="16" oct="3" pname="a" />
+                    <note xml:id="note-0000002070826820" dur="16" oct="3" pname="a" />
                   </beam>
                 </layer>
               </staff>
@@ -1618,29 +1645,29 @@
             <measure xml:id="measure-0000000713192428" n="50">
               <staff xml:id="staff-0000001418435444" n="1">
                 <layer xml:id="layer-0000001294142864" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000002045395794" n="2" facs="#facsZone-staff-0000002045395794">
                 <layer xml:id="layer-0000000372340511" n="1">
                   <beam>
-                    <note xml:id="note-0000000445074062" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000000565099596" dur="16" oct="3" pname="d"/>
-                    <note xml:id="note-0000001658000274" dur="16" oct="3" pname="d"/>
+                    <note xml:id="note-0000000445074062" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000000565099596" dur="16" oct="3" pname="d" />
+                    <note xml:id="note-0000001658000274" dur="16" oct="3" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000816554118" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000000816554118" dur="16" oct="4" pname="d" />
                     <note xml:id="note-0000001398320146" dur="16" oct="3" pname="e">
-                      <accid accid="n"/>
+                      <accid accid="n" />
                     </note>
-                    <note xml:id="note-0000000793389988" dur="16" oct="3" pname="e"/>
+                    <note xml:id="note-0000000793389988" dur="16" oct="3" pname="e" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001829444076" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000001829444076" dur="16" oct="4" pname="d" />
                     <note xml:id="note-0000000719082775" dur="16" oct="3" pname="f">
-                      <accid accid="s"/>
+                      <accid accid="s" />
                     </note>
-                    <note xml:id="note-0000001747828672" dur="16" oct="3" pname="f" accid.ges="s"/>
+                    <note xml:id="note-0000001747828672" dur="16" oct="3" pname="f" accid.ges="s" />
                   </beam>
                 </layer>
               </staff>
@@ -1653,25 +1680,25 @@
             <measure xml:id="measure-0000001322644024" n="51">
               <staff xml:id="staff-0000001944134248" n="1">
                 <layer xml:id="layer-0000001944659116" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000978579471" n="2" facs="#facsZone-staff-0000000978579471">
                 <layer xml:id="layer-0000002008812257" n="1">
                   <beam>
-                    <note xml:id="note-0000001459772590" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000000999441869" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000000356895231" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000001459772590" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000000999441869" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000000356895231" dur="16" oct="4" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001860511386" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000000041291151" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001429032251" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000001860511386" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000000041291151" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001429032251" dur="16" oct="4" pname="c" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000260510816" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000000186288215" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001096407396" dur="16" oct="3" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000000260510816" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000000186288215" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001096407396" dur="16" oct="3" pname="b" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -1679,27 +1706,27 @@
             <measure xml:id="measure-0000001483844873" n="52">
               <staff xml:id="staff-0000000069897789" n="1">
                 <layer xml:id="layer-0000000291978076" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000317349326" n="2" facs="#facsZone-staff-0000000317349326">
                 <layer xml:id="layer-0000001971406204" n="1">
                   <beam>
                     <note xml:id="note-0000000869808739" dur="16" oct="3" pname="c">
-                      <accid accid="s"/>
+                      <accid accid="s" />
                     </note>
-                    <note xml:id="note-0000000575736148" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000000930218219" dur="16" oct="3" pname="g"/>
+                    <note xml:id="note-0000000575736148" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000000930218219" dur="16" oct="3" pname="g" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001094867521" dur="16" oct="3" pname="c" accid.ges="s"/>
-                    <note xml:id="note-0000001078701645" dur="16" oct="3" pname="a"/>
-                    <note xml:id="note-0000000043346022" dur="16" oct="3" pname="a"/>
+                    <note xml:id="note-0000001094867521" dur="16" oct="3" pname="c" accid.ges="s" />
+                    <note xml:id="note-0000001078701645" dur="16" oct="3" pname="a" />
+                    <note xml:id="note-0000000043346022" dur="16" oct="3" pname="a" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001190127349" dur="16" oct="3" pname="c" accid.ges="s"/>
-                    <note xml:id="note-0000001439382427" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000001622404468" dur="16" oct="3" pname="g"/>
+                    <note xml:id="note-0000001190127349" dur="16" oct="3" pname="c" accid.ges="s" />
+                    <note xml:id="note-0000001439382427" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000001622404468" dur="16" oct="3" pname="g" />
                   </beam>
                 </layer>
               </staff>
@@ -1712,25 +1739,25 @@
             <measure xml:id="measure-0000001841900510" n="53">
               <staff xml:id="staff-0000000621069204" n="1">
                 <layer xml:id="layer-0000000311353051" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001513787909" n="2" facs="#facsZone-staff-0000001513787909">
                 <layer xml:id="layer-0000001738659235" n="1">
                   <beam>
-                    <note xml:id="note-0000001377949259" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000001569875596" dur="16" oct="3" pname="d"/>
-                    <note xml:id="note-0000001501670829" dur="16" oct="3" pname="d"/>
+                    <note xml:id="note-0000001377949259" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000001569875596" dur="16" oct="3" pname="d" />
+                    <note xml:id="note-0000001501670829" dur="16" oct="3" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000521878022" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000002020129536" dur="16" oct="3" pname="g"/>
-                    <note xml:id="note-0000000856640964" dur="16" oct="3" pname="d"/>
+                    <note xml:id="note-0000000521878022" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000002020129536" dur="16" oct="3" pname="g" />
+                    <note xml:id="note-0000000856640964" dur="16" oct="3" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000186241511" dur="16" oct="3" pname="a"/>
-                    <note xml:id="note-0000001786813584" dur="16" oct="3" pname="d"/>
-                    <note xml:id="note-0000000429481525" dur="16" oct="3" pname="d"/>
+                    <note xml:id="note-0000000186241511" dur="16" oct="3" pname="a" />
+                    <note xml:id="note-0000001786813584" dur="16" oct="3" pname="d" />
+                    <note xml:id="note-0000000429481525" dur="16" oct="3" pname="d" />
                   </beam>
                 </layer>
               </staff>
@@ -1753,33 +1780,33 @@
             <measure xml:id="measure-0000000812949635" n="54">
               <staff xml:id="staff-0000001996685353" n="1">
                 <layer xml:id="layer-0000001418941847" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001213204359" n="2" facs="#facsZone-staff-0000001213204359">
                 <layer xml:id="layer-0000002098622223" n="1">
                   <beam>
-                    <note xml:id="note-0000000464842575" dur="16" oct="3" pname="g"/>
+                    <note xml:id="note-0000000464842575" dur="16" oct="3" pname="g" />
                     <note xml:id="note-0000001908168151" dur="16" oct="4" pname="e">
-                      <accid accid="n"/>
+                      <accid accid="n" />
                     </note>
-                    <note xml:id="note-0000000524749094" dur="16" oct="4" pname="e"/>
+                    <note xml:id="note-0000000524749094" dur="16" oct="4" pname="e" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001556181549" dur="16" oct="3" pname="a"/>
+                    <note xml:id="note-0000001556181549" dur="16" oct="3" pname="a" />
                     <note xml:id="note-0000000794907992" dur="16" oct="4" pname="c">
-                      <accid accid="s"/>
+                      <accid accid="s" />
                     </note>
-                    <note xml:id="note-0000001870122025" dur="16" oct="4" pname="c" accid.ges="s"/>
+                    <note xml:id="note-0000001870122025" dur="16" oct="4" pname="c" accid.ges="s" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000598995058" dur="16" oct="3" pname="a"/>
+                    <note xml:id="note-0000000598995058" dur="16" oct="3" pname="a" />
                     <note xml:id="note-0000001208701120" dur="16" oct="4" pname="c" accid.ges="s">
                       <orig>
-                        <accid accid="s"/>
+                        <accid accid="s" />
                       </orig>
                     </note>
-                    <note xml:id="note-0000001311065067" dur="16" oct="4" pname="c" accid.ges="s"/>
+                    <note xml:id="note-0000001311065067" dur="16" oct="4" pname="c" accid.ges="s" />
                   </beam>
                 </layer>
               </staff>
@@ -1790,20 +1817,20 @@
               </harm>
             </measure>
             <measure xml:id="measure-0000001263331462" n="55">
-              <pb n="374" source="#secondEdition" facs="#facs-p458"/>
-              <pb n="170" source="#firstEdition" facs="#facs-p386"/>
+              <pb n="374" source="#secondEdition" facs="#facs-p458" />
+              <pb n="170" source="#firstEdition" facs="#facs-p386" />
               <staff xml:id="staff-0000000219517113" n="1">
                 <layer xml:id="layer-0000000092859128" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000000976468647" n="2" facs="#facsZone-staff-0000000976468647">
                 <layer xml:id="layer-0000000178037656" n="1">
                   <beam>
-                    <note xml:id="note-0000002008009217" dots="1" dur="8" oct="3" pname="d"/>
-                    <note xml:id="note-0000001780306183" dots="1" dur="8" oct="4" pname="d"/>
+                    <note xml:id="note-0000002008009217" dots="1" dur="8" oct="3" pname="d" />
+                    <note xml:id="note-0000001780306183" dots="1" dur="8" oct="4" pname="d" />
                     <note xml:id="note-0000001416836926" dots="1" dur="8" oct="4" pname="c">
-                      <accid accid="n"/>
+                      <accid accid="n" />
                     </note>
                   </beam>
                 </layer>
@@ -1817,17 +1844,17 @@
             <measure xml:id="measure-0000000129074234" n="56">
               <staff xml:id="staff-0000001154804852" n="1">
                 <layer xml:id="layer-0000000792139820" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001543994193" n="2" facs="#facsZone-staff-0000001543994193">
                 <layer xml:id="layer-0000000177914602" n="1">
                   <beam>
-                    <note xml:id="note-0000001216367190" dots="1" dur="8" oct="3" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000001216367190" dots="1" dur="8" oct="3" pname="b" accid.ges="f" />
                     <note xml:id="note-0000001863745838" dots="1" dur="8" oct="3" pname="f">
-                      <accid accid="s"/>
+                      <accid accid="s" />
                     </note>
-                    <note xml:id="note-0000000168190562" dots="1" dur="8" oct="3" pname="g"/>
+                    <note xml:id="note-0000000168190562" dots="1" dur="8" oct="3" pname="g" />
                   </beam>
                 </layer>
               </staff>
@@ -1845,15 +1872,15 @@
             <measure xml:id="measure-0000000815808309" n="57">
               <staff xml:id="staff-0000001141995787" n="1">
                 <layer xml:id="layer-0000000922549638" n="1">
-                  <mSpace/>
+                  <mSpace />
                 </layer>
               </staff>
               <staff xml:id="staff-0000001094559103" n="2" facs="#facsZone-staff-0000001094559103">
                 <layer xml:id="layer-0000000987722169" n="1">
                   <beam>
-                    <note xml:id="note-0000000892754143" dots="1" dur="8" oct="3" pname="d"/>
-                    <note xml:id="note-0000000626595153" dots="1" dur="8" oct="3" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000001555855904" dots="1" dur="8" oct="3" pname="c"/>
+                    <note xml:id="note-0000000892754143" dots="1" dur="8" oct="3" pname="d" />
+                    <note xml:id="note-0000000626595153" dots="1" dur="8" oct="3" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000001555855904" dots="1" dur="8" oct="3" pname="c" />
                   </beam>
                 </layer>
               </staff>
@@ -1867,38 +1894,38 @@
               <staff xml:id="staff-0000000610169869" n="1">
                 <layer xml:id="layer-0000002145446719" n="1">
                   <beam>
-                    <note xml:id="note-0000000857903115" dur="16" oct="4" pname="a"/>
-                    <note xml:id="note-0000001951401405" dur="16" oct="5" pname="f"/>
-                    <note xml:id="note-0000000914722111" dur="16" oct="5" pname="f"/>
+                    <note xml:id="note-0000000857903115" dur="16" oct="4" pname="a" />
+                    <note xml:id="note-0000001951401405" dur="16" oct="5" pname="f" />
+                    <note xml:id="note-0000000914722111" dur="16" oct="5" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000002056330340" dur="16" oct="4" pname="a"/>
-                    <note xml:id="note-0000000929711159" dur="16" oct="5" pname="f"/>
-                    <note xml:id="note-0000000095946632" dur="16" oct="5" pname="f"/>
+                    <note xml:id="note-0000002056330340" dur="16" oct="4" pname="a" />
+                    <note xml:id="note-0000000929711159" dur="16" oct="5" pname="f" />
+                    <note xml:id="note-0000000095946632" dur="16" oct="5" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001736175136" dur="16" oct="4" pname="a"/>
-                    <note xml:id="note-0000000742844241" dur="16" oct="5" pname="f"/>
-                    <note xml:id="note-0000000097638971" dur="16" oct="5" pname="f"/>
+                    <note xml:id="note-0000001736175136" dur="16" oct="4" pname="a" />
+                    <note xml:id="note-0000000742844241" dur="16" oct="5" pname="f" />
+                    <note xml:id="note-0000000097638971" dur="16" oct="5" pname="f" />
                   </beam>
                 </layer>
               </staff>
               <staff xml:id="staff-0000001176830573" n="2" facs="#facsZone-staff-0000001176830573">
                 <layer xml:id="layer-0000000709864792" n="1">
                   <beam>
-                    <note xml:id="note-0000000486679248" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000000063852076" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001801085296" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000000486679248" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000000063852076" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001801085296" dur="16" oct="4" pname="c" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001482020052" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000000660020087" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000000680889555" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000001482020052" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000000660020087" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000000680889555" dur="16" oct="4" pname="c" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000683653129" dur="16" oct="3" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000001828295701" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001924642394" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000000683653129" dur="16" oct="3" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000001828295701" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001924642394" dur="16" oct="4" pname="c" />
                   </beam>
                 </layer>
               </staff>
@@ -1907,38 +1934,38 @@
               <staff xml:id="staff-0000000150546898" n="1">
                 <layer xml:id="layer-0000000443726287" n="1">
                   <beam>
-                    <note xml:id="note-0000000248095309" dur="16" oct="4" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000881423081" dur="16" oct="5" pname="f"/>
-                    <note xml:id="note-0000001754782743" dur="16" oct="5" pname="f"/>
+                    <note xml:id="note-0000000248095309" dur="16" oct="4" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000881423081" dur="16" oct="5" pname="f" />
+                    <note xml:id="note-0000001754782743" dur="16" oct="5" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001092745370" dur="16" oct="4" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000355095023" dur="16" oct="5" pname="f"/>
-                    <note xml:id="note-0000000307282379" dur="16" oct="5" pname="f"/>
+                    <note xml:id="note-0000001092745370" dur="16" oct="4" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000355095023" dur="16" oct="5" pname="f" />
+                    <note xml:id="note-0000000307282379" dur="16" oct="5" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001787492740" dur="16" oct="4" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000919327823" dur="16" oct="5" pname="f"/>
-                    <note xml:id="note-0000001915892562" dur="16" oct="5" pname="f"/>
+                    <note xml:id="note-0000001787492740" dur="16" oct="4" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000919327823" dur="16" oct="5" pname="f" />
+                    <note xml:id="note-0000001915892562" dur="16" oct="5" pname="f" />
                   </beam>
                 </layer>
               </staff>
               <staff xml:id="staff-0000000345144481" n="2" facs="#facsZone-staff-0000000345144481">
                 <layer xml:id="layer-0000002047936679" n="1">
                   <beam>
-                    <note xml:id="note-0000001190886918" dur="16" oct="3" pname="d"/>
-                    <note xml:id="note-0000000508247690" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001399241397" dur="16" oct="3" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000001190886918" dur="16" oct="3" pname="d" />
+                    <note xml:id="note-0000000508247690" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001399241397" dur="16" oct="3" pname="b" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000789418444" dur="16" oct="3" pname="d"/>
-                    <note xml:id="note-0000001006050403" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000071702894" dur="16" oct="3" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000000789418444" dur="16" oct="3" pname="d" />
+                    <note xml:id="note-0000001006050403" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000071702894" dur="16" oct="3" pname="b" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000718021978" dur="16" oct="3" pname="d"/>
-                    <note xml:id="note-0000001245564478" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000516259886" dur="16" oct="3" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000000718021978" dur="16" oct="3" pname="d" />
+                    <note xml:id="note-0000001245564478" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000516259886" dur="16" oct="3" pname="b" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -1947,38 +1974,38 @@
               <staff xml:id="staff-0000000073229299" n="1">
                 <layer xml:id="layer-0000000086994591" n="1">
                   <beam>
-                    <note xml:id="note-0000001160959511" dur="16" oct="5" pname="g"/>
-                    <note xml:id="note-0000000307287263" dur="16" oct="4" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000270602930" dur="16" oct="4" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000001160959511" dur="16" oct="5" pname="g" />
+                    <note xml:id="note-0000000307287263" dur="16" oct="4" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000270602930" dur="16" oct="4" pname="b" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001233515465" dur="16" oct="5" pname="g"/>
-                    <note xml:id="note-0000000531371869" dur="16" oct="4" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000020810314" dur="16" oct="4" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000001233515465" dur="16" oct="5" pname="g" />
+                    <note xml:id="note-0000000531371869" dur="16" oct="4" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000020810314" dur="16" oct="4" pname="b" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001855375130" dur="16" oct="5" pname="g"/>
-                    <note xml:id="note-0000001008501104" dur="16" oct="4" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000585350032" dur="16" oct="4" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000001855375130" dur="16" oct="5" pname="g" />
+                    <note xml:id="note-0000001008501104" dur="16" oct="4" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000585350032" dur="16" oct="4" pname="b" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
               <staff xml:id="staff-0000001817517022" n="2" facs="#facsZone-staff-0000001817517022">
                 <layer xml:id="layer-0000001735438022" n="1">
                   <beam>
-                    <note xml:id="note-0000000558358288" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000942539371" dur="16" oct="3" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000001881688956" dur="16" oct="3" pname="e" accid.ges="f"/>
+                    <note xml:id="note-0000000558358288" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000942539371" dur="16" oct="3" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000001881688956" dur="16" oct="3" pname="e" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000859935076" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001677832322" dur="16" oct="3" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000000661855206" dur="16" oct="3" pname="e" accid.ges="f"/>
+                    <note xml:id="note-0000000859935076" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001677832322" dur="16" oct="3" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000000661855206" dur="16" oct="3" pname="e" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000242961769" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000000508635866" dur="16" oct="3" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000002055450775" dur="16" oct="3" pname="e" accid.ges="f"/>
+                    <note xml:id="note-0000000242961769" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000000508635866" dur="16" oct="3" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000002055450775" dur="16" oct="3" pname="e" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -1987,19 +2014,19 @@
               <staff xml:id="staff-0000000395871584" n="1">
                 <layer xml:id="layer-0000000390663919" n="1">
                   <beam>
-                    <note xml:id="note-0000000406755688" dur="16" oct="5" pname="c"/>
-                    <note xml:id="note-0000001839222409" dur="16" oct="5" pname="g"/>
-                    <note xml:id="note-0000000561462033" dur="16" oct="5" pname="g"/>
+                    <note xml:id="note-0000000406755688" dur="16" oct="5" pname="c" />
+                    <note xml:id="note-0000001839222409" dur="16" oct="5" pname="g" />
+                    <note xml:id="note-0000000561462033" dur="16" oct="5" pname="g" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001987163028" dur="16" oct="5" pname="c"/>
-                    <note xml:id="note-0000001312984452" dur="16" oct="5" pname="g"/>
-                    <note xml:id="note-0000001934225625" dur="16" oct="5" pname="g"/>
+                    <note xml:id="note-0000001987163028" dur="16" oct="5" pname="c" />
+                    <note xml:id="note-0000001312984452" dur="16" oct="5" pname="g" />
+                    <note xml:id="note-0000001934225625" dur="16" oct="5" pname="g" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000004061091" dur="16" oct="5" pname="c"/>
-                    <note xml:id="note-0000001565399825" dur="16" oct="5" pname="g"/>
-                    <note xml:id="note-0000000610028354" dur="16" oct="5" pname="g"/>
+                    <note xml:id="note-0000000004061091" dur="16" oct="5" pname="c" />
+                    <note xml:id="note-0000001565399825" dur="16" oct="5" pname="g" />
+                    <note xml:id="note-0000000610028354" dur="16" oct="5" pname="g" />
                   </beam>
                 </layer>
               </staff>
@@ -2007,20 +2034,20 @@
                 <layer xml:id="layer-0000001779012958" n="1">
                   <beam>
                     <note xml:id="note-0000000205719488" dur="16" oct="3" pname="e">
-                      <accid accid="n"/>
+                      <accid accid="n" />
                     </note>
-                    <note xml:id="note-0000001746594344" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001967695747" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000001746594344" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001967695747" dur="16" oct="4" pname="c" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000947709002" dur="16" oct="3" pname="e"/>
-                    <note xml:id="note-0000002120088617" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000000167529459" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000000947709002" dur="16" oct="3" pname="e" />
+                    <note xml:id="note-0000002120088617" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000000167529459" dur="16" oct="4" pname="c" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000002086920891" dur="16" oct="3" pname="e"/>
-                    <note xml:id="note-0000000372063221" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001863147372" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000002086920891" dur="16" oct="3" pname="e" />
+                    <note xml:id="note-0000000372063221" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001863147372" dur="16" oct="4" pname="c" />
                   </beam>
                 </layer>
               </staff>
@@ -2029,38 +2056,38 @@
               <staff xml:id="staff-0000001061048055" n="1">
                 <layer xml:id="layer-0000001475733374" n="1">
                   <beam>
-                    <note xml:id="note-0000000309683933" dur="16" oct="5" pname="a"/>
-                    <note xml:id="note-0000000394963506" dur="16" oct="5" pname="c"/>
-                    <note xml:id="note-0000001078877624" dur="16" oct="5" pname="c"/>
+                    <note xml:id="note-0000000309683933" dur="16" oct="5" pname="a" />
+                    <note xml:id="note-0000000394963506" dur="16" oct="5" pname="c" />
+                    <note xml:id="note-0000001078877624" dur="16" oct="5" pname="c" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000804254188" dur="16" oct="5" pname="a"/>
-                    <note xml:id="note-0000000745150575" dur="16" oct="5" pname="c"/>
-                    <note xml:id="note-0000001694891102" dur="16" oct="5" pname="c"/>
+                    <note xml:id="note-0000000804254188" dur="16" oct="5" pname="a" />
+                    <note xml:id="note-0000000745150575" dur="16" oct="5" pname="c" />
+                    <note xml:id="note-0000001694891102" dur="16" oct="5" pname="c" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001243757335" dur="16" oct="5" pname="a"/>
-                    <note xml:id="note-0000002022991220" dur="16" oct="5" pname="c"/>
-                    <note xml:id="note-0000000975900999" dur="16" oct="5" pname="c"/>
+                    <note xml:id="note-0000001243757335" dur="16" oct="5" pname="a" />
+                    <note xml:id="note-0000002022991220" dur="16" oct="5" pname="c" />
+                    <note xml:id="note-0000000975900999" dur="16" oct="5" pname="c" />
                   </beam>
                 </layer>
               </staff>
               <staff xml:id="staff-0000000468336033" n="2" facs="#facsZone-staff-0000000468336033">
                 <layer xml:id="layer-0000001283044534" n="1">
                   <beam>
-                    <note xml:id="note-0000001894283775" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001521479738" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000000666149395" dur="16" oct="3" pname="f"/>
+                    <note xml:id="note-0000001894283775" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001521479738" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000000666149395" dur="16" oct="3" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000658750917" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001548790947" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000000037199706" dur="16" oct="3" pname="f"/>
+                    <note xml:id="note-0000000658750917" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001548790947" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000000037199706" dur="16" oct="3" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000618762897" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000000506647253" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000000185692561" dur="16" oct="3" pname="f"/>
+                    <note xml:id="note-0000000618762897" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000000506647253" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000000185692561" dur="16" oct="3" pname="f" />
                   </beam>
                 </layer>
               </staff>
@@ -2069,42 +2096,42 @@
               <staff xml:id="staff-0000001191677559" n="1">
                 <layer xml:id="layer-0000000971349489" n="1">
                   <beam>
-                    <note xml:id="note-0000001279435404" dur="16" oct="5" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000000733719228" dur="16" oct="6" pname="c"/>
-                    <note xml:id="note-0000001416664030" dur="16" oct="6" pname="c"/>
+                    <note xml:id="note-0000001279435404" dur="16" oct="5" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000000733719228" dur="16" oct="6" pname="c" />
+                    <note xml:id="note-0000001416664030" dur="16" oct="6" pname="c" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000002021659238" dur="16" oct="5" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001688968117" dur="16" oct="5" pname="d"/>
-                    <note xml:id="note-0000002125395914" dur="16" oct="5" pname="d"/>
+                    <note xml:id="note-0000002021659238" dur="16" oct="5" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001688968117" dur="16" oct="5" pname="d" />
+                    <note xml:id="note-0000002125395914" dur="16" oct="5" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001165300111" dur="16" oct="5" pname="c"/>
-                    <note xml:id="note-0000000213513165" dur="16" oct="5" pname="a"/>
-                    <note xml:id="note-0000001269706994" dur="16" oct="5" pname="a"/>
+                    <note xml:id="note-0000001165300111" dur="16" oct="5" pname="c" />
+                    <note xml:id="note-0000000213513165" dur="16" oct="5" pname="a" />
+                    <note xml:id="note-0000001269706994" dur="16" oct="5" pname="a" />
                   </beam>
                 </layer>
               </staff>
               <staff xml:id="staff-0000001691854142" n="2" facs="#facsZone-staff-0000001691854142">
                 <layer xml:id="layer-0000002119727881" n="1">
                   <beam>
-                    <note xml:id="note-0000000609361135" dur="16" oct="3" pname="g"/>
+                    <note xml:id="note-0000000609361135" dur="16" oct="3" pname="g" />
                     <note xml:id="note-0000001502429502" dur="16" oct="4" pname="e" accid.ges="f">
                       <orig>
-                        <accid accid="f"/>
+                        <accid accid="f" />
                       </orig>
                     </note>
-                    <note xml:id="note-0000001608677775" dur="16" oct="4" pname="e" accid.ges="f"/>
+                    <note xml:id="note-0000001608677775" dur="16" oct="4" pname="e" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001945856307" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000000671995577" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000001747203546" dur="16" oct="3" pname="f"/>
+                    <note xml:id="note-0000001945856307" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000000671995577" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000001747203546" dur="16" oct="3" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001552203104" dur="16" oct="3" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000000891099605" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001453993772" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000001552203104" dur="16" oct="3" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000000891099605" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001453993772" dur="16" oct="4" pname="c" />
                   </beam>
                 </layer>
               </staff>
@@ -2113,42 +2140,42 @@
               <staff xml:id="staff-0000000186569052" n="1">
                 <layer xml:id="layer-0000001699507852" n="1">
                   <beam>
-                    <note xml:id="note-0000001071658975" dur="16" oct="5" pname="g"/>
-                    <note xml:id="note-0000001538752521" dur="16" oct="4" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001109742094" dur="16" oct="4" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000001071658975" dur="16" oct="5" pname="g" />
+                    <note xml:id="note-0000001538752521" dur="16" oct="4" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001109742094" dur="16" oct="4" pname="b" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000171807219" dur="16" oct="4" pname="a"/>
-                    <note xml:id="note-0000001055000572" dur="16" oct="5" pname="f"/>
-                    <note xml:id="note-0000001107888151" dur="16" oct="5" pname="f"/>
+                    <note xml:id="note-0000000171807219" dur="16" oct="4" pname="a" />
+                    <note xml:id="note-0000001055000572" dur="16" oct="5" pname="f" />
+                    <note xml:id="note-0000001107888151" dur="16" oct="5" pname="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001870745365" dur="16" oct="5" pname="e" accid.ges="f"/>
-                    <note xml:id="note-0000001029247724" dur="16" oct="6" pname="c"/>
-                    <note xml:id="note-0000000227888867" dur="16" oct="6" pname="c"/>
+                    <note xml:id="note-0000001870745365" dur="16" oct="5" pname="e" accid.ges="f" />
+                    <note xml:id="note-0000001029247724" dur="16" oct="6" pname="c" />
+                    <note xml:id="note-0000000227888867" dur="16" oct="6" pname="c" />
                   </beam>
                 </layer>
               </staff>
               <staff xml:id="staff-0000000516967649" n="2" facs="#facsZone-staff-0000000516967649">
                 <layer xml:id="layer-0000001274091438" n="1">
                   <beam>
-                    <note xml:id="note-0000000470571357" dur="16" oct="3" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001474193093" dur="16" oct="3" pname="d"/>
-                    <note xml:id="note-0000000451325085" dur="16" oct="3" pname="d"/>
+                    <note xml:id="note-0000000470571357" dur="16" oct="3" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001474193093" dur="16" oct="3" pname="d" />
+                    <note xml:id="note-0000000451325085" dur="16" oct="3" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000264567191" dur="16" oct="3" pname="c"/>
-                    <note xml:id="note-0000001478997445" dur="16" oct="3" pname="a"/>
-                    <note xml:id="note-0000001872595963" dur="16" oct="3" pname="a"/>
+                    <note xml:id="note-0000000264567191" dur="16" oct="3" pname="c" />
+                    <note xml:id="note-0000001478997445" dur="16" oct="3" pname="a" />
+                    <note xml:id="note-0000001872595963" dur="16" oct="3" pname="a" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001631690474" dur="16" oct="3" pname="g"/>
+                    <note xml:id="note-0000001631690474" dur="16" oct="3" pname="g" />
                     <note xml:id="note-0000000462613592" dur="16" oct="4" pname="e" accid.ges="f">
                       <orig>
-                        <accid accid="f"/>
+                        <accid accid="f" />
                       </orig>
                     </note>
-                    <note xml:id="note-0000001401157937" dur="16" oct="4" pname="e" accid.ges="f"/>
+                    <note xml:id="note-0000001401157937" dur="16" oct="4" pname="e" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -2157,42 +2184,42 @@
               <staff xml:id="staff-0000001768018743" n="1">
                 <layer xml:id="layer-0000000984473756" n="1">
                   <beam>
-                    <note xml:id="note-0000001770065462" dur="16" oct="5" pname="d"/>
-                    <note xml:id="note-0000001233142599" dur="16" oct="6" pname="c"/>
-                    <note xml:id="note-0000000548295603" dur="16" oct="6" pname="c"/>
+                    <note xml:id="note-0000001770065462" dur="16" oct="5" pname="d" />
+                    <note xml:id="note-0000001233142599" dur="16" oct="6" pname="c" />
+                    <note xml:id="note-0000000548295603" dur="16" oct="6" pname="c" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000002142849153" dur="16" oct="5" pname="d"/>
-                    <note xml:id="note-0000001072881240" dur="16" oct="5" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001416347833" dur="16" oct="5" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000002142849153" dur="16" oct="5" pname="d" />
+                    <note xml:id="note-0000001072881240" dur="16" oct="5" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001416347833" dur="16" oct="5" pname="b" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000001338635318" dur="16" oct="5" pname="d"/>
-                    <note xml:id="note-0000000584908542" dur="16" oct="5" pname="a"/>
-                    <note xml:id="note-0000000627532046" dur="16" oct="5" pname="a"/>
+                    <note xml:id="note-0000001338635318" dur="16" oct="5" pname="d" />
+                    <note xml:id="note-0000000584908542" dur="16" oct="5" pname="a" />
+                    <note xml:id="note-0000000627532046" dur="16" oct="5" pname="a" />
                   </beam>
                 </layer>
               </staff>
               <staff xml:id="staff-0000000240521592" n="2" facs="#facsZone-staff-0000000240521592">
                 <layer xml:id="layer-0000001413321567" n="1">
                   <beam>
-                    <note xml:id="note-0000000458180842" dur="16" oct="3" pname="f"/>
+                    <note xml:id="note-0000000458180842" dur="16" oct="3" pname="f" />
                     <note xml:id="note-0000002010967759" dur="16" oct="4" pname="e" accid.ges="f">
                       <orig>
-                        <accid accid="f"/>
+                        <accid accid="f" />
                       </orig>
                     </note>
-                    <note xml:id="note-0000000776807627" dur="16" oct="4" pname="e" accid.ges="f"/>
+                    <note xml:id="note-0000000776807627" dur="16" oct="4" pname="e" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000748725435" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000001361326643" dur="16" oct="4" pname="d"/>
-                    <note xml:id="note-0000000146328924" dur="16" oct="4" pname="d"/>
+                    <note xml:id="note-0000000748725435" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000001361326643" dur="16" oct="4" pname="d" />
+                    <note xml:id="note-0000000146328924" dur="16" oct="4" pname="d" />
                   </beam>
                   <beam>
-                    <note xml:id="note-0000000384133862" dur="16" oct="3" pname="f"/>
-                    <note xml:id="note-0000000521839937" dur="16" oct="4" pname="c"/>
-                    <note xml:id="note-0000001811138598" dur="16" oct="4" pname="c"/>
+                    <note xml:id="note-0000000384133862" dur="16" oct="3" pname="f" />
+                    <note xml:id="note-0000000521839937" dur="16" oct="4" pname="c" />
+                    <note xml:id="note-0000001811138598" dur="16" oct="4" pname="c" />
                   </beam>
                 </layer>
               </staff>
@@ -2201,21 +2228,21 @@
               <staff xml:id="staff-0000000848010546" n="1">
                 <layer xml:id="layer-0000000562334443" n="1">
                   <chord xml:id="chord-0000001130204982" dots="1" dur="4">
-                    <note xml:id="note-0000000653126659" oct="4" pname="b" accid.ges="f"/>
-                    <note xml:id="note-0000001087902168" oct="5" pname="d"/>
-                    <note xml:id="note-0000001907584985" oct="5" pname="f"/>
-                    <note xml:id="note-0000000986207282" oct="5" pname="b" accid.ges="f"/>
+                    <note xml:id="note-0000000653126659" oct="4" pname="b" accid.ges="f" />
+                    <note xml:id="note-0000001087902168" oct="5" pname="d" />
+                    <note xml:id="note-0000001907584985" oct="5" pname="f" />
+                    <note xml:id="note-0000000986207282" oct="5" pname="b" accid.ges="f" />
                   </chord>
-                  <space xml:id="space-0000001323260950" dur="8"/>
+                  <space xml:id="space-0000001323260950" dur="8" />
                 </layer>
               </staff>
               <staff xml:id="staff-0000002024245590" n="2" facs="#facsZone-staff-0000002024245590">
                 <layer xml:id="layer-0000001051747469" n="1">
-                  <note xml:id="note-0000001533412361" dots="1" dur="4" oct="3" pname="b" accid.ges="f"/>
-                  <note xml:id="note-0000000360421828" dots="1" dur="8" oct="3" pname="b" accid.ges="f"/>
+                  <note xml:id="note-0000001533412361" dots="1" dur="4" oct="3" pname="b" accid.ges="f" />
+                  <note xml:id="note-0000000360421828" dots="1" dur="8" oct="3" pname="b" accid.ges="f" />
                 </layer>
               </staff>
-              <tie xml:id="tie-0000001758762529" startid="#note-0000001533412361" endid="#note-0000000360421828"/>
+              <tie xml:id="tie-0000001758762529" startid="#note-0000001533412361" endid="#note-0000000360421828" />
             </measure>
           </section>
         </score>

--- a/encodings/14/mattheson/score-2.xml
+++ b/encodings/14/mattheson/score-2.xml
@@ -239,7 +239,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="4">
                 <fb>
-                  <f>♮6</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>6♮</f>
+                    </reg>
+                    <orig>
+                      <f>♮6</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="7">

--- a/encodings/14/mattheson/score.xml
+++ b/encodings/14/mattheson/score.xml
@@ -719,7 +719,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="1">
                 <fb>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="4">
@@ -1099,7 +1106,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="7">
                 <fb>
-                  <f>♮5</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♮</f>
+                    </reg>
+                    <orig>
+                      <f>♮5</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="10">
@@ -1281,7 +1295,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="4">
                 <fb>
-                  <f>♮6</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>6♮</f>
+                    </reg>
+                    <orig>
+                      <f>♮6</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="7">

--- a/encodings/15/mattheson/score.xml
+++ b/encodings/15/mattheson/score.xml
@@ -339,7 +339,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="1">
                 <fb>
-                  <f>♭6</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>6♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭6</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -389,7 +396,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="1">
                 <fb>
-                  <f>♭6</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>6♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭6</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -1117,7 +1131,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="2">
                 <fb>
-                  <f>♭5</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭5</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>

--- a/encodings/16/mattheson/score.xml
+++ b/encodings/16/mattheson/score.xml
@@ -300,8 +300,22 @@
               </staff>
               <harm place="above" staff="2" tstamp="1">
                 <fb>
-                  <f>♭5</f>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭5</f>
+                    </orig>
+                  </choice>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="3">
@@ -358,7 +372,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="2.5">
                 <fb>
-                  <f>♭5</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭5</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="3">
@@ -1049,7 +1070,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="1">
                 <fb>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                   <f>5</f>
                 </fb>
               </harm>
@@ -1239,7 +1267,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="1">
                 <fb>
-                  <f>♭4</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>4♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭4</f>
+                    </orig>
+                  </choice>
                   <f>2</f>
                 </fb>
               </harm>
@@ -1362,7 +1397,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="2">
                 <fb>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                   <f>5</f>
                 </fb>
               </harm>

--- a/encodings/18/mattheson/score.xml
+++ b/encodings/18/mattheson/score.xml
@@ -2263,7 +2263,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="1">
                 <fb>
-                  <f>♭5</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭5</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>

--- a/encodings/2/mattheson/score.xml
+++ b/encodings/2/mattheson/score.xml
@@ -1611,7 +1611,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="1.0">
                 <fb>
-                  <f>♭6</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>6♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭6</f>
+                    </orig>
+                  </choice>
                   <f>5</f>
                 </fb>
               </harm>
@@ -1815,7 +1822,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="2.0">
                 <fb>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="2.5">

--- a/encodings/3/mattheson/score.xml
+++ b/encodings/3/mattheson/score.xml
@@ -1306,7 +1306,14 @@
               <harm place="above" staff="2" tstamp="1">
                 <fb>
                   <f>6</f>
-                  <f>♭5</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭5</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -1565,7 +1572,14 @@
               </harm>
               <harm place="above" staff="2" startid="#m-1568">
                 <fb>
-                  <f>♭6</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>6♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭6</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -1738,8 +1752,22 @@
               </staff>
               <harm place="above" staff="2" startid="#m-1769">
                 <fb>
-                  <f>♮7</f>
-                  <f>♭5</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♮</f>
+                    </reg>
+                    <orig>
+                      <f>♮7</f>
+                    </orig>
+                  </choice>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭5</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>

--- a/encodings/6/mattheson/score.xml
+++ b/encodings/6/mattheson/score.xml
@@ -1770,7 +1770,14 @@
               </staff>
               <harm place="above" staff="2" startid="#m-1183">
                 <fb>
-                  <f>♭6</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>6♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭6</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" startid="#m-1197">

--- a/encodings/9/mattheson/score.xml
+++ b/encodings/9/mattheson/score.xml
@@ -1109,7 +1109,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="3.0">
                 <fb>
-                  <f>♭6</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>6♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭6</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -1450,7 +1457,14 @@
               </staff>
               <harm place="above" staff="2" tstamp="1.0">
                 <fb>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                   <f>5</f>
                   <f>3</f>
                 </fb>
@@ -1607,7 +1621,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="4.0">
                 <fb>
-                  <f>♭5</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭5</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -2209,7 +2230,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="4.5">
                 <fb>
-                  <f>♭5</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭5</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -2361,7 +2389,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="3.5">
                 <fb>
-                  <f>♮7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♮</f>
+                    </reg>
+                    <orig>
+                      <f>♮7</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="4.0">
@@ -2371,7 +2406,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="4.5">
                 <fb>
-                  <f>♭5</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>5♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭5</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
             </measure>
@@ -2444,7 +2486,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="4.0">
                 <fb>
-                  <f>♭6</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>6♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭6</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="4.5">
@@ -2511,7 +2560,14 @@
               </harm>
               <harm place="above" staff="2" tstamp="3.5">
                 <fb>
-                  <f>♭7</f>
+                  <choice>
+                    <reg resp="#rettinghaus">
+                      <f>7♭</f>
+                    </reg>
+                    <orig>
+                      <f>♭7</f>
+                    </orig>
+                  </choice>
                 </fb>
               </harm>
               <harm place="above" staff="2" tstamp="4.0">


### PR DESCRIPTION
This PR regularizes the positions of accidentals in figured bass to match modern practice. 
I'm less sure if we should use `orig` or `sic` to tag the printed version. I think `orig` is fine, as the rules at the time have been less strict if I'm not mistaken. 