### PR TITLE
Add link to measure

### DIFF
--- a/encodings/18/mattheson/comments_1st.xml
+++ b/encodings/18/mattheson/comments_1st.xml
@@ -134,7 +134,7 @@
           <head>§. 3.</head>
           <p xml:id="p3-1">
             <lb/>Mit folgenden <ref target="#measure-0000000404998919">ſechszehnten</ref>, <ref target="#measure-0000000797194466">ſiebenzehnten</ref> und <ref target="#measure-0000000971045622">achtzehnten Taͤcten</ref> ver-
-            <lb/>faͤhret man wie mit dem fuͤnfften, und wo das <ref target="#clef-0000001087880551"><hi rendition="#aq">Tenor</hi>-Zeichen</ref> die <hi rendition="#aq">Repercuſſion</hi>
+            <lb/>faͤhret man wie mit dem <ref target="#measure-0000001605013106">fuͤnfften</ref>, und wo das <ref target="#clef-0000001087880551"><hi rendition="#aq">Tenor</hi>-Zeichen</ref> die <hi rendition="#aq">Repercuſſion</hi>
             <lb/>des <hi rendition="#aq">Thematis</hi> anhebet, eben wie mit dem Anfang. Jm <ref target="#measure-0000001099786812">acht und zwantzigſten
             <lb/>Tact</ref> iſt zu mercken, daß die rechte Hand daſelbſt nebſt der Sexte, welche liegen
             <lb/>bleibet, zu jeder Note die Tertie mit anſchlage. Weiter wolle man den <ref target="#measure-0000000346618578">ſieben

--- a/encodings/18/mattheson/comments_de.xml
+++ b/encodings/18/mattheson/comments_de.xml
@@ -131,7 +131,7 @@
         <head>§. 3.</head>
         <p xml:id="p3-1" facs="#facsZone-p3-1 #facsZone-p3-1-2">
           <lb/>Mit folgenden <ref target="#measure-0000000404998919 #measure-0000000797194466 #measure-0000000971045622">ſechszehnten, ſiebenzehnten und achtzehnten Taͤcten</ref> verfaͤh-
-          <lb/>ret man wie mit dem fuͤnfften, und wo das <ref target="#clef-0000001087880551">Tenor-Zeichen</ref> die Verſetzung des
+          <lb/>ret man wie mit dem <ref target="#measure-0000001605013106">fuͤnfften</ref>, und wo das <ref target="#clef-0000001087880551">Tenor-Zeichen</ref> die Verſetzung des
           <lb/>Haupt-Satzes anhebet, eben wie mit dem Anfange. Jm <ref target="#measure-0000001099786812">acht und zwantzigſten
           <lb/>Tact</ref> iſt zu mercken, daß die rechte Hand daſelbſt nebſt der Sexte, welche liegen
           <lb/>bleibet, zu jeder Note die Tertz mit anſchlaͤget. Weiter wolle man den <ref target="#measure-0000000346618578">ſieben


### PR DESCRIPTION
NB: The second edition combines the links to three measures, yet online they appear separated. Is there something wrong?