### PR TITLE
Unify quotes

### DIFF
--- a/encodings/10/mattheson/comments_en.xml
+++ b/encodings/10/mattheson/comments_en.xml
@@ -105,7 +105,7 @@
           follows again and it is played with all forces as full-voiced as possible, also with arpeggiations in both hands.
           Concerning the actual use of this arpeggiation, considering that it makes a big noise and is the most pervasive way
           of playing on the keyboard, it must be used nowhere else but in full-voiced pieces such as strong concerti, ouvertures,
-          symphonies and choirs, especially there, where a <foreign>forte</foreign> and <foreign>tutti</foreign> is placed;
+          symphonies and choirs, especially there, where a <foreign xml:lang="ita">forte</foreign> and <foreign xml:lang="ita">tutti</foreign> is placed;
           otherwise it would drown and ruin everything too easily. This aria can be used as something of foreign hand.
         </p>
       </div>

--- a/encodings/13/mattheson/comments_1st.xml
+++ b/encodings/13/mattheson/comments_1st.xml
@@ -112,7 +112,7 @@
           <lb/>mer, oder doch ſelten, geſehen haben, und ſich dannenhero, wenn er ihnen einmahl
           <lb/>unvermuthet begegnen ſolte, ein wenig fuͤrchten moͤchten. Es heiſſet zwar:
           <hi rendition="#aq">
-            <quote>
+            <quote xml:lang="lat">
               Entia
               <lb/>non ſunt multiplicanda praeter neceſſitatem,
             </quote>
@@ -124,7 +124,7 @@
           und mag jener alte erfahrne <hi rendition="#aq">Muſicus</hi>
           <lb/>nicht unrecht geſagt haben:
           <hi rendition="#aq">
-            <quote>
+            <quote xml:lang="lat">
               Summa eſt dementia, cantionem, quae ſimplicibus
               <lb/>Notis ſcribi poteſt, obſcuris ſignis perplexare;
             </quote>

--- a/encodings/15/mattheson/comments_de.xml
+++ b/encodings/15/mattheson/comments_de.xml
@@ -181,12 +181,10 @@
           <lb/>tze abzugeben, bey welcher ſie ſich wieder auffrichten, und in guter Einigkeit mit-
           <lb/>fortſchreiten koͤnnen. <hi rendition="#b"><persName corresp="#ed_ghv_kvx_qlb">Donius</persName></hi> ſchreibet<note place="foot" n="*)">
             <hi rendition="#aq">
-              <quote xml:id="donius-quote" xml:lang="lat" corresp="#donius-translation">
-                <foreign xml:lang="lat">
-                  <lb/>De tibicinum romanorum ſui temporis imperitia ſic loquitur: <hi rendition="#i">Demiratus ſum minus,
-                    <lb/>iis in uſu eſſe rhythmum pedibus moderari: ſine quo vix numeros exacte ſequi unquam poſ-
-                    <lb/>ſunt.</hi>
-                </foreign>
+              <quote xml:id="donius-quote" corresp="#donius-quote-trans" xml:lang="lat">
+                <lb/>De tibicinum romanorum ſui temporis imperitia ſic loquitur: <hi rendition="#i">Demiratus ſum minus,
+                <lb/>iis in uſu eſſe rhythmum pedibus moderari: ſine quo vix numeros exacte ſequi unquam poſ-
+                <lb/>ſunt.</hi>
               </quote>
               <bibl corresp="#ed_i1b_lfl_tlb">Don. de Præst. Vet. Music. pag. 111.</bibl>
             </hi>
@@ -194,7 +192,7 @@
           <note type="editorial" resp="#pfeffer">
             Doni bezieht sich hier auf das sogenannte collegium tibicinum, eine Musikergenossenschaft im antiken Rom.
           </note>
-          <quote type="translation" xml:id="donius-translation" corresp="#donius-quote">
+          <quote type="translation" xml:id="donius-quote-trans" corresp="#donius-quote">
             von den <orgName>Roͤmischen Kunſt-Pfeiffern</orgName>
             und ihrer Unerfahrenheit, alſo:
             <hi rendition="#b">
@@ -243,13 +241,11 @@
             Gemeint ist <persName>Basilius der Große</persName>.
           </note>
           ſchreibet:
-          <hi rendition="#aq">
-            <quote xml:id="basilius-quote" corresp="#basilius-translation" xml:lang="lat">
-              <foreign xml:lang="lat">Non adeſt Eccleſia ut audiat mirabilia &amp;c.</foreign>
-            </quote>
-          </hi>
+          <hi rendition="#aq"><quote xml:id="basilius-quote" corresp="#basilius-quote-trans" xml:lang="lat">
+            Non adeſt Ecclesia ut audiat mirabilia &amp;c.
+          </quote></hi>
           <hi rendition="#b">
-            <quote type="translation" corresp="#basilius-quote" xml:id="basilius-translation">
+            <quote type="translation" corresp="#basilius-quote" xml:id="basilius-quote-trans">
               Es kom-
               <lb/>me nemlich die Chriſtliche <sic>Gemeine</sic> nicht deßwegen zusammen, daß
               <lb/>ſie Wunder-Dinge

--- a/encodings/18/mattheson/comments_1st.xml
+++ b/encodings/18/mattheson/comments_1st.xml
@@ -216,10 +216,8 @@
           <lb/>werden kan, iſt ſonſt eine Sache die nicht alle Tage auffstöſſet, der edlen <hi rendition="#aq">Muſique</hi>
           <lb/>aber eine ſonderbare Avantage giebt. Siehe die Vorbereitung.
           <quote xml:lang="lat">
-            <foreign xml:lang="lat">
               Hanc Reges
               <lb/>olim &amp; ſummi Principes didicere; hanc <hi rendition="#i">publice</hi> &amp; privatim exercuere
-            </foreign>
           </quote>,
           wie <hi rendition="#i"><persName corresp="#ed_rkl_p3j_vlb">Marcus Meibom.</persName> in
           <bibl corresp="#ed_cqx_yjj_vlb">Dedic. antiqu. Muſ. ad Reginam Chriſtinam</bibl></hi>

--- a/encodings/20/mattheson/comments_de.xml
+++ b/encodings/20/mattheson/comments_de.xml
@@ -240,7 +240,7 @@
         <p xml:id="p8-1" facs="#facsZone-p8-1">
           <lb/>Daß dieſer Ton in Franckreich was rares ſeyn muͤſſe, erſehe aus dem Lam-
           <lb/>bertiſchen<note place="foot" n="*)"><hi rendition="#aq"><foreign xml:lang="fra">
-          <quote xml:id="lambert-quote" corresp="#lambert-translation" xml:lang="fra">
+          <quote xml:id="lambert-quote" corresp="#lambert-quote-trans" xml:lang="fra">
             Le B Fa Si Beccarre etant un Ton, ſur lequel on compoſe rarement, il n'y a point
             <lb/>de modulation qui lui ſoit particulierement affectée: ſ'il en avoit une, ce croit la mineure.
           </quote></foreign>
@@ -248,7 +248,7 @@
             <hi rendition="#i"><persName corresp="#ed_dwf_j5x_qlb">Mr. de St. Lambert</persName>,
             Traité de l'Accompagnement</hi>, <hi rendition="#i">p.</hi>27.
           </bibl></hi></note> Buche vom General-Baß, da es ſo lautet: <hi rendition="#b">
-          <quote xml:id="lambert-translation" type="translation" corresp="#lambert-quote">
+          <quote xml:id="lambert-quote-trans" type="translation" corresp="#lambert-quote">
             H iſt ein Ton, aus wel-
             <lb/>chem man ſelten etwas ſetzet, daher hat er auch eigentlich keine Tertz, die
             <lb/>ihm beſonders zugehoͤrt; haͤtte er aber eine, ſo muͤſte es wol die kleine

--- a/encodings/20/mattheson/comments_de.xml
+++ b/encodings/20/mattheson/comments_de.xml
@@ -86,7 +86,7 @@
       </surface>
       <surface ulx="0" uly="0" lrx="1998" lry="2426" xml:id="facs-p502">
           <graphic width="1998px" height="2426px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/502"/>
-          <zone ulx="90" uly="185" lrx="440" xml:id="facsZone-p2-1-2"/>
+          <zone ulx="90" uly="185" lry="440" lrx="1941" xml:id="facsZone-p2-1-2"/>
           <zone ulx="93" uly="407" lry="760" lrx="1941" xml:id="facsZone-p3-1"/>
           <zone ulx="102" uly="737" lry="1057" lrx="1938" xml:id="facsZone-music-example3"/>
           <zone ulx="711" uly="1586" lry="1849" lrx="1359" xml:id="facsZone-music-example4"/>

--- a/encodings/24/mattheson/comments_de.xml
+++ b/encodings/24/mattheson/comments_de.xml
@@ -187,17 +187,17 @@
           <lb />Ich könnte wol den weiſen <persName corresp="#ed_mnv_cks_tlb">Horatianiſchen</persName> Spruch:
           <lb />
           <note n="*)" place="foot">
-            <persName corresp="#ed_mnv_cks_tlb">Hor.</persName> <bibl corresp="#ed_hgg_fw1_5lb">de Art. Poet.</bibl> V. 306.
-            Es hatte nehmlich Horatius nie ein theatraliſches oder epiſches Ge-
+            <bibl corresp="#ed_hgg_fw1_5lb">Hor. de Art. Poet.</bibl> V. 306.
+            Es hatte nehmlich <persName corresp="#ed_mnv_cks_tlb">Horatius</persName> nie ein theatraliſches oder epiſches Ge-
             <lb />dicht geſchrieben, und gab doch Regeln davon, die biß auf den heutigen Tag hochgeachtet
             <lb />werden.
           </note>
           <hi rendition="#aq">
-            <quote>Munus &amp; officium, nil ſcribens, ipſe docebo</quote>,
+            <quote xml:id="horaz-quote" corresp="#horaz-quote-trans" xml:lang="lat">Munus &amp; officium, nil ſcribens, ipſe docebo</quote>,
           </hi>
           folgender Geſtalt verteutſchen und ſagen:
           <hi rendition="#b">
-            <quote>Laß ich mich ſelber gleich nicht mehr mit Spielen Horen;
+            <quote xml:id="horaz-quote-trans" corresp="#horaz-quote">Laß ich mich ſelber gleich nicht mehr mit Spielen Horen;
               So kann ich andre doch den General-Baß lehren.</quote>
           </hi>
           <fw place="bottom" type="catch">Da.</fw>
@@ -249,7 +249,7 @@
           Lob-Gedicht
           <note type="editorial" resp="#pfeffer">
             zu jenem Lobgedicht hat Mattheson die Worte
-            <quote xml:id="mattheson-quote" corresp="#mattheson-quote-trans">
+            <quote xml:id="mattheson-quote" corresp="#mattheson-quote-trans" xml:lang="lat">
               "–.– rumpantur ut ilia Hancken"
             </quote>
             (<quote type="translation" xml:id="mattheson-quote-trans" corresp="#mattheson-quote">
@@ -537,21 +537,19 @@
         <p>
           <persName corresp="#ed_ghv_kvx_qlb">Donius</persName>
           <note n="e)" place="foot">
-            <cit>
-              <quote xml:lang="lat">
-                <hi rendition="#aq">
-                  <lb />Non ſolo non baſtano le voci di queſti Inſtromenti ſpezzati, che dicono chromati-
-                  <lb />ci, màne meno di quelli che dicono enarmonici. Oltre che ſarebbe gran temeri-
-                  <lb />tà di dire, che con l'iſteſſa facilità, ommodità e preſtezza ſi poſſa caminare con
-                  <lb />le dite ſui taſti neri e ſpezzati, diſpoſti in una ſola taſtatura, che ſopra diverſe ta-
-                  <lb />ſtature e armonie, ſecondo la noſtra inventione, ſenza mettere a conto la com-
-                  <lb />modità, che ſi riceve da più ſiſtemi, di poter far ſentire gra diverſità trà gli uni-
-                  <lb />ſoni ſteſſi, mediante maggiore o minore tenſione delle corde, come nelle viole e
-                  <lb />ne' cembali ſ'è trattico. 
-                </hi>
-              </quote>
-              <bibl corresp="#ed_s4h_t1b_5lb" rend="#i"><persName corresp="#ed_ghv_kvx_qlb">Doni</persName>, Annotaz. p. 6.</bibl>
-            </cit>
+            <quote xml:lang="lat">
+              <hi rendition="#aq">
+                <lb />Non ſolo non baſtano le voci di queſti Inſtromenti ſpezzati, che dicono chromati-
+                <lb />ci, màne meno di quelli che dicono enarmonici. Oltre che ſarebbe gran temeri-
+                <lb />tà di dire, che con l'iſteſſa facilità, ommodità e preſtezza ſi poſſa caminare con
+                <lb />le dite ſui taſti neri e ſpezzati, diſpoſti in una ſola taſtatura, che ſopra diverſe ta-
+                <lb />ſtature e armonie, ſecondo la noſtra inventione, ſenza mettere a conto la com-
+                <lb />modità, che ſi riceve da più ſiſtemi, di poter far ſentire gra diverſità trà gli uni-
+                <lb />ſoni ſteſſi, mediante maggiore o minore tenſione delle corde, come nelle viole e
+                <lb />ne' cembali ſ'è trattico. 
+              </hi>
+            </quote>
+            <bibl corresp="#ed_s4h_t1b_5lb" rend="#i"><persName corresp="#ed_ghv_kvx_qlb">Doni</persName>, Annotaz. p. 6.</bibl>
           </note>
           ſtehet in den Gedancken: <hi rendition="#b">Daß es mit den Stoffen der chro-
             <lb />matiſchen Claviere eben ſo wenig, als mit der enharmoniſchen Ein-
@@ -599,14 +597,12 @@
           <lb />niger maſſen eben ſo bewandt, als mit andern Dingen, und <note
               n="(f)" place="foot">
               <hi rendition="#aq">
-                <cit>
-                  <quote xml:lang="fra">
-                    <foreign xml:lang="fra">Ce qui faiſoit honneur il ya cent ans, eſt en quelque maniere honteux aujourdhui.</foreign>
-                  </quote>
-                  <bibl corresp="#ed_nhc_gbb_5lb">
-                    <lb /><hi rendition="#i">Memoir. de Buſſy, p. 105.</hi>
-                  </bibl>
-                </cit>
+                <quote xml:lang="fra">
+                  <foreign xml:lang="fra">Ce qui faiſoit honneur il ya cent ans, eſt en quelque maniere honteux aujourdhui.</foreign>
+                </quote>
+                <bibl corresp="#ed_nhc_gbb_5lb">
+                  <lb /><hi rendition="#i">Memoir. de Buſſy, p. 105.</hi>
+                </bibl>
               </hi>
             </note>
           was <date when="1631">vor hundert
@@ -685,7 +681,7 @@
         <p>
           Es ſind aber des <persName corresp="#ed_tj3_cwx_qlb">Herrn Marcello</persName>
           <note n="h)" place="foot">
-            <quote xml:id="marcello-quote" corresp="marcello-quote-trans">
+            <quote xml:id="marcello-quote" corresp="marcello-quote-trans" xml:lang="ita">
               Affine che creſcano alcune corde d'un intero tuono, dove non ſieno obligati gli
               <lb />accidenti maggiori alla chiave, ſi ſono apoſti due ## chromatici, non uſandoſi
               <lb />mai per cotal effetto nel preſente lavoro l'erharmonico x dieſis, ſiccome in ſimile
@@ -868,7 +864,7 @@
           <lb />Zeichen. Wegen des erſten ſchreibt ein Frantzösiſcher
           <note n="*)" place="foot">
             <hi rendition="#aq"><foreign xml:lang="fra">
-              <quote xml:id="brossard-quote" corresp="#corresp-translation">
+              <quote xml:id="brossard-quote" corresp="#corresp-quote-trans" xml:lang="fra">
                 <hi rendition="#i">Quadrato:</hi> c'eſt l'epithete qu'on donne au b, quand il eſt ſigne diatonique, ou na-
                 <lb />turel, &amp; figurè ainſi <hi rendition="#i">h</hi>, &amp; pour lors ſon effet eſt de remettre les corde alterées
                 <lb />par le dieze ou par le <hi rendition="#i">b</hi> mol, dans leur ſituation naturelle, &amp; de deſcendre d'un demi-
@@ -878,7 +874,7 @@
             <lb /><hi rendition="#i"><persName corresp="#ed_xbw_55b_5lb">Rouſſeau</persName>, dans ſa <bibl corresp="#ed_dyl_r5b_5lb">Methode pour chanter</bibl>, p. 77.</hi></foreign></hi>
           </note>
           Verfaſſer alſo:
-          <quote type="translation" xml:id="brossard-translation" corresp="#brossard-quote">
+          <quote type="translation" xml:id="brossard-quote-trans" corresp="#brossard-quote">
             Man le-
             <lb />get dem h das Beiwort, viereckigt, zu, wenn es ein diatoniſches Zeichen iſt;
             <lb />und als denn hat es die Wirckung, daß es die Saiten oder Klänge, welche durch
@@ -969,7 +965,7 @@
           <note place="foot" n="a)">
             <hi rendition="#aq">
               <foreign xml:lang="lat">
-                <quote xml:id="morhof-quote" corresp="#morhof-translation">
+                <quote xml:id="morhof-quote" corresp="#morhof-quote-trans" xml:lang="lat">
                   Quod ſi forte erunt, qui has minutias contemnendas judicauerint, illi ſciant, nihil
                   minutum aut leue eſſe, quod cum juuentutis commodo cunjunctum eſt.
                 </quote>
@@ -979,7 +975,7 @@
             </hi>
           </note>
           groſſen Mann:
-          <quote type="translation" corresp="#morhof-quote" xml:id="morhof-translation">
+          <quote type="translation" corresp="#morhof-quote" xml:id="morhof-quote-trans">
             <hi rendition="#b">Sollten ſich Leute finden,
             <lb /> die ſolche Kleinigkeiten für verächtlich hielten; ſo mögen ſie wol wiſ-
             <lb />ſen, daß nichts klein oder geringe ſeyn könne, welches mit dem Vor-
@@ -1130,7 +1126,7 @@
            <note place="foot" n="h)">
              <hi rendition="#aq">
                <foreign xml:lang="lat">
-                 <quote xml:id="salin-quote" corresp="#salin-translation">
+                 <quote xml:id="salin-quote" corresp="#salin-quote-trans" xml:lang="lat">
                    Quod nunc Inſtrumentorum defectui meritò adſcribitur, tunc ipſius Organiſtae cul-
                    <lb />pae tribueter.
                  </quote>
@@ -1140,7 +1136,7 @@
            </note>
            ſpricht,
            <hi rendition="#b">
-             <quote type="translation" xml:id="salin-translation" corresp="#salin-quote">
+             <quote type="translation" xml:id="salin-quote-trans" corresp="#salin-quote">
                was dem
                <lb />Mangel des Jnſtruments anjetzo mit Recht beigelegt wird, alsdenn
                <lb />dem Organiſten zur Schuld gereiche, wenns nicht rein klingt.
@@ -1207,14 +1203,12 @@
           <lb />denn der offt gedachte <persName corresp="#ed_rtv_wrx_qlb">Henfling</persName>
           <note place="foot" n="(n)">
             <hi rendition="#aq">
-              <foreign xml:lang="lat">
-                <quote>
-                  Nec illi, qui duodecimam commatis partem ab hypate quavis ſubducunt, diapaſon
-                  <lb />claudere queunt, qui, ſi inſtituto ſuo recte inhaereant, ultra illud quintate
-                  <figure></figure>
-                  <lb />progrediuntur. <bibl corresp="#ed_wnr_txb_5lb">Miſcell. Berol.</bibl> Vol. I., p. 287.
-                </quote>
-              </foreign>
+              <quote xml:lang="lat">
+                Nec illi, qui duodecimam commatis partem ab hypate quavis ſubducunt, diapaſon
+                <lb />claudere queunt, qui, ſi inſtituto ſuo recte inhaereant, ultra illud quintate
+                <figure></figure>
+                <lb />progrediuntur. <bibl corresp="#ed_wnr_txb_5lb">Miſcell. Berol. Vol. I., p. 287.</bibl>
+              </quote>
             </hi>
           </note>
           ſchon vor vielen Jahren dargethan hat, daß die-

--- a/encodings/24/mattheson/comments_de.xml
+++ b/encodings/24/mattheson/comments_de.xml
@@ -1254,7 +1254,7 @@
           <lb />gleiche Theile der Octave nicht nur vor Augen legen,
           <note n="(p)" place="foot">
             <hi rendition="#aq">
-              Voy. Hiſtoire des Ouvrages des Savans. Octobre. 1691.
+              Voy. <bibl corresp="#ed_ne8-ak3-gpr">Hiſtoire des Ouvrages des Savans. Octobre. 1691.</bibl>
             </hi>
           </note>
           ſondern leicht, ich weiß nicht

--- a/encodings/24/mattheson/comments_de.xml
+++ b/encodings/24/mattheson/comments_de.xml
@@ -1062,7 +1062,7 @@
         <p>
           <lb /><hi rendition="#b"><persName corresp="#ed_jlh_wvy_qlb">Zarlin</persName></hi>
           <note place="foot" n="*)">
-            Siehe was unſere Vorbereitung p. 4. und das <bibl corresp="#ed_vtr_vzb_5lb">Gelehrte Lexicon</bibl> p. 1602. von dieſem Mann
+            Siehe was unſere Vorbereitung p. 4. und das <bibl corresp="#ed_vtr_vzb_5lb">Gelehrte Lexicon p. 1602.</bibl><note type="editorial" resp="#rettinghaus">Bd. 2, Sp. 1975.</note> von dieſem Mann
             <lb />ſagen. Er war Capellmeiſter der <placeName ref="https://www.geonames.org/3164603">Republick Venedig</placeName>.
           </note>
           und <hi rendition="#b"><persName corresp="#ed_rpk_l2y_qlb">Salin</persName></hi>, zween der beſten muſicaliſchen Scribenten, hiel-
@@ -1159,7 +1159,7 @@
            <lb />und das <date>77. Jahr ſeines Alters erreicht hat.</date>
            <note n="i)" place="foot">
              Siehe die Vorbereitung, oder erſte Claſſe dieſes Wercks p. 4., ingleichen das <bibl corresp="#ed_vtr_vzb_5lb">Gelehrten-Lexi-
-             <lb />con, p. 886.</bibl>
+             <lb />con, p. 886.</bibl><note type="editorial" resp="#rettinghaus">Bd. 2, Sp. 995.</note>
            </note>
          </p>
       </div>

--- a/encodings/5/mattheson/comments_en.xml
+++ b/encodings/5/mattheson/comments_en.xml
@@ -70,7 +70,7 @@
             one is out of poverty and sparingness so modest and will contradict me so little in that, that both duties are given to one person,
             through which many voices accrue in my opinion. But jokes aside. Who does not want to believe me and so many honest
             and upright men, shall try out the church music, that an organist not able to sing has created (for those people have fruitful nights, in which
-            dozens of their mushrooms – I mean, their so-called <foreign>compositiones</foreign> force their way out of the earth)
+            dozens of their mushrooms – I mean, their so-called <foreign xml:lang="lat">compositiones</foreign> force their way out of the earth)
             and shall listen, how badly the melodies are arranged, how poor it sounds. Who wants to go further,
             shall let such a person inexperienced in singing (we are
             not talking about those who did their part in the art of singing) play this example – he will see and hear wonders.

--- a/encodings/8/mattheson/comments_1st.xml
+++ b/encodings/8/mattheson/comments_1st.xml
@@ -93,7 +93,7 @@
           <lb/><hi rendition="#aq"><persName corresp="#ed_dwf_j5x_qlb">Monſr. de St. Lambert</persName></hi>
           ſagt <hi rendition="#aq">pag. 27.</hi> ſeines Tractats, von diesem Ton:
 
-          <quote xml:id="lambert-quote" corresp="#lambert-quote-trans">
+          <quote xml:id="lambert-quote" corresp="#lambert-quote-trans" xml:lang="fra">
             <hi rendition="#aq">Que le
             <lb/>G Re ſol n'a point de modulation qui lui ſoit plus naturelle
             que l'autre, &amp; qu'on

--- a/encodings/8/mattheson/comments_1st.xml
+++ b/encodings/8/mattheson/comments_1st.xml
@@ -117,7 +117,7 @@
       </div>
 
       <fw place="bottom" type="catch">Er-</fw>
-      <pb n="142"/>
+      <pb n="142" facs="#facs-p308"/>
 
       <div n="0" type="chapter">
         <head>Erlaͤuterung.</head>
@@ -158,7 +158,7 @@
             Keiner wolle ſich indeſſen einbilden, man gebe dieſe <hi rendition="#aq">Aria</hi> fuͤr Hand-Sa-
             <lb/>chen aus; denn die muͤſſen anders kommen: Ein Curieuſer beliebe auch nur et-
             <fw place="bottom" type="catch">wann</fw>
-            <pb n="143"/>
+            <pb n="143" facs="#facs-p309"/>
 
             auch nur eine <hi rendition="#aq"><foreign xml:lang="fra">Suite</foreign></hi> des
             <persName ref="http://d-nb.info/gnd/118718517">Herrn Capell-Meister <hi rendition="#b"><persName corresp="#ed_md2_fmx_qlb">Graupners</persName></hi>

--- a/encodings/9/mattheson/comments_1st.xml
+++ b/encodings/9/mattheson/comments_1st.xml
@@ -164,14 +164,12 @@
             <lb/>Stimme <hi rendition="#aq">accompagnirt</hi>, und die <hi rendition="#aq">Subjecta</hi> oder Fugen der <hi rendition="#aq">Arie</hi> mit allen Par-
             <lb/>teyen auf ſeinem Clavier dabey <hi rendition="#aq">imiti</hi>ret. Seine Worte lauten <hi rendition="#aq">pag. 63</hi> alſo:
             <hi rendition="#aq">
-              <quote>
-                <foreign xml:lang="fra">
-                  Quand on accompagne une voix ſeule qui chante quelque Air de mouvement,
-                  <lb/>dans lequel il y a pluſieurs imitations de chants, <abbr>NB.</abbr> tels que ſont les Airs Ita-
-                  <lb/>liens, on peut imiter ſur ſon Clavecin le Sujet &amp; les Fuges de l'Air, faisant entrer
-                  <lb/>les Parties l'une après l'autre; mais cela demande une ſcience consommée, &amp; il
-                  <lb/>faut etre du premier Ordre pour y reussir.
-                </foreign>
+              <quote xml:lang="fra">
+                Quand on accompagne une voix ſeule qui chante quelque Air de mouvement,
+                <lb/>dans lequel il y a pluſieurs imitations de chants, <abbr>NB.</abbr> tels que ſont les Airs Ita-
+                <lb/>liens, on peut imiter ſur ſon Clavecin le Sujet &amp; les Fuges de l'Air, faisant entrer
+                <lb/>les Parties l'une après l'autre; mais cela demande une ſcience consommée, &amp; il
+                <lb/>faut etre du premier Ordre pour y reussir.
               </quote>
             </hi>
             Hierunter koͤnnen diese <hi rendition="#aq">Exempla</hi> als

--- a/encodings/9/mattheson/comments_1st.xml
+++ b/encodings/9/mattheson/comments_1st.xml
@@ -175,7 +175,7 @@
               </quote>
             </hi>
             Hierunter koͤnnen diese <hi rendition="#aq">Exempla</hi> als
-            <lb/>als Muſter, dienen. Jch haͤtte gerne etliche mehr <hi rendition="#aq">de ce premir Ordre</hi> in der Welt,
+            <lb/>Muſter, dienen. Jch haͤtte gerne etliche mehr <hi rendition="#aq"><foreign xml:lang="fra">de ce premir Ordre</foreign></hi> in der Welt,
             <lb/>es ſind ihrer gar zu wenig.
             <hi rendition="#aq">
               <foreign xml:lang="fra">

--- a/encodings/9/mattheson/comments_de.xml
+++ b/encodings/9/mattheson/comments_de.xml
@@ -178,15 +178,13 @@
                 Wenn
                 <note place="foot" n="*)">
                   <hi rendition="#aq">
-                    <quote xml:id="lambert-quote" corresp="#lambert-quote-trans">
-                      <foreign xml:lang="fra">
-                        Quand on accompagne une voix ſeule qui chante quelque Air demouvement, dans lequel il
-                        <lb/>y a pluſieurs imitations de chants, tels que ſont les Airs Italiens, on peut imiter ſur ſon
-                        <lb/>Clavecin le Sujet &amp; les Fuges de l'Air, faisant entrer les Parties l'une après l'autre; mais cela
-                        <lb/>demande une ſcience consommée, &amp; il faut etre du premier Ordre pour y reussir.
-                        <hi rendition="#i">Voy. <bibl corresp="#ed_hfr_2cl_tlb">Traité
-                        <lb/>de l'accompagn. de Mr. de St. Lambert, p. 63.</bibl></hi>
-                      </foreign>
+                    <quote xml:id="lambert-quote" corresp="#lambert-quote-trans" xml:lang="fra">
+                      Quand on accompagne une voix ſeule qui chante quelque Air demouvement, dans lequel il
+                      <lb/>y a pluſieurs imitations de chants, tels que ſont les Airs Italiens, on peut imiter ſur ſon
+                      <lb/>Clavecin le Sujet &amp; les Fuges de l'Air, faisant entrer les Parties l'une après l'autre; mais cela
+                      <lb/>demande une ſcience consommée, &amp; il faut etre du premier Ordre pour y reussir.
+                      <hi rendition="#i">Voy. <bibl corresp="#ed_hfr_2cl_tlb">Traité
+                      <lb/>de l'accompagn. de Mr. de St. Lambert, p. 63.</bibl></hi>
                     </quote>
                   </hi>
                 </note>

--- a/encodings/guidelines/guidelines_en.xml
+++ b/encodings/guidelines/guidelines_en.xml
@@ -90,14 +90,14 @@
       <div>
         <head>Text</head>
         <p>
-          All textes are provided as a diplomatic transcription, preserving original linebreaks, orthography,
+          All texts are provided as a diplomatic transcription, preserving original line breaks, orthography,
           mistakes and other idiosyncrasies. Text portions of this edition follow the guidelines of the
           <ref target="http://www.deutschestextarchiv.de/doku/basisformat/introduction_en.html"> DTA ›Base Format‹ (DTABf)</ref>.
           Thus, only deviations from the <hi rend="italic">DTABf</hi> are specified here.
         </p>
 
         <p>
-          All <hi rend="bold">/</hi> of the original textes are reproduced as normal commata (<hi rend="bold">,</hi>).
+          All <hi rend="bold">/</hi> of the original texts are reproduced as normal commata (<hi rend="bold">,</hi>).
         </p>
 
         <p>

--- a/encodings/guidelines/guidelines_en.xml
+++ b/encodings/guidelines/guidelines_en.xml
@@ -129,6 +129,11 @@
           When the text is referencing a particular measure, note, clef etc. of the score, a <tag>ref</tag>
           element should be used, with the <code>@target</code> attribute pointing to the corresponding element(s) of the score.
         </p>
+
+        <p>
+          Foreign words in the continuous text are marked with the <tag>foreign</tag> tag,
+          while foreign-language quotations are marked only with the corresponding attribute on the <tag>quote</tag> tag.
+        </p>
       </div>
     </body>
   </text>

--- a/encodings/indices/bibliography.xml
+++ b/encodings/indices/bibliography.xml
@@ -32,6 +32,9 @@
                     </editor>
                     <title>Critica Musica</title>
                 </bibl>
+                <bibl type="journal" xml:id="ed_ne8-ak3-gpr">
+                    <title>Histoire des Ouvrages des Savans</title>
+                </bibl>
                 <bibl type="journal" xml:id="ed_wnr_txb_5lb">
                     <title>Miscellanea Berolinensia</title>
                 </bibl>

--- a/encodings/indices/bibliography.xml
+++ b/encodings/indices/bibliography.xml
@@ -25,6 +25,7 @@
                     <title>Compendiöses Gelehrten-Lexicon</title>
                     <pubPlace>Leipzig</pubPlace>
                     <date>1726</date>
+                    <note target="https://www.digitale-sammlungen.de/de/view/bsb10797509" />
                 </bibl>
                 <bibl xml:id="ed_app_scb_5lb" type="journal">
                     <editor>
@@ -186,6 +187,7 @@
                     <title>Exemplarische Organisten-Probe</title>
                     <pubPlace>Hamburg</pubPlace>
                     <date>1719</date>
+                    <note target="https://www.digitale-sammlungen.de/de/view/bsb10527430" />
                 </bibl>
                 <bibl xml:id="ed_cqx_yjj_vlb">
                     <author>

--- a/encodings/indices/persons.xml
+++ b/encodings/indices/persons.xml
@@ -541,9 +541,9 @@
                     <idno type="uri">http://d-nb.info/gnd/119378523</idno>
                     <persName type="reg">
                         <surname>Salinas</surname>
-                        <forename>Francisco</forename>
+                        <forename>Francisco de</forename>
                     </persName>
-                    <birth>1530</birth>
+                    <birth>1513</birth>
                     <death>1590</death>
                 </person>
                 <person xml:id="ed_nhl_nxx_qlb">


### PR DESCRIPTION
This unifies all quotes to directly use the respective language attribute instead of having a `foreign` child.
Also it unifies the xml:id schema to `{author}-quote-trans`.

On the way some small problems were fixed and an entry added to the bibliography.