### PR TITLE
Fix graphics

### DIFF
--- a/encodings/1/mattheson/music-example2.xml
+++ b/encodings/1/mattheson/music-example2.xml
@@ -29,7 +29,7 @@
     </meiHead>
     <music>
         <body>
-            <mdiv label="Example 1">
+            <mdiv label="Example 2">
                 <score>
                     <scoreDef key.pname="d" key.mode="minor" meter.unit="4" mnum.visible="false">
                         <staffGrp>

--- a/encodings/15/mattheson/score.xml
+++ b/encodings/15/mattheson/score.xml
@@ -70,8 +70,8 @@
       </surface>
     </facsimile>
     <facsimile decls="#secondEdition">
-      <surface ulx="0" uly="0" lrx="1998" lry="2422" xml:id="facs-p466">
-        <graphic width="1998" height="2422" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/466" />
+      <surface ulx="0" uly="0" lrx="2017" lry="2489" xml:id="facs-p450">
+        <graphic width="2018" height="2490" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/450" />
         <zone ulx="135" uly="275" lrx="579" lry="634" xml:id="facsZone-staff-0000001354335255" />
         <zone ulx="525" uly="278" lrx="840" lry="634" xml:id="facsZone-staff-0000001674810572" />
         <zone ulx="792" uly="281" lrx="1038" lry="637" xml:id="facsZone-staff-0000000445707228" />
@@ -123,8 +123,8 @@
         <zone ulx="1566" uly="1955" lrx="1704" lry="2287" xml:id="facsZone-staff-0000001714284910" />
         <zone ulx="1680" uly="1952" lrx="1983" lry="2287" xml:id="facsZone-staff-0000001866161304" />
       </surface>
-      <surface ulx="0" uly="0" lrx="1998" lry="2427" xml:id="facs-p467">
-        <graphic width="1998" height="2427" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/467" />
+      <surface ulx="0" uly="0" lrx="2047" lry="2490" xml:id="facs-p451">
+        <graphic width="2048" height="2491" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/451" />
         <zone ulx="62" uly="233" lrx="518" lry="562" xml:id="facsZone-staff-0000000417107568" />
         <zone ulx="489" uly="227" lrx="822" lry="562" xml:id="facsZone-staff-0000001436864915" />
         <zone ulx="801" uly="269" lrx="1014" lry="550" xml:id="facsZone-staff-0000001509211090" />
@@ -187,7 +187,7 @@
             </staffGrp>
           </scoreDef>
           <section>
-            <pb n="382" source="#secondEdition" facs="#facs-p466" />
+            <pb n="382" source="#secondEdition" facs="#facs-p450" />
             <pb n="174" source="#firstEdition" facs="#facs-p396" />
             <measure xml:id="measure-0000000308092062" metcon="false">
               <staff xml:id="staff-0000000951353407" n="1">
@@ -1479,6 +1479,7 @@
                 </layer>
               </staff>
             </measure>
+            <pb n="383" source="#secondEdition" facs="#facs-p451" />
             <measure xml:id="measure-0000002075109581" n="51">
               <staff xml:id="staff-0000000022076621" n="1">
                 <layer n="1">

--- a/encodings/16/mattheson/score.xml
+++ b/encodings/16/mattheson/score.xml
@@ -70,8 +70,8 @@
       </surface>
     </facsimile>
     <facsimile decls="#secondEdition">
-      <surface ulx="0" uly="0" lrx="1998" lry="2512" xml:id="facs-p476">
-        <graphic width="1998" height="2512" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/476" />
+      <surface ulx="0" uly="0" lrx="2023" lry="2492" xml:id="facs-p460">
+        <graphic width="2024" height="2493" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/460" />
         <zone ulx="57" uly="338" lrx="687" lry="610" xml:id="facsZone-staff-0000001487026554" />
         <zone ulx="651" uly="281" lrx="1245" lry="619" xml:id="facsZone-staff-0000000469021128" />
         <zone ulx="1206" uly="296" lrx="1932" lry="607" xml:id="facsZone-staff-0000001370080221" />
@@ -95,8 +95,8 @@
         <zone ulx="1269" uly="1826" lrx="1611" lry="2158" xml:id="facsZone-staff-0000000906382025" />
         <zone ulx="1587" uly="1823" lrx="1950" lry="2152" xml:id="facsZone-staff-0000002095462985" />
       </surface>
-      <surface ulx="0" uly="0" lrx="1998" lry="2422" xml:id="facs-p477">
-        <graphic width="1998" height="2422" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/477" />
+      <surface ulx="0" uly="0" lrx="2053" lry="2490" xml:id="facs-p461">
+        <graphic width="2054" height="2491" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/461" />
         <zone ulx="66" uly="191" lrx="732" lry="517" xml:id="facsZone-staff-0000002095462985-2" />
         <zone ulx="687" uly="194" lrx="1146" lry="517" xml:id="facsZone-staff-0000002058571182" />
         <zone ulx="1116" uly="197" lrx="1881" lry="532" xml:id="facsZone-staff-0000000776765693" />
@@ -133,7 +133,7 @@
             </staffGrp>
           </scoreDef>
           <section>
-            <pb n="392" source="#secondEdition" facs="#facs-p476" />
+            <pb n="392" source="#secondEdition" facs="#facs-p460" />
             <pb n="186" source="#firstEdition" facs="#facs-p404" />
             <measure xml:id="measure-0000002140611949" metcon="false">
               <staff n="2" facs="#facsZone-staff-0000001487026554">
@@ -877,7 +877,7 @@
                     <note xml:id="note-0000000989423541" dur="16" oct="4" pname="c" accid.ges="f" />
                     <note xml:id="note-0000000556532461" dur="16" oct="4" pname="d" accid.ges="f" />
                   </beam>
-                  <pb n="393" source="#secondEdition" facs="#facs-p477" />
+                  <pb n="393" source="#secondEdition" facs="#facs-p461" />
                   <pb n="187" source="#firstEdition" facs="#facs-p405" />
                   <beam>
                     <note xml:id="note-0000001483058331" dur="16" oct="4" pname="e" accid.ges="f" />

--- a/encodings/17/mattheson/score.xml
+++ b/encodings/17/mattheson/score.xml
@@ -73,8 +73,8 @@
       </surface>
     </facsimile>
     <facsimile decls="#secondEdition">
-      <surface ulx="0" uly="0" lrx="1998" lry="2475" xml:id="facs-p484">
-        <graphic width="1998" height="2475" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/484" />
+      <surface ulx="0" uly="0" lrx="2023" lry="2485" xml:id="facs-p468">
+        <graphic width="2024" height="2486" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/468" />
         <zone ulx="96" uly="293" lrx="888" lry="667" xml:id="facsZone-staff-0000000664768570" />
         <zone ulx="864" uly="344" lrx="1509" lry="682" xml:id="facsZone-staff-0000001707759743" />
         <zone ulx="1473" uly="341" lrx="1953" lry="703" xml:id="facsZone-staff-0000002026905036" />
@@ -98,8 +98,8 @@
         <zone ulx="843" uly="1823" lrx="1440" lry="2254" xml:id="facsZone-staff-0000001222682805" />
         <zone ulx="1413" uly="1832" lrx="1959" lry="2263" xml:id="facsZone-staff-0000001079419260" />
       </surface>
-      <surface ulx="0" uly="0" lrx="1998" lry="2438" xml:id="facs-p485">
-        <graphic width="1998" height="2438" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/485" />
+      <surface ulx="0" uly="0" lrx="2048" lry="2489" xml:id="facs-p469">
+        <graphic width="2049" height="2490" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/469" />
         <zone ulx="54" uly="206" lrx="678" lry="550" xml:id="facsZone-staff-0000001079419260-2" />
         <zone ulx="636" uly="200" lrx="1920" lry="574" xml:id="facsZone-staff-0000000255935115" />
         <zone ulx="69" uly="557" lrx="1227" lry="922" xml:id="facsZone-staff-0000000827566939" />
@@ -117,8 +117,8 @@
         <zone ulx="675" uly="1853" lrx="1395" lry="2242" xml:id="facsZone-staff-0000001782076380" />
         <zone ulx="1368" uly="1865" lrx="1926" lry="2263" xml:id="facsZone-staff-0000000825352347" />
       </surface>
-      <surface ulx="0" uly="0" lrx="1998" lry="2420" xml:id="facs-p486">
-        <graphic width="1998" height="2420" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/486" />
+      <surface ulx="0" uly="0" lrx="2008" lry="2487" xml:id="facs-p470">
+        <graphic width="2009" height="2488" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/470" />
         <zone ulx="123" uly="185" lrx="1185" lry="541" xml:id="facsZone-staff-0000001369627589" />
         <zone ulx="1158" uly="185" lrx="1932" lry="544" xml:id="facsZone-staff-0000001171159395" />
         <zone ulx="132" uly="506" lrx="774" lry="832" xml:id="facsZone-staff-0000001994625974" />
@@ -151,8 +151,8 @@
             </staffGrp>
           </scoreDef>
           <section>
-            <pb n="400" source="#secondEdition" facs="#facs-p484" />
             <pb n="194" source="#firstEdition" facs="#facs-p412" />
+            <pb n="400" source="#secondEdition" facs="#facs-p468" />
             <measure xml:id="measure-0000001591287003" n="1">
               <staff xml:id="staff-0000000178160730" n="1">
                 <layer xml:id="layer-0000000615652000" n="1">
@@ -1042,8 +1042,8 @@
                     <note xml:id="note-0000000184340124" dur="32" oct="3" pname="b" />
                     <note xml:id="note-0000001508590448" dur="32" oct="4" pname="c" accid.ges="s" />
                   </beam>
-                  <pb n="400" source="#secondEdition" facs="#facs-p485" />
                   <pb n="195" source="#firstEdition" facs="#facs-p413" />
+                  <pb n="400" source="#secondEdition" facs="#facs-p469" />
                   <beam xml:id="beam-0000001360925142">
                     <note xml:id="note-0000000662546701" dur="32" oct="3" pname="d" />
                     <note xml:id="note-0000002057189359" dur="64" oct="3" pname="e" />
@@ -1650,7 +1650,7 @@
               </harm>
             </measure>
             <measure xml:id="measure-0000001628765405" n="36">
-              <pb n="402" source="#secondEdition" facs="#facs-p486" />
+              <pb n="402" source="#secondEdition" facs="#facs-p470" />
               <staff xml:id="staff-0000000826202459" n="1">
                 <layer xml:id="layer-0000001538239956" n="1">
                   <mSpace />

--- a/encodings/18/mattheson/score.xml
+++ b/encodings/18/mattheson/score.xml
@@ -76,8 +76,8 @@
       </surface>
     </facsimile>
     <facsimile decls="#secondEdition">
-      <surface ulx="0" uly="0" lrx="1998" lry="2476" xml:id="facs-p489">
-        <graphic width="1998" height="2476" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/489" />
+      <surface ulx="0" uly="0" lrx="2047" lry="2488" xml:id="facs-p473">
+        <graphic width="2048" height="2489" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/473" />
         <zone ulx="48" uly="197" lrx="551" lry="535" xml:id="facsZone-staff-0000002002584263" />
         <zone ulx="503" uly="197" lrx="782" lry="532" xml:id="facsZone-staff-0000001099693417" />
         <zone ulx="753" uly="206" lrx="1008" lry="529" xml:id="facsZone-staff-0000000365892974" />
@@ -117,8 +117,8 @@
         <zone ulx="1239" uly="1823" lrx="1626" lry="2275" xml:id="facsZone-staff-0000001421165927" />
         <zone ulx="1593" uly="1859" lrx="1884" lry="2212" xml:id="facsZone-staff-0000000164107030" />
       </surface>
-      <surface ulx="0" uly="0" lrx="1998" lry="2456" xml:id="facs-p490">
-        <graphic width="1998" height="2456" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/490" />
+      <surface ulx="0" uly="0" lrx="2011" lry="2486" xml:id="facs-p474">
+        <graphic width="2012" height="2487" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/474" />
         <zone ulx="99" uly="212" lrx="387" lry="520" xml:id="facsZone-staff-0000001277364665" />
         <zone ulx="354" uly="224" lrx="666" lry="520" xml:id="facsZone-staff-0000001280162782" />
         <zone ulx="630" uly="215" lrx="954" lry="508" xml:id="facsZone-staff-0000000793426205" />
@@ -160,8 +160,8 @@
         <zone ulx="1347" uly="1886" lrx="1704" lry="2263" xml:id="facsZone-staff-0000001518788276" />
         <zone ulx="1674" uly="1880" lrx="1965" lry="2260" xml:id="facsZone-staff-0000000786927405" />
       </surface>
-      <surface ulx="0" uly="0" lrx="1998" lry="2427" xml:id="facs-p491">
-        <graphic width="1998" height="2427" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/491" />
+      <surface ulx="0" uly="0" lrx="2048" lry="2484" xml:id="facs-p475">
+        <graphic width="2049" height="2485" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/475" />
         <zone ulx="60" uly="212" lrx="363" lry="508" xml:id="facsZone-staff-0000000514444824" />
         <zone ulx="333" uly="209" lrx="633" lry="508" xml:id="facsZone-staff-0000000043663283" />
         <zone ulx="612" uly="200" lrx="933" lry="541" xml:id="facsZone-staff-0000000626220939" />
@@ -197,7 +197,7 @@
             </staffGrp>
           </scoreDef>
           <section>
-            <pb source="#secondEdition" n="405" facs="#facs-p489" />
+            <pb source="#secondEdition" n="405" facs="#facs-p473" />
             <measure xml:id="measure-0000001647363724" n="1">
               <staff xml:id="staff-0000001380307905" n="1">
                 <layer xml:id="layer-0000000053677622" n="1">
@@ -1194,7 +1194,7 @@
                 </fb>
               </harm>
             </measure>
-            <pb source="#secondEdition" n="406" facs="#facs-p490" />
+            <pb source="#secondEdition" n="406" facs="#facs-p474" />
             <sb source="#firstEdition" />
             <measure xml:id="measure-0000000804701007" n="39">
               <staff xml:id="staff-0000000245228146" n="1">
@@ -2239,7 +2239,7 @@
                 </fb>
               </harm>
             </measure>
-            <pb source="#secondEdition" n="407" facs="#facs-p491" />
+            <pb source="#secondEdition" n="407" facs="#facs-p475" />
             <sb source="#firstEdition" />
             <measure xml:id="measure-0000001516729666" n="79">
               <staff xml:id="staff-0000001943645508" n="1">

--- a/encodings/19/mattheson/score.xml
+++ b/encodings/19/mattheson/score.xml
@@ -70,8 +70,8 @@
       </surface>
     </facsimile>
     <facsimile decls="#secondEdition">
-      <surface ulx="0" uly="0" lrx="1998" lry="2439" xml:id="facs-p494">
-        <graphic width="1998" height="2439" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/494" />
+      <surface ulx="0" uly="0" lrx="2026" lry="2485" xml:id="facs-p478">
+        <graphic width="2027" height="2486" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/478" />
         <zone ulx="123" uly="317" lrx="729" lry="661" xml:id="facsZone-staff-0000001152028572" />
         <zone ulx="699" uly="308" lrx="1011" lry="643" xml:id="facsZone-staff-0000000315127783" />
         <zone ulx="1002" uly="317" lrx="1563" lry="658" xml:id="facsZone-staff-0000000141869093" />
@@ -106,8 +106,8 @@
         <zone ulx="1233" uly="1925" lrx="1551" lry="2275" xml:id="facsZone-staff-0000001227529403" />
         <zone ulx="1524" uly="1892" lrx="1974" lry="2272" xml:id="facsZone-staff-0000000075919496" />
       </surface>
-      <surface ulx="0" uly="0" lrx="1998" lry="2458" xml:id="facs-p495">
-        <graphic width="1998" height="2458" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/495" />
+      <surface ulx="0" uly="0" lrx="2041" lry="2487" xml:id="facs-p479">
+        <graphic width="2042" height="2488" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/479" />
         <zone ulx="24" uly="203" lrx="504" lry="529" xml:id="facsZone-staff-0000001638460942" />
         <zone ulx="468" uly="209" lrx="885" lry="526" xml:id="facsZone-staff-0000000581665083" />
         <zone ulx="858" uly="206" lrx="1137" lry="523" xml:id="facsZone-staff-0000000267017666" />
@@ -153,8 +153,8 @@
             </staffGrp>
           </scoreDef>
           <section>
-            <pb n="410" source="#secondEdition" facs="#facs-p494" />
             <pb n="204" source="#firstEdition" facs="#facs-p422" />
+            <pb n="410" source="#secondEdition" facs="#facs-p478" />
             <measure xml:id="measure-0000000706010246" n="1">
               <staff n="2" facs="#facsZone-staff-0000001152028572">
                 <layer xml:id="layer-0000001967887744" n="1">
@@ -1272,8 +1272,8 @@
               </harm>
             </measure>
             <measure xml:id="measure-0000001803695547" n="32">
-              <pb n="411" source="#secondEdition" facs="#facs-p495" />
               <pb n="205" source="#firstEdition" facs="#facs-p423" />
+              <pb n="411" source="#secondEdition" facs="#facs-p479" />
               <staff n="2" facs="#facsZone-staff-0000001638460942">
                 <layer xml:id="layer-0000001619350936" n="1">
                   <note xml:id="note-0000000635212608" dur="4" oct="3" pname="b" />

--- a/encodings/20/mattheson/score.xml
+++ b/encodings/20/mattheson/score.xml
@@ -79,8 +79,8 @@
       </surface>
     </facsimile>
     <facsimile decls="#secondEdition">
-      <surface ulx="0" uly="0" lrx="1998" lry="2481" xml:id="facs-p498">
-        <graphic width="1998" height="2481" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/498" />
+      <surface ulx="0" uly="0" lrx="2014" lry="2488" xml:id="facs-p482">
+        <graphic width="2015" height="2489" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/482" />
         <zone ulx="90" uly="356" lrx="1086" lry="646" xml:id="facsZone-staff-0000000421648790" />
         <zone ulx="1056" uly="359" lrx="1938" lry="649" xml:id="facsZone-staff-0000001572878809" />
         <zone ulx="96" uly="650" lrx="990" lry="934" xml:id="facsZone-staff-0000001715542127" />
@@ -98,8 +98,8 @@
         <zone ulx="93" uly="1874" lrx="1029" lry="2215" xml:id="facsZone-staff-0000000301680065" />
         <zone ulx="987" uly="1862" lrx="1935" lry="2221" xml:id="facsZone-staff-0000000507943915" />
       </surface>
-      <surface ulx="0" uly="0" lrx="1998" lry="2420" xml:id="facs-p499">
-        <graphic width="1998" height="2420" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/499" />
+      <surface ulx="0" uly="0" lrx="2049" lry="2487" xml:id="facs-p483">
+        <graphic width="2050" height="2488" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/483" />
         <zone ulx="57" uly="191" lrx="939" lry="508" xml:id="facsZone-staff-0000000895072582" />
         <zone ulx="909" uly="194" lrx="1365" lry="514" xml:id="facsZone-staff-0000000009902250" />
         <zone ulx="1329" uly="203" lrx="1914" lry="547" xml:id="facsZone-staff-0000000250175289" />
@@ -111,8 +111,8 @@
         <zone ulx="60" uly="1424" lrx="1896" lry="1759" xml:id="facsZone-staff-0000001925513216" />
         <zone ulx="57" uly="1688" lrx="1731" lry="2125" xml:id="facsZone-staff-0000000568155429" />
       </surface>
-      <surface ulx="0" uly="0" lrx="1998" lry="2430" xml:id="facs-p500">
-        <graphic width="1998" height="2430" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/500" />
+      <surface ulx="0" uly="0" lrx="2033" lry="2485" xml:id="facs-p484">
+        <graphic width="2034" height="2486" target="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/484" />
         <zone ulx="108" uly="218" lrx="1227" lry="547" xml:id="facsZone-staff-0000000502710151" />
         <zone ulx="1185" uly="212" lrx="1935" lry="535" xml:id="facsZone-staff-0000000956024277" />
         <zone ulx="78" uly="515" lrx="480" lry="790" xml:id="facsZone-staff-0000000956024277-2" />
@@ -163,8 +163,8 @@
             </staffGrp>
           </scoreDef>
           <section>
-            <pb n="414" source="#secondEdition" facs="#facs-p498" />
             <pb n="208" source="#firstEdition" facs="#facs-p426" />
+            <pb n="414" source="#secondEdition" facs="#facs-p482" />
             <measure xml:id="measure-0000001017587021" n="1">
               <staff xml:id="staff-0000000497456602" n="1">
                 <layer n="1">
@@ -976,8 +976,8 @@
               </harm>
             </measure>
             <measure xml:id="measure-0000000567414890" n="15">
-              <pb n="415" source="#secondEdition" facs="#facs-p499" />
               <pb n="209" source="#firstEdition" facs="#facs-p427" />
+              <pb n="415" source="#secondEdition" facs="#facs-p483" />
               <staff xml:id="staff-0000001102596487" n="1">
                 <layer n="1">
                   <mSpace />
@@ -1506,8 +1506,8 @@
           </section>
           <section>
             <measure xml:id="measure-0000000091997873" n="24">
-              <pb n="416" source="#secondEdition" facs="#facs-p500" />
               <pb n="210" source="#firstEdition" facs="#facs-p428" />
+              <pb n="416" source="#secondEdition" facs="#facs-p484" />
               <staff xml:id="staff-0000000782050009" n="1">
                 <layer n="1">
                   <mSpace />


### PR DESCRIPTION
The links to the pages of the second edition are wrong (have they changed?). I fixed PS15 to PS20 without rechecking the zones. 

NB: `width` and `height` carry total number of pixels. As the `surface` attributes start with zero coordinates the maximum has to be one lower than the respective value in `graphic`.