### PR TITLE
Add facsimile information

### DIFF
--- a/encodings/1/mattheson/comments_de.xml
+++ b/encodings/1/mattheson/comments_de.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../../schema/basisformat_customized.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>
@@ -20,7 +20,7 @@
       </titleStmt>
       <publicationStmt>
         <publisher>
-          <persName xml:id="pfeffer">
+          <persName>
             <surname>Pfeffer</surname>
             <forename>Niels</forename>
           </persName>

--- a/encodings/11/mattheson/comments_en.xml
+++ b/encodings/11/mattheson/comments_en.xml
@@ -91,7 +91,7 @@
 
       <div n="4">
         <head>§. 4.</head>
-        <p xml:id="p4-2">
+          <p xml:id="p4-1">
           The <ref target="#measure-0000000233971040">tenth measure of the last section</ref>
           needs an arpeggiation with the sixth and fifth in the right hand as the left
           hand has introduced previously. In the

--- a/encodings/18/mattheson/comments_1st.xml
+++ b/encodings/18/mattheson/comments_1st.xml
@@ -74,16 +74,25 @@
     </fileDesc>
   </teiHeader>
   <facsimile>
-    <surface ulx="0" uly="0" lry="1881" lrx="1579" xml:id="facs-p381">
-      <graphic width="1579px" height="1881px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/381" />
-    </surface>
-    <surface ulx="0" uly="0" lry="1930" lrx="1579" xml:id="facs-p382">
-      <graphic width="1579px" height="1930px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/382" />
-    </surface>
-    <surface ulx="0" uly="0" lry="1908" lrx="1579" xml:id="facs-p383">
-      <graphic width="1579px" height="1908px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/383" />
-    </surface>
-  </facsimile>
+    <surface ulx="0" uly="0" lrx="1987" lry="2379" xml:id="facs-p418" n="198">
+      <graphic width="1988px" height="2380px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/418" />
+  </surface>
+  <surface ulx="0" uly="0" lrx="1939" lry="2379" xml:id="facs-p419" n="199">
+      <graphic width="1940px" height="2380px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/419" />
+  </surface>
+  <surface ulx="0" uly="0" lrx="1934" lry="2367" xml:id="facs-p420" n="200">
+      <graphic width="1935px" height="2368px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/420" />
+  </surface>
+  <surface ulx="0" uly="0" lrx="1978" lry="2371" xml:id="facs-p421" n="201">
+      <graphic width="1979px" height="2372px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/421" />
+  </surface>
+  <surface ulx="0" uly="0" lrx="1926" lry="2364" xml:id="facs-p422" n="202">
+      <graphic width="1927px" height="2365px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/422" />
+  </surface>
+  <surface ulx="0" uly="0" lrx="1959" lry="2379" xml:id="facs-p423" n="203">
+      <graphic width="1960px" height="2380px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/423" />
+  </surface>
+</facsimile>
   <text>
     <body>
       <div>
@@ -141,7 +150,7 @@
             <lb/>und dreyßigſten</ref> und <ref target="#measure-0000000804701007">acht und dreyßigſten Tact</ref> in acht nehmen, und dazu eben das
             <lb/>ſpielen, was der Baß in den beyden vorhergehenden Taͤcten gehabt hat; doch alſo,
             <fw place="bottom" type="catch">als</fw>
-            <pb n="202" facs="#facs-p382"/>
+            <pb facs="#facs-p422" n="202" />
             <lb/>als wenn nun ein niedriger Diſcant-Schluͤſſel davor ſtuͤnde. Die <ref target="#measure-0000001280575648 #measure-0000001343838691 #measure-0000001748474312 #measure-0000000023982366">folgenden vier
             <lb/>Taͤcte</ref>, biß zum Schluß des erſten Theils, werden gantz ſtarck, mit Zuſchlagung zu je-
             <lb/>der Note, angegriffen, und vollſtimmig <hi rendition="#aq">abſolvi</hi>rt.
@@ -184,6 +193,7 @@
             <notatedMusic xml:id="music-example1">
               <ptr target="music-example1.xml"/>
             </notatedMusic>
+            <!--<pb facs="#facs-p423" n="203" />-->
             <lb/>Wobey jedoch unauſbleiblich die lincke Hand alles auf das vollſtimmigſte an-
             <lb/>ſchlagen muß, welches je und allewege feſt geſetzet wird.
           </p>

--- a/encodings/19/mattheson/comments_1st.xml
+++ b/encodings/19/mattheson/comments_1st.xml
@@ -73,13 +73,19 @@
     </fileDesc>
   </teiHeader>
   <facsimile>
-    <surface ulx="0" uly="0" lry="1899" lrx="1579" xml:id="facs-p386">
-      <graphic width="1579px" height="1899px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/386" />
-    </surface>
-    <surface ulx="0" uly="0" lry="1869" lrx="1579" xml:id="facs-p387">
-      <graphic width="1579px" height="1869px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/387" />
-    </surface>
-  </facsimile>
+    <surface ulx="0" uly="0" lrx="1939" lry="2365" xml:id="facs-p424" n="204">
+      <graphic width="1940px" height="2366px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/424" />
+  </surface>
+  <surface ulx="0" uly="0" lrx="1957" lry="2357" xml:id="facs-p425" n="205">
+      <graphic width="1958px" height="2358px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/425" />
+  </surface>
+  <surface ulx="0" uly="0" lrx="1951" lry="2411" xml:id="facs-p426" n="206">
+      <graphic width="1952px" height="2412px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/426" />
+  </surface>
+  <surface ulx="0" uly="0" lrx="1971" lry="2403" xml:id="facs-p427" n="207">
+      <graphic width="1972px" height="2404px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/427" />
+  </surface>
+</facsimile>
   <text>
     <body>
       <div n="0" type="chapter">

--- a/encodings/20/mattheson/comments_1st.xml
+++ b/encodings/20/mattheson/comments_1st.xml
@@ -73,6 +73,29 @@
       </sourceDesc>
     </fileDesc>
   </teiHeader>
+  <facsimile>
+    <surface ulx="0" uly="0" lrx="1955" lry="2419" xml:id="facs-p428">
+      <graphic width="1956px" height="2420px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/428" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1944" lry="2371" xml:id="facs-p429">
+      <graphic width="1945px" height="2372px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/429" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1966" lry="2340" xml:id="facs-p430">
+      <graphic width="1967px" height="2341px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/430" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2009" lry="2363" xml:id="facs-p431">
+      <graphic width="2010px" height="2364px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/431" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2002" lry="2363" xml:id="facs-p432">
+      <graphic width="2003px" height="2364px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/432" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1950" lry="2364" xml:id="facs-p433">
+      <graphic width="1951px" height="2365px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/433" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1971" lry="2375" xml:id="facs-p434">
+      <graphic width="1972px" height="2376px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/434" />
+    </surface>
+  </facsimile>
   <text>
     <body>
       <div n="0" type="chapter">
@@ -103,7 +126,7 @@
           <notatedMusic xml:id="music-example2" facs="#facsZone-music-example2">
             <ptr target="music-example2.xml"/>
           </notatedMusic>
-          <pb n="212" />
+          <pb facs="#facs-p432" n="212" />
           <lb />wie auch im <ref target="#measure-0000001425906512">achtzehnten</ref> und <ref target="#measure-0000000763300727">neunzehnten</ref> dieſelbe <hi rendition="#aq">Paſſage</hi> wieder vorko&#x0364;mmt; Wer
           <lb />aber im <ref target="#measure-0000001527420734">zwantzigſten</ref> und folgenden <hi rendition="#aq">Menſu</hi>ren nicht zu ſpa&#x0364;t erſcheinen will, der
           <lb />muß nicht lange ſa&#x0364;umen, ſondern die Finger <hi rendition="#aq">galoppi</hi>ren laſſen.
@@ -149,7 +172,7 @@
           <lb />die rechte Hand ihre Accorte und Griffe eben ſo bricht als der Baß die ſeine.
           <lb />Solches muß aber nur auf dieſe drey Viertel geſchehen:
         </p>
-        <pb n="213" />
+        <pb facs="#facs-p433" n="213" />
         <notatedMusic xml:id="music-example5" facs="#facsZone-music-example5">
           <ptr target="music-example5.xml"/>
         </notatedMusic>
@@ -186,7 +209,7 @@
         </notatedMusic>
       </div>
 
-      <pb n="214" />
+      <pb facs="facs-p434" n="214" />
 
       <div n="8">
         <p xml:id="p8-1" facs="#facsZone-p8-1">

--- a/encodings/21/mattheson/comments_1st.xml
+++ b/encodings/21/mattheson/comments_1st.xml
@@ -73,9 +73,32 @@
       </sourceDesc>
     </fileDesc>
   </teiHeader>
+  <facsimile>
+    <surface ulx="0" uly="0" lrx="1950" lry="2364" xml:id="facs-p433">
+      <graphic width="1951px" height="2365px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/433" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1971" lry="2375" xml:id="facs-p434">
+      <graphic width="1972px" height="2376px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/434" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1976" lry="2362" xml:id="facs-p435">
+      <graphic width="1977px" height="2363px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/435" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1996" lry="2359" xml:id="facs-p436">
+      <graphic width="1997px" height="2360px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/436" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1973" lry="2366" xml:id="facs-p437">
+      <graphic width="1974px" height="2367px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/437" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1970" lry="2356" xml:id="facs-p438">
+      <graphic width="1971px" height="2357px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/438" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1970" lry="2367" xml:id="facs-p439">
+      <graphic width="1971px" height="2368px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/439" />
+    </surface>
+  </facsimile>
   <text>
     <body>
-      <pb n="217" />
+      <pb facs="#facs-p437" n="217" />
       <div n="0" type="chapter">
       <head>Erla&#x0364;uterung.</head>
       <div n="1">
@@ -125,7 +148,7 @@
       </div>
 
       <fw place="bottom" type="catch">Bey</fw>
-      <pb n="218" />
+      <pb facs="#facs-p438" n="218" />
 
       <div n="4">
         <head>§. 4.</head>
@@ -163,7 +186,7 @@
           <lb />mahl herſetzen:
         </p>
         <fw place="bottom" type="catch">Wenn</fw>
-        <pb n="219" />
+        <pb facs="#facs-p439" n="219" />
         <notatedMusic xml:id="music-example4" facs="#facsZone-music-example4">
           <ptr target="music-example4.xml"/>
         </notatedMusic>

--- a/encodings/22/mattheson/comments_1st.xml
+++ b/encodings/22/mattheson/comments_1st.xml
@@ -89,6 +89,9 @@
     <surface ulx="0" uly="0" lrx="1984" lry="2361" xml:id="facs-p224">
       <graphic width="1985px" height="2362px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/444" />
     </surface>
+    <surface ulx="0" uly="0" lrx="1972" lry="2359" xml:id="facs-p225">
+      <graphic width="1973px" height="2360px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/445" />
+    </surface>
   </facsimile>
   <text>
     <body>
@@ -167,6 +170,31 @@
           <notatedMusic xml:id="music-example3">
             <ptr target="music-example3.xml" />
           </notatedMusic>
+          <!--<pb facs="#facs-p225" n="225" />-->
+        </p>
+      </div>
+
+      <div n="3">
+        <lb /><head>§. 4.</head>
+        <p xml:id="p4-1">
+          <lb />Ich wiederhole nochmahls, daß es keine <hi rendition="#aq">Sanctio pragmatica</hi> ſen, eben
+          <lb />dieſe Noten, ſo wie hier ſtehen, an bemeldten Oertern zu ſpielen; denn es wird
+          <lb />unmüglich ſeyn, daß einer unter hundert es juſt ſo treffe. Es iſt alles nur zur
+          <lb />Nachricht hingeſetzet worden, und wer ſich der Probe unternimmt, kan ſchon
+          <lb />etwas beffers <hi rendition="#aq">extemporifiren</hi>, anbey dadurch zu erkennen geben, daß die Sel-
+          <lb />tenheit des Tons ſeinen Geiſt nicht feſſelt, ſondern, daß er, derfelben ungeachtet,
+          <lb />freye <hi rendition="#aq">Fantaiſie</hi> habe, und nach Gefallen mit dem Clavier ſchalten könne. Wenn
+          <lb />felbiges reine geftimmet iſt, ſo wird es ſchon gut aus dem <hi rendition="#aq">Fis dur</hi> klingen, da-
+          <lb />fern ein <hi rendition="#aq">habiler</hi> Meiſter darüber kömmt; ſtimmt das Inſtrument aber nicht/
+          <lb />ſo kan es auch aus dem gemeinſten Straſſen-Ton nicht gut klingen, und wenn ein
+          <lb /><hi rendition="#aq">Orpheus</hi> ſelber ſpielte. Gibt ſich inzwiſchen einer für Meiſter aus, ſo muß er
+          <lb />hier <hi rendition="#aq">extemporifiren</hi> können; denn ſolche Leute, hauptsächlich unter den Organi-
+          <lb />ſten, zu prüfen, iſt hier der erſte und fürnehmſte Zweck; dahingegen der Un-
+          <lb />terricht nur beyläuffig gehandelt und <hi rendition="#aq">ſecundo loco</hi> geſetzt wird. Es kan und mag
+          <lb />zwar ein jeder, wie in der Vorbereitung geſagt worden, ſich ohne Zeugen ſelbſt prü-
+          <lb />fen; aber weil uns doch die Eigen-Liebe gar zu ſehr anhängt, und man gerne mit
+          <lb />ſeinen eigenen Fehlern durch die Finger ſiehet, ſo wäre mein Rath, erſt ins geheim,
+          <lb />hernach mit Zuziehung eines unpartheyiſchen Kenners, die Probe anzuſtellen.
         </p>
       </div>
 

--- a/encodings/22/mattheson/comments_1st.xml
+++ b/encodings/22/mattheson/comments_1st.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../../schema/basisformat_customized.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>
     <fileDesc>
@@ -72,9 +73,26 @@
       </sourceDesc>
     </fileDesc>
   </teiHeader>
+  <facsimile>
+    <surface ulx="0" uly="0" lrx="1991" lry="2371" xml:id="facs-p220">
+      <graphic width="1992px" height="2372px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/440" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1935" lry="2383" xml:id="facs-p221">
+      <graphic width="1936px" height="2384px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/441" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1937" lry="2358" xml:id="facs-p222">
+      <graphic width="1938px" height="2359px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/442" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1966" lry="2357" xml:id="facs-p223">
+      <graphic width="1967px" height="2358px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/443" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1984" lry="2361" xml:id="facs-p224">
+      <graphic width="1985px" height="2362px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/444" />
+    </surface>
+  </facsimile>
   <text>
     <body>
-      <pb n="223" />
+      <pb facs="#facs-p223" n="223" />
 
       <div n="0" type="chapter">
       <lb /><head>Erla&#x0364;uterung.</head>
@@ -93,7 +111,7 @@
       <div n="2">
         <lb /><head>§. 2.</head>
         <p xml:id="p2-1">
-          <!-- no new line beginning after title -->
+            <!-- no new line beginning after title -->
           Das war, was ſich in gegenwärtiger <hi rendition="#aq">Pieçe</hi> nicht befindet; nun wollen
           <lb />wir mit wenigen dasjenige betrachten, was darinnen vorkömmt. Erſtlich
           <lb />muß bey dem Fall aus dem <ref target="#note-0000001105515864"><hi rendition="#aq">#c</hi></ref>
@@ -118,14 +136,14 @@
           <notatedMusic xml:id="music-example1">
             <ptr target="music-example1.xml" />
           </notatedMusic>
-          <pb n="224" />
+          <pb facs="#facs-p224" n="224" />
           <lb />Jndeſſen muß, was ſo offt erinnert worden, die Vollstimmigkeit des Baſſes
           <lb />und Beobachtung der <hi rendition="#aq">Signaturen</hi> in der lincken Hand keines weges ausge-
           <lb />ſetzet werden.
         </p>
       </div>
 
-      <pb n="224" />
+      <pb facs="#facs-p224" n="224" />
 
       <div n="3">
         <lb /><head>§. 3.</head>

--- a/encodings/22/mattheson/comments_1st.xml
+++ b/encodings/22/mattheson/comments_1st.xml
@@ -74,28 +74,28 @@
     </fileDesc>
   </teiHeader>
   <facsimile>
-    <surface ulx="0" uly="0" lrx="1991" lry="2371" xml:id="facs-p220">
+    <surface ulx="0" uly="0" lrx="1991" lry="2371" xml:id="facs-p440">
       <graphic width="1992px" height="2372px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/440" />
     </surface>
-    <surface ulx="0" uly="0" lrx="1935" lry="2383" xml:id="facs-p221">
+    <surface ulx="0" uly="0" lrx="1935" lry="2383" xml:id="facs-p441">
       <graphic width="1936px" height="2384px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/441" />
     </surface>
-    <surface ulx="0" uly="0" lrx="1937" lry="2358" xml:id="facs-p222">
+    <surface ulx="0" uly="0" lrx="1937" lry="2358" xml:id="facs-p442">
       <graphic width="1938px" height="2359px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/442" />
     </surface>
-    <surface ulx="0" uly="0" lrx="1966" lry="2357" xml:id="facs-p223">
+    <surface ulx="0" uly="0" lrx="1966" lry="2357" xml:id="facs-p443">
       <graphic width="1967px" height="2358px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/443" />
     </surface>
-    <surface ulx="0" uly="0" lrx="1984" lry="2361" xml:id="facs-p224">
+    <surface ulx="0" uly="0" lrx="1984" lry="2361" xml:id="facs-p444">
       <graphic width="1985px" height="2362px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/444" />
     </surface>
-    <surface ulx="0" uly="0" lrx="1972" lry="2359" xml:id="facs-p225">
+    <surface ulx="0" uly="0" lrx="1972" lry="2359" xml:id="facs-p445">
       <graphic width="1973px" height="2360px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/445" />
     </surface>
   </facsimile>
   <text>
     <body>
-      <pb facs="#facs-p223" n="223" />
+      <pb facs="#facs-p443" n="223" />
 
       <div n="0" type="chapter">
       <lb /><head>Erla&#x0364;uterung.</head>
@@ -139,14 +139,14 @@
           <notatedMusic xml:id="music-example1">
             <ptr target="music-example1.xml" />
           </notatedMusic>
-          <pb facs="#facs-p224" n="224" />
+          <pb facs="#facs-p444" n="224" />
           <lb />Jndeſſen muß, was ſo offt erinnert worden, die Vollstimmigkeit des Baſſes
           <lb />und Beobachtung der <hi rendition="#aq">Signaturen</hi> in der lincken Hand keines weges ausge-
           <lb />ſetzet werden.
         </p>
       </div>
 
-      <pb facs="#facs-p224" n="224" />
+      <pb facs="#facs-p444" n="224" />
 
       <div n="3">
         <lb /><head>§. 3.</head>
@@ -170,7 +170,7 @@
           <notatedMusic xml:id="music-example3">
             <ptr target="music-example3.xml" />
           </notatedMusic>
-          <!--<pb facs="#facs-p225" n="225" />-->
+          <!--<pb facs="#facs-p445" n="225" />-->
         </p>
       </div>
 

--- a/encodings/22/mattheson/comments_de.xml
+++ b/encodings/22/mattheson/comments_de.xml
@@ -4,7 +4,7 @@
   <teiHeader>
     <fileDesc>
       <titleStmt>
-        <title type="part">Mattheson: Der Ober-Classe dreiundzwanzigstes Probstück</title>
+        <title type="part">Mattheson: Der Ober-Classe zweiundzwanzigstes Probstück</title>
         <editor>
           <persName xml:id="pfeffer">
             <surname>Pfeffer</surname>
@@ -75,6 +75,20 @@
       </sourceDesc>
     </fileDesc>
   </teiHeader>
+  <facsimile>
+    <surface ulx="0" uly="0" lrx="2007" lry="2480" xml:id="facs-p426">
+      <graphic width="2008px" height="2481px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/494" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2067" lry="2490" xml:id="facs-p427">
+      <graphic width="2068px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/495" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2063" lry="2519" xml:id="facs-p428">
+      <graphic width="2064px" height="2520px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/496" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2056" lry="2490" xml:id="facs-p429">
+      <graphic width="2057px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/497" />
+    </surface>
+  </facsimile>
   <text>
     <body>
       <div n="0" type="chapter">

--- a/encodings/23/mattheson/comments_1st.xml
+++ b/encodings/23/mattheson/comments_1st.xml
@@ -74,16 +74,16 @@
     </fileDesc>
   </teiHeader>
   <facsimile>
-    <surface ulx="0" uly="0" lrx="1960" lry="2354" xml:id="facs-p226">
+    <surface ulx="0" uly="0" lrx="1960" lry="2354" xml:id="facs-p446">
       <graphic width="1961px" height="2355px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/446" />
     </surface>
-    <surface ulx="0" uly="0" lrx="1978" lry="2376" xml:id="facs-p227">
+    <surface ulx="0" uly="0" lrx="1978" lry="2376" xml:id="facs-p447">
       <graphic width="1979px" height="2377px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/447" />
     </surface>
-    <surface ulx="0" uly="0" lrx="1942" lry="2360" xml:id="facs-p228">
+    <surface ulx="0" uly="0" lrx="1942" lry="2360" xml:id="facs-p450">
       <graphic width="1943px" height="2361px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/450" />
     </surface>
-    <surface ulx="0" uly="0" lrx="1965" lry="2360" xml:id="facs-p229">
+    <surface ulx="0" uly="0" lrx="1965" lry="2360" xml:id="facs-p451">
       <graphic width="1966px" height="2361px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/451" />
     </surface>
 </facsimile>
@@ -99,7 +99,7 @@
         </p>
       </div>
 
-      <pb facs="#facs-p228" n="228" />
+      <pb facs="#facs-p450" n="228" />
       <div n="0" type="chapter">
       <lb /><head>Erla&#x0364;uterung.</head>
       <div n="1">
@@ -138,7 +138,7 @@
         </p>
       </div>
       <fw type="catch" place="bottom">Erſt-</fw>
-      <pb facs="#facs-p229" n="229" />
+      <pb facs="#facs-p451" n="229" />
 
       <div n="3">
         <lb /><head>§. 3.</head>

--- a/encodings/23/mattheson/comments_1st.xml
+++ b/encodings/23/mattheson/comments_1st.xml
@@ -73,6 +73,20 @@
       </sourceDesc>
     </fileDesc>
   </teiHeader>
+  <facsimile>
+    <surface ulx="0" uly="0" lrx="1960" lry="2354" xml:id="facs-p226">
+      <graphic width="1961px" height="2355px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/446" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1978" lry="2376" xml:id="facs-p227">
+      <graphic width="1979px" height="2377px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/447" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1942" lry="2360" xml:id="facs-p228">
+      <graphic width="1943px" height="2361px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/450" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="1965" lry="2360" xml:id="facs-p229">
+      <graphic width="1966px" height="2361px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527431/canvas/451" />
+    </surface>
+</facsimile>
   <text>
     <body>
       <div>
@@ -85,7 +99,7 @@
         </p>
       </div>
 
-      <pb n="228" />
+      <pb facs="#facs-p228" n="228" />
       <div n="0" type="chapter">
       <lb /><head>Erla&#x0364;uterung.</head>
       <div n="1">
@@ -124,12 +138,12 @@
         </p>
       </div>
       <fw type="catch" place="bottom">Erſt-</fw>
-      <pb n="239" />
+      <pb facs="#facs-p229" n="229" />
 
       <div n="3">
         <lb /><head>§. 3.</head>
         <p xml:id="p3-1">
-          <!-- no pagebreak after head -->
+            <!-- no pagebreak after head -->
           Erſtlich iſt das <hi rendition="#b">Prob-Stu&#x0364;ck</hi>, wenn es ſoll <ref target="#tempo-001"><hi rendition="#aq">preſto aſſai</hi></ref> und reine dabey
           <lb /> geſpielet werden, nicht von der Art, daß es auf einmahl ko&#x0364;nne vollkommen her-
           <lb />auskommen, ſondern es braucht einer zu ſolchem Sprunge wohl mehr, als einen Zu-
@@ -137,7 +151,7 @@
           <lb />der Probe ſtehenden ein groſſer Troſt, wenn ich nicht nur zu dir, wie der Soldat
           <lb />(<hi rendition="#aq"><foreign xml:lang="fra">ſans comparaiſon</foreign></hi>) zum Generalen ſage: <hi rendition="#aq"><foreign xml:lang="fra">Je te le donne en quattre,</foreign></hi>, ich will dichs
           <lb />gerne viermahl durchſpielen laſſen, ehe es recht gelten ſoll; ſondern, <hi rendition="#aq"><foreign xml:lang="fra">Je te le donne en
-          <lb />ſix</foreign></hi>, ich ge>be dirs wol ſechs und mehrmahl frey. Siehe, den Troſt haſt du aus der
+          <lb />ſix</foreign></hi>, ich gebe dirs wol ſechs und mehrmahl frey. Siehe, den Troſt haſt du aus der
           <lb /><hi rendition="#aq">Application</hi> meiner kleinen Geſchichte. Drittens folget ja nothwendig daraus,
           <lb />wenn man dir Zeit la&#x0364;ſſt, das Stu&#x0364;ck vier- bis ſechsmahl u&#x0364;ber zu ſpielen, daß
           <lb />durch dieſe <hi rendition="#aq">Praxin</hi> dir eine groſſe Erla&#x0364;uterung daru&#x0364;ber wird zuwachſen. Und
@@ -148,7 +162,7 @@
       <div n="4">
         <lb /><head>§. 4.</head>
         <p xml:id="p4-1">
-          <!-- no pagebreak after head -->
+            <!-- no pagebreak after head -->
           Nun thue dein beſtes, und laß dich ho&#x0364;ren; ich verlange nicht, daß die
           <lb />rechte Hand das geringſte (auſſer ein paar Tertien dann und wann) machen
           <lb />ſoll, es wird auch keine Zeit dazu ſeyn, wenn das <hi rendition="#aq">preſto aſſai</hi> wol in acht genom<supplied resp="#pfeffer">-</supplied>
@@ -169,7 +183,7 @@
       <div n="5">
         <lb /><head>§. 5.</head>
         <p xml:id="p5-1">
-          <!-- no pagebreak after head -->
+            <!-- no pagebreak after head -->
           Wie dieſer Ton, <hi rendition="#aq">Cis moll</hi>, gar offt <hi rendition="#aq">affinaliter</hi> (des <hi rendition="#aq">Recitativi</hi> zu geſchwei-
           <lb />gen) in den kleineſten <hi rendition="#aq">Ariet</hi>ten vorkomme, kan man inſonderheit aus <persName ref="http://d-nb.info/gnd/118560999">Herrn <hi rendition="#b">Kei-
           <lb />ſers</hi></persName> <name type="musicalWork" corresp="#ed_sbs_x2c_tlb">Erleſenen Sa&#x0364;tzen</name> <hi rendition="#aq">p. 67. f.</hi> ingleichen aus deſſelben <name type="musicalWork" corresp="#ed_qdl_mrc_tlb"><hi rendition="#b">Erlo&#x0364;sungs-Gedan-

--- a/encodings/23/mattheson/comments_de.xml
+++ b/encodings/23/mattheson/comments_de.xml
@@ -75,9 +75,29 @@
       </sourceDesc>
     </fileDesc>
   </teiHeader>
+  <facsimile>
+    <surface ulx="0" uly="0" lrx="2063" lry="2519" xml:id="facs-p428">
+      <graphic width="2064px" height="2520px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/496" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2056" lry="2490" xml:id="facs-p429">
+      <graphic width="2057px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/497" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2041" lry="2487" xml:id="facs-p430">
+      <graphic width="2042px" height="2488px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/498" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2059" lry="2490" xml:id="facs-p431">
+      <graphic width="2060px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/499" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2010" lry="2484" xml:id="facs-p432">
+      <graphic width="2011px" height="2485px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/500" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2067" lry="2490" xml:id="facs-p433">
+      <graphic width="2068px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/501" />
+    </surface>
+  </facsimile>
   <text>
     <body>
-      <pb n="432" />
+      <pb facs="#facs-p432" n="432" />
       <div n="0" type="chapter">
       <lb /><head>Erla&#x0364;uterung.</head>
       <div n="1">
@@ -123,7 +143,7 @@
           <lb />Erſtlich iſt die Aufgabe, wenn sie <ref target="#tempo-001"><hi rendition="#aq">preſto aſſai</hi></ref> und dabey rein geſpielet wer-
           <lb />den ſoll, nicht von der Art, daß ſie auf einmahl vollkommen heraus gebracht wer-
           <fw type="catch" place="bottom">den</fw>
-          <pb n="433" />
+          <pb facs="#facs-p433" n="433" />
           den ko&#x0364;nne; ſondern es braucht einer zu ſolchem Sprunge wol mehr, als einen Zu-
           <lb />lauff. Auf dieſe Weiſe reimet ſich die Geſchicht. Fu&#x0364;rs andere iſt es dir,
           <lb />auf der Probe ſtehendem, ein groſſer Troſt, wenn ich nicht nur zu dir, wie der Soldat

--- a/encodings/23/mattheson/comments_de.xml
+++ b/encodings/23/mattheson/comments_de.xml
@@ -76,28 +76,28 @@
     </fileDesc>
   </teiHeader>
   <facsimile>
-    <surface ulx="0" uly="0" lrx="2063" lry="2519" xml:id="facs-p428">
+    <surface ulx="0" uly="0" lrx="2063" lry="2519" xml:id="facs-p496">
       <graphic width="2064px" height="2520px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/496" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2056" lry="2490" xml:id="facs-p429">
+    <surface ulx="0" uly="0" lrx="2056" lry="2490" xml:id="facs-p497">
       <graphic width="2057px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/497" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2041" lry="2487" xml:id="facs-p430">
+    <surface ulx="0" uly="0" lrx="2041" lry="2487" xml:id="facs-p498">
       <graphic width="2042px" height="2488px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/498" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2059" lry="2490" xml:id="facs-p431">
+    <surface ulx="0" uly="0" lrx="2059" lry="2490" xml:id="facs-p499">
       <graphic width="2060px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/499" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2010" lry="2484" xml:id="facs-p432">
+    <surface ulx="0" uly="0" lrx="2010" lry="2484" xml:id="facs-p500">
       <graphic width="2011px" height="2485px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/500" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2067" lry="2490" xml:id="facs-p433">
+    <surface ulx="0" uly="0" lrx="2067" lry="2490" xml:id="facs-p501">
       <graphic width="2068px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/501" />
     </surface>
   </facsimile>
   <text>
     <body>
-      <pb facs="#facs-p432" n="432" />
+      <pb facs="#facs-p500" n="432" />
       <div n="0" type="chapter">
       <lb /><head>Erla&#x0364;uterung.</head>
       <div n="1">
@@ -143,7 +143,7 @@
           <lb />Erſtlich iſt die Aufgabe, wenn sie <ref target="#tempo-001"><hi rendition="#aq">preſto aſſai</hi></ref> und dabey rein geſpielet wer-
           <lb />den ſoll, nicht von der Art, daß ſie auf einmahl vollkommen heraus gebracht wer-
           <fw type="catch" place="bottom">den</fw>
-          <pb facs="#facs-p433" n="433" />
+          <pb facs="#facs-p501" n="433" />
           den ko&#x0364;nne; ſondern es braucht einer zu ſolchem Sprunge wol mehr, als einen Zu-
           <lb />lauff. Auf dieſe Weiſe reimet ſich die Geſchicht. Fu&#x0364;rs andere iſt es dir,
           <lb />auf der Probe ſtehendem, ein groſſer Troſt, wenn ich nicht nur zu dir, wie der Soldat

--- a/encodings/24/mattheson/comments_de.xml
+++ b/encodings/24/mattheson/comments_de.xml
@@ -75,6 +75,101 @@
       </sourceDesc>
     </fileDesc>
   </teiHeader>
+  <facsimile>
+    <surface ulx="0" uly="0" lrx="2058" lry="2480" xml:id="facs-p434">
+      <graphic width="2059px" height="2481px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/502" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2066" lry="2487" xml:id="facs-p435">
+      <graphic width="2067px" height="2488px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/503" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2039" lry="2486" xml:id="facs-p436">
+      <graphic width="2040px" height="2487px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/504" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2054" lry="2485" xml:id="facs-p437">
+      <graphic width="2055px" height="2486px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/505" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2041" lry="2489" xml:id="facs-p438">
+      <graphic width="2042px" height="2490px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/506" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2054" lry="2488" xml:id="facs-p439">
+      <graphic width="2055px" height="2489px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/507" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2036" lry="2490" xml:id="facs-p440">
+      <graphic width="2037px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/508" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2055" lry="2482" xml:id="facs-p441">
+      <graphic width="2056px" height="2483px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/509" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2009" lry="2480" xml:id="facs-p442">
+      <graphic width="2010px" height="2481px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/510" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2074" lry="2490" xml:id="facs-p443">
+      <graphic width="2075px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/511" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2055" lry="2487" xml:id="facs-p444">
+      <graphic width="2056px" height="2488px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/512" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2062" lry="2488" xml:id="facs-p445">
+      <graphic width="2063px" height="2489px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/513" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2004" lry="2484" xml:id="facs-p446">
+      <graphic width="2005px" height="2485px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/514" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2063" lry="2489" xml:id="facs-p447">
+      <graphic width="2064px" height="2490px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/515" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2036" lry="2484" xml:id="facs-p448">
+      <graphic width="2037px" height="2485px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/516" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2062" lry="2490" xml:id="facs-p449">
+      <graphic width="2063px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/517" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2000" lry="2485" xml:id="facs-p450">
+      <graphic width="2001px" height="2486px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/518" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2057" lry="2491" xml:id="facs-p451">
+      <graphic width="2058px" height="2492px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/519" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2000" lry="2485" xml:id="facs-p452">
+      <graphic width="2001px" height="2486px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/520" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2055" lry="2489" xml:id="facs-p453">
+      <graphic width="2056px" height="2490px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/521" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2051" lry="2490" xml:id="facs-p454">
+      <graphic width="2052px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/522" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2022" lry="2488" xml:id="facs-p455">
+      <graphic width="2023px" height="2489px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/523" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2040" lry="2491" xml:id="facs-p456">
+      <graphic width="2041px" height="2492px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/524" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2053" lry="2482" xml:id="facs-p457">
+      <graphic width="2054px" height="2483px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/525" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2027" lry="2489" xml:id="facs-p458">
+      <graphic width="2028px" height="2490px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/526" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2053" lry="2483" xml:id="facs-p459">
+      <graphic width="2054px" height="2484px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/527" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2034" lry="2491" xml:id="facs-p460">
+      <graphic width="2035px" height="2492px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/528" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2033" lry="2474" xml:id="facs-p461">
+      <graphic width="2034px" height="2475px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/529" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2014" lry="2480" xml:id="facs-p462">
+      <graphic width="2015px" height="2481px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/530" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2069" lry="2487" xml:id="facs-p463">
+      <graphic width="2070px" height="2488px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/531" />
+    </surface>
+    <surface ulx="0" uly="0" lrx="2035" lry="2491" xml:id="facs-p464">
+      <graphic width="2036px" height="2492px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/532" />
+    </surface>
+  </facsimile>
   <text>
     <body>
       <div n="0" type="chapter">

--- a/encodings/24/mattheson/comments_de.xml
+++ b/encodings/24/mattheson/comments_de.xml
@@ -76,97 +76,97 @@
     </fileDesc>
   </teiHeader>
   <facsimile>
-    <surface ulx="0" uly="0" lrx="2058" lry="2480" xml:id="facs-p434">
+    <surface ulx="0" uly="0" lrx="2058" lry="2480" xml:id="facs-p502">
       <graphic width="2059px" height="2481px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/502" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2066" lry="2487" xml:id="facs-p435">
+    <surface ulx="0" uly="0" lrx="2066" lry="2487" xml:id="facs-p503">
       <graphic width="2067px" height="2488px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/503" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2039" lry="2486" xml:id="facs-p436">
+    <surface ulx="0" uly="0" lrx="2039" lry="2486" xml:id="facs-p504">
       <graphic width="2040px" height="2487px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/504" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2054" lry="2485" xml:id="facs-p437">
+    <surface ulx="0" uly="0" lrx="2054" lry="2485" xml:id="facs-p505">
       <graphic width="2055px" height="2486px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/505" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2041" lry="2489" xml:id="facs-p438">
+    <surface ulx="0" uly="0" lrx="2041" lry="2489" xml:id="facs-p506">
       <graphic width="2042px" height="2490px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/506" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2054" lry="2488" xml:id="facs-p439">
+    <surface ulx="0" uly="0" lrx="2054" lry="2488" xml:id="facs-p507">
       <graphic width="2055px" height="2489px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/507" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2036" lry="2490" xml:id="facs-p440">
+    <surface ulx="0" uly="0" lrx="2036" lry="2490" xml:id="facs-p508">
       <graphic width="2037px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/508" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2055" lry="2482" xml:id="facs-p441">
+    <surface ulx="0" uly="0" lrx="2055" lry="2482" xml:id="facs-p509">
       <graphic width="2056px" height="2483px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/509" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2009" lry="2480" xml:id="facs-p442">
+    <surface ulx="0" uly="0" lrx="2009" lry="2480" xml:id="facs-510">
       <graphic width="2010px" height="2481px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/510" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2074" lry="2490" xml:id="facs-p443">
+    <surface ulx="0" uly="0" lrx="2074" lry="2490" xml:id="facs-p511">
       <graphic width="2075px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/511" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2055" lry="2487" xml:id="facs-p444">
+    <surface ulx="0" uly="0" lrx="2055" lry="2487" xml:id="facs-p512">
       <graphic width="2056px" height="2488px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/512" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2062" lry="2488" xml:id="facs-p445">
+    <surface ulx="0" uly="0" lrx="2062" lry="2488" xml:id="facs-p513">
       <graphic width="2063px" height="2489px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/513" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2004" lry="2484" xml:id="facs-p446">
+    <surface ulx="0" uly="0" lrx="2004" lry="2484" xml:id="facs-p514">
       <graphic width="2005px" height="2485px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/514" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2063" lry="2489" xml:id="facs-p447">
+    <surface ulx="0" uly="0" lrx="2063" lry="2489" xml:id="facs-p515">
       <graphic width="2064px" height="2490px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/515" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2036" lry="2484" xml:id="facs-p448">
+    <surface ulx="0" uly="0" lrx="2036" lry="2484" xml:id="facs-p516">
       <graphic width="2037px" height="2485px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/516" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2062" lry="2490" xml:id="facs-p449">
+    <surface ulx="0" uly="0" lrx="2062" lry="2490" xml:id="facs-p517">
       <graphic width="2063px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/517" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2000" lry="2485" xml:id="facs-p450">
+    <surface ulx="0" uly="0" lrx="2000" lry="2485" xml:id="facs-p518">
       <graphic width="2001px" height="2486px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/518" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2057" lry="2491" xml:id="facs-p451">
+    <surface ulx="0" uly="0" lrx="2057" lry="2491" xml:id="facs-p519">
       <graphic width="2058px" height="2492px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/519" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2000" lry="2485" xml:id="facs-p452">
+    <surface ulx="0" uly="0" lrx="2000" lry="2485" xml:id="facs-p520">
       <graphic width="2001px" height="2486px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/520" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2055" lry="2489" xml:id="facs-p453">
+    <surface ulx="0" uly="0" lrx="2055" lry="2489" xml:id="facs-p521">
       <graphic width="2056px" height="2490px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/521" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2051" lry="2490" xml:id="facs-p454">
+    <surface ulx="0" uly="0" lrx="2051" lry="2490" xml:id="facs-p522">
       <graphic width="2052px" height="2491px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/522" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2022" lry="2488" xml:id="facs-p455">
+    <surface ulx="0" uly="0" lrx="2022" lry="2488" xml:id="facs-p523">
       <graphic width="2023px" height="2489px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/523" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2040" lry="2491" xml:id="facs-p456">
+    <surface ulx="0" uly="0" lrx="2040" lry="2491" xml:id="facs-p524">
       <graphic width="2041px" height="2492px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/524" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2053" lry="2482" xml:id="facs-p457">
+    <surface ulx="0" uly="0" lrx="2053" lry="2482" xml:id="facs-p525">
       <graphic width="2054px" height="2483px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/525" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2027" lry="2489" xml:id="facs-p458">
+    <surface ulx="0" uly="0" lrx="2027" lry="2489" xml:id="facs-p526">
       <graphic width="2028px" height="2490px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/526" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2053" lry="2483" xml:id="facs-p459">
+    <surface ulx="0" uly="0" lrx="2053" lry="2483" xml:id="facs-p527">
       <graphic width="2054px" height="2484px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/527" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2034" lry="2491" xml:id="facs-p460">
+    <surface ulx="0" uly="0" lrx="2034" lry="2491" xml:id="facs-p528">
       <graphic width="2035px" height="2492px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/528" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2033" lry="2474" xml:id="facs-p461">
+    <surface ulx="0" uly="0" lrx="2033" lry="2474" xml:id="facs-p529">
       <graphic width="2034px" height="2475px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/529" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2014" lry="2480" xml:id="facs-p462">
+    <surface ulx="0" uly="0" lrx="2014" lry="2480" xml:id="facs-p530">
       <graphic width="2015px" height="2481px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/530" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2069" lry="2487" xml:id="facs-p463">
+    <surface ulx="0" uly="0" lrx="2069" lry="2487" xml:id="facs-531">
       <graphic width="2070px" height="2488px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/531" />
     </surface>
-    <surface ulx="0" uly="0" lrx="2035" lry="2491" xml:id="facs-p464">
+    <surface ulx="0" uly="0" lrx="2035" lry="2491" xml:id="facs-p532">
       <graphic width="2036px" height="2492px" url="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10598495/canvas/532" />
     </surface>
   </facsimile>
@@ -200,7 +200,7 @@
               <lb />ſten im geringſten entſchuldigen könne.</item>
           </list>
           <fw place="bottom" type="catch">Es</fw>
-          <pb n="441" />
+          <pb facs="#facs-p509" n="441" />
         </p>
       </div>
 
@@ -249,7 +249,7 @@
           <lb />Schüler hier leiſten könnte, was man dem Lehrer ſelbſt nicht zutrauet, welches,
           <lb />da es ja wahr, jenen ein groſſer Schimpft ſeyn mag, die Meiſter heiſſen wollen,
           <fw place="bottom" type="catch">und</fw>
-          <pb n="442" />
+          <pb facs="#facs-p510" n="442" />
 
           und es nicht können; wenn ich gleich hier, ſo zu reden, keine Ausnahm machen könnte,
           <lb />und mich von jedem Haluncken auf die Probe ſetzen laſſen müſſe: ſo ſehe doch nicht, was
@@ -296,7 +296,7 @@
               So kann ich andre doch den General-Baß lehren.</quote>
           </hi>
           <fw place="bottom" type="catch">Da.</fw>
-          <pb n="443" />
+          <pb facs="#facs-p511" n="443" />
 
           Damit man aber nicht meyne, ich wolle es gar von mir lehnen, ſo will ich doch, oh-
           <lb />ne eintzigen Ruhm, hiemit verſichert haben, daß, wenn es eine Probe gel-
@@ -327,7 +327,6 @@
         </p>
       </div>
 
-
       <div n="5">
         <lb /><head>§. 5.</head>
         <lb /><p>
@@ -356,7 +355,7 @@
           <lb />wie der Augenſchein erweiſet, ſo lange iſt mirs auch gleichviel, ob ich von dieſem
           <lb />
           <fw place="bottom" type="catch">für</fw>
-          <pb n="444" />
+          <pb facs="#facs-p512" n="444" />
 
           für einen musicaliſchen Grillenfänger, oder von jenem für den <persName corresp="#ed_wpd_2lx_qlb">Apollo</persName> ſelbſt ge-
           <lb />halten werde. Es kann mir nicht zuwieder ſeyn, ob Hintz oder Kuntz beſſer ſetzet,
@@ -434,7 +433,7 @@
           <lb />gehorſamen Diener nennet; dürffte doch derjenige thöricht genug handeln, der die
           <lb />Aufſchrifft ſeiner Antwort darnach einrichten, und ſchreiben wollte: An meinen
           <fw place="bottom" type="catch">gehor-</fw>
-          <pb n="445" />
+          <pb facs="#facs-p513" n="445" />
 
           gehorſamen Diener
           <lb /><hi rendition="#aq"><persName corresp="#ed_b2n_mx1_5lb">Marſyas</persName></hi>
@@ -482,7 +481,7 @@
           <lb />dern mit Latten, wie der <persName>Staar-Stecher</persName> redet. Und da ein eintziger von dieſen in
           <lb />der gelehrten und geſchliffenen Welt wol zehn mahl ſo viel gilt, als funfzig <persName corresp="#ed_arq_vfy_qlb">Hancken</persName>,
           <fw place="bottom" type="catch">ſo</fw>
-          <pb n="446" />
+          <pb facs="#facs-p514" n="446" />
 
           ſo mögen die Schmähungen des letztem mit dem, obgleich gar zu höflich ſcheinenden,
           <lb />Beifall jener hochberühmten Männer in keinen Vergleich kommen. Was frägt
@@ -539,7 +538,7 @@
         <lb /><p>
           Nun mögte zwar wol ſolche Ungeſchicklichkeit bey einem Recitativ nicht ſo
           <fw place="bottom" type="catch">ſehr</fw>
-          <pb n="447" />
+          <pb facs="#facs-p515" n="447" />
 
           <lb />ſehr vermercket werden: weil der General-Baß allda nicht ſo genau an einander
           <lb />hänget; aber in arioſen Sachen ſiehet es wircklich ſehr mangelhafft aus, welches
@@ -588,6 +587,8 @@
             </quote>
         </p>
       </div>
+
+      <pb facs="#facs-p516" n="448" />
 
       <div n="9">
         <head>§. 9.</head>
@@ -651,7 +652,7 @@
           ſtehet in den Gedancken: <hi rendition="#b">Daß es mit den Stoffen der chro-
             <lb />matiſchen Claviere eben ſo wenig, als mit der enharmoniſchen Ein-
             <fw place="bottom" type="catch">thei-</fw>
-            <pb n="449" />
+            <pb facs="#facs-p517" n="449" />
 
             theilung der Tangenten, auf einer eintzigen Griff-Tafel Art habe, weil
             <lb />man lange nicht ſo leicht, bequem und geſchwind darauf ſpielen könne,
@@ -706,7 +707,7 @@
             </note>
           was <date when="1631">vor hundert
             <fw place="bottom" type="catch">Jahren</fw>
-            <pb n="450" />
+            <pb facs="#facs-p518" n="450" />
 
             Jahren</date>
           eine Ehre war, deſſen ſchämet man ſich auf gewiſſe Art bey itzigen Zeiten.
@@ -753,7 +754,7 @@
           <lb />Endlich brachte ich auch Exempel von unſern gröſſeſten Meiſtern bey, die es noch im-
           <lb />mer mit zweyen Doppel-Kreutzen (##) hielten, und gab zwo Urſachen an, war-
           <fw place="bottom" type="catch">um</fw>
-          <pb n="451" />
+          <pb facs="#facs-p519" n="451" />
 
           <lb />um das einfache Kreutz (x) beſſer ſeyn würde / nemlich: weil man es ſo dann mit
           <lb />einem Zeichen beſtellen könnte, und weil dabey auch ein jedes Ding ſein eignes Zei-
@@ -820,7 +821,7 @@
             <lb />chens x erſtrecket ſich nur auf die Erhöhung eines Viertel-Tons, und theilet den
             <lb />groſſen halben Ton in zween Theile. Auſſer dem enharmoniſchen Geſchlecht, und
             <fw place="bottom" type="catch">dem</fw>
-            <pb n="452" />
+            <pb facs="#facs-p520" n="452" />
 
             dem Gebrauch der Viertel-Tone hat alſo das x keine Statt, thut auch in der That,
             <lb />wenn es ſo zur Unzeit gebraucht wird, keine andere Dienſte, als ein verdoppel-
@@ -854,7 +855,7 @@
           mit gutem Fug, daß durch die vier, kreutzweiſe gefloch-
           <lb />tene Strichlein eine Erhöhung von vier Commatibus angezeiget wird, daraus unge-
           <fw place="bottom" type="catch">fehr</fw>
-          <pb n="453" />
+          <pb facs="#facs-p521" n="453" />
 
           <lb />gefehr ein kleiner halber Ton beſtehet. Wenn wir nun den Fall ſetzen, daß ſich
           <lb />dieſes ſo verhalte, und dennoch betrachten, wie eben daſſelbe Zeichen täglich zur
@@ -898,6 +899,8 @@
           </note>
         </p>
       </div>
+
+      <pb facs="#facs-p522" n="454" />
 
       <div n="18">
         <lb /><head>§. 18.</head>
@@ -943,7 +946,7 @@
           <lb />und in dieſem Fall lieber das h genommen werden: weil bey beiden Vorfällen, ſo
           <lb />wol im Steigen, als auch Fallen, der Endzweck einerley iſt, nemlich dieſer: Daß die
           <fw place="bottom" type="catch">Note</fw>
-          <pb n="455" />
+          <pb facs="#facs-p523" n="455" />
 
           ihren vorigen alten und gewöhnlichen Sitz, es ſey fallend oder
           <lb />ſteigend, wieder einnehmen ſoll. Daher es ein groſſer Irrthum iſt, wenn
@@ -990,7 +993,7 @@
           Ich kehre wieder zum Vorhaben, wegen der Kreutze, und bemerke, daß
           <lb /><persName corresp="#ed_dwf_j5x_qlb">Mſr. St. Lambert</persName> noch eine andere Erfindung hat, da er nemlich, vorne auf
           <fw place="bottom" type="catch">den</fw>
-          <pb n="456" />
+          <pb facs="#facs-p524" n="456" />
 
           <lb />den Linien, gleich das eine ♯, von dem andern auf derſelben Stelle befindlichen,
           <lb />mittelſt eines Durſchnitts, abſcheidet und trennet. Mit dem ♭ hat er auch eine ſol-
@@ -1025,7 +1028,7 @@
         <p>
           Wenn auch eine Verdoppelung des ♭ nöthig wäre, welches ich zwar noch
           <fw type="catch" place="bottom">nicht</fw>
-          <pb n="457"/>
+          <pb facs="#facs-p525" n="457"/>
 
           <lb />nicht erlebet habe, ſo könnte etwan, dafern es ſo gefällig wäre, das β dazu genommen
           <lb />werden, weil doch kurtzum alles Griechiſch ſeyn ſoll. Jch will, zur Nachricht, ein
@@ -1055,7 +1058,7 @@
           <lb />betrachtungen zu bringen ; allein, ein rechtſchaffener Liebhaber und ſeiner
           <lb />Wiſſenſchaft Befliſſener achtet es für keine Kleinigkeit, wenn er auch nur
           <fw type="catch" place="bottom">ein</fw>
-          <pb n="458" />
+          <pb facs="#facs-p526" n="458" />
 
           <lb />ein eintziges Pünctgen in der Sache, die er zu unterſuchen vorgenommen hat,
           <lb />wo nicht verbeſſert, wnigſtens, wenn etwas daran fehlet, den Mangel
@@ -1116,7 +1119,7 @@
           <lb />will ich doch, denen zu Gefallen, die gar keinen Begriff von der Sache haben, all-
           <lb />hie auf das gröbſte entwerffen. Jch ſage billig auf das gröbſte, weil mir nicht un-
           <fw place="bottom" type="catch">be-</fw>
-          <pb n="459"/>
+          <pb facs="#facs-p527" n="459"/>
 
           <lb />bekannt, daß ein kleiner Ton mehr, als acht, und weniger als neun Theilgen, inglei-
           <lb />chen, daß ein kleiner halber Ton mehr, als drey, und weniger als vier haben ſollen,
@@ -1167,7 +1170,7 @@
           und <hi rendition="#b"><persName corresp="#ed_rpk_l2y_qlb">Salin</persName></hi>, zween der beſten muſicaliſchen Scribenten, hiel-
           <lb />ten nicht gar viel von dergleichen zerhackten Clavieren, die man in ſo ſchrecklich
           <fw type="catch" place="bottom">kleine</fw>
-          <pb n="460"/>
+          <pb facs="#facs-p528" n="460"/>
 
           <lb />kleine Glieder eintheilte, ob wol der erſte
           <note place="foot" n="e)">
@@ -1243,7 +1246,7 @@
            </hi>
            Man
            <fw type="catch" place="bottom">findet</fw>
-           <pb n="461"/>
+           <pb facs="#facs-p529" n="461"/>
 
            <lb />findet auch noch hin und wieder dieſe Einrichtung in alten Orgel-Wercken, <abbr>Z.E.</abbr>
            <lb />hier, in <placeName ref="https://www.geonames.org/2911298">Hamburg</placeName> in der <placeName>Marien-Magdalenen-Kirche</placeName>. Wobey denn anzumercken
@@ -1263,7 +1266,7 @@
          </p>
       </div>
 
-      <div n="461">
+      <div n="28">
         <head>§. 28.</head>
         <p>
           <lb />Es iſt indeſſen gantz gewiß, daß dieſe beide berühmte Scribenten, de-
@@ -1288,7 +1291,7 @@
           und ſo gar zehn bis zwölff Fehler des <hi rendition="#b"><persName corresp="#ed_jlh_wvy_qlb">Zarlins</persName></hi> vom
           <lb /><hi rendition="#b"><persName corresp="#ed_rpk_l2y_qlb">Salin</persName></hi>
           <note place="foot" n="(l)">
-            <hi rendition="#aq">Salin <bibl corresp="#ed_h4c_wwb_5lb">de Mus. p. 228-232, <aabr>ſqq.</aabr></bibl></hi>
+            <hi rendition="#aq"><bibl corresp="#ed_h4c_wwb_5lb">Salin de Mus. p. 228-232, <abbr>ſqq.</abbr></bibl></hi>
           </note>
           <hi rendition="#b"><persName corresp="#ed_ghv_kvx_qlb">Doni</persName></hi>
           <note place="foot" n="(m)">
@@ -1314,7 +1317,7 @@
           </note>
           ſchon vor vielen Jahren dargethan hat, daß die-
           <fw type="catch" place="bottom">ſes</fw>
-          <pb n="462"/>
+          <pb facs="#facs-p530" n="462"/>
 
           <lb />ſes zwölfftel die Octave nicht rein liefert, ſondern überſchreitet. Jch wollte wol, daß ein
           <lb />gewiſſer Mann hierauf antwortete, und mich verlanget, den Streit einmahl ſo geho-
@@ -1381,7 +1384,7 @@
             Darum hat es GOTT ſo weiß-
             <lb />lich geordnet, und unſer Gemüth alſo zugerichtet, daß es mit einer guten
             <fw type="catch" place="bottom">Tem-</fw>
-            <pb n="463"/>
+            <pb facs="#facs-p531" n="463"/>
             Temperatur zufrieden iſt; ja, GOtt hat alles, was in der Natur iſt, in die
             <lb />Temepratur geſetzt, warum wollten wir dieſelbe aus der Muſic ver-
             <lb />bannen und verwerffen, zumahl es nicht anders ſeyn kann.
@@ -1428,7 +1431,7 @@
             <lb />ger Beiſtand zu leiſten; nicht aber deſſelben Beſtreben, durch ein unzeitiges Geklängel, zu hindern, oder
             <lb />zu verſtellen. Es giebt Leute, die ſo viel von ſich ſelbſt halten, daß ſie glauben, ein gantzes Concert von Vir-
             <fw type="catch" place="bottom">tuoſen</fw>
-            <pb n="464" />
+            <pb facs="#facs-p532" n="464" />
 
             <lb />tuoſen ſey ihrer kaum werth, und laſſen ſichs daher recht ſauer werden, vor allen andern hervorzuragen.
             <lb />Dieſe Organiſten überhäufften ihre vorgeſchrieben Bäſſe mit vielen krummen Sprüngen, verbrämen

--- a/encodings/3/hill/beginning2.xml
+++ b/encodings/3/hill/beginning2.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
@@ -36,15 +36,15 @@
                                     <chord xml:id="chord-0000002081275272" dur="2">
                                         <note xml:id="note-0000001899766158" oct="4" pname="c" />
                                         <note xml:id="note-0000001942901290" oct="4" pname="e" />
-                                        <note xml:id="note-0000000888608624" oct="4" pname="a" />
-                                    </chord>
-                                    <chord dur="4">
-                                        <note oct="4" pname="e"/>
-                                        <note oct="4" pname="a"/>
-                                        <note oct="5" pname="c"/>
-                                    </chord>
-                                </layer>
-                                <layer xml:id="layer-0000000060554651" n="3">
+                    <note xml:id="note-0000000888608624" oct="4" pname="a" />
+                  </chord>
+                  <chord dur="4">
+                    <note oct="4" pname="e" />
+                    <note oct="4" pname="a" />
+                    <note oct="5" pname="c" />
+                  </chord>
+                </layer>
+                <layer xml:id="layer-0000000060554651" n="3">
                                     <space xml:id="space-0000001423893520" dur="4" dots="2" />
                                     <chord xml:id="chord-0000000683438040" cue="true" stem.len="0" dur="4">
                                         <note xml:id="note-0000001316316498" cue="true" oct="4" pname="a" />
@@ -81,17 +81,17 @@
                                 <layer xml:id="layer-0000002097569482" n="1">
                                     <chord xml:id="chord-0000000875609415" dur="2">
                                         <note xml:id="note-0000000850259644" oct="4" pname="e" />
-                                        <note xml:id="note-0000000496073920" oct="4" pname="a" />
-                                        <note xml:id="note-0000000787379075" oct="4" pname="b" />
-                                    </chord>
-                                    <chord xml:id="chord-0000000875609415" dur="4">
-                                        <note xml:id="note-0000000496073920" oct="4" pname="g">
-                                            <accid accid="s" />
-                                        </note>
-                                        <note xml:id="note-0000000787379075" oct="4" pname="b" />
-                                        <note oct="5" pname="e" />
-                                    </chord>
-                                </layer>
+                    <note xml:id="note-0000000496073920" oct="4" pname="a" />
+                    <note xml:id="note-0000000787379075" oct="4" pname="b" />
+                  </chord>
+                  <chord dur="4">
+                    <note oct="4" pname="g">
+                      <accid accid="s" />
+                    </note>
+                    <note oct="4" pname="b" />
+                    <note oct="5" pname="e" />
+                  </chord>
+                </layer>
                             </staff>
                             <staff xml:id="staff-0000001058294838" n="2">
                                 <layer xml:id="layer-0000000807138612" n="1">
@@ -320,6 +320,6 @@
                     </section>
                 </score>
             </mdiv>
-        </body>
-    </music>
+    </body>
+  </music>
 </mei>


### PR DESCRIPTION
This PR adds some missing facsimile information including some updates and smaller fixes.
Additionally a missing paragraph from the first edition has been added.

This accompanies #34.